### PR TITLE
IG-349 - Detect duplicate paper links

### DIFF
--- a/src/resources/paper/paper.route.js
+++ b/src/resources/paper/paper.route.js
@@ -71,7 +71,7 @@ router.post(
         return res.status(200).json({ success: true });
       }
       // 3. Use MongoDb to perform a direct comparison on all paper links, trimming leading and trailing white space from the request body
-      const papers = await Data.find({ type: "paper", link: link.trim() }).count();
+      const papers = await Data.find({ type: "paper", link: link.trim(), activeflag: {$ne: "rejected"} }).count();
       // 4. If any results are found, return error that the link exists on the Gateway already
       if(papers > 0)
         return res.status(200).json({ success: true, error: "This link is already associated to another paper on the HDR-UK Innovation Gateway" });

--- a/src/resources/paper/paper.route.js
+++ b/src/resources/paper/paper.route.js
@@ -55,7 +55,7 @@ router.get(
   }
 );
 
-// @router   GET /api/v1/
+// @router   POST /api/v1/
 // @desc     Validates that a paper link does not exist on the gateway
 // @access   Private
 router.post(
@@ -64,18 +64,19 @@ router.post(
   utils.checkIsInRole(ROLES.Admin, ROLES.Creator),
   async (req, res) => {
     try {
+      // 1. Deconstruct message body which contains the link entered by the user against a paper
       const { link } = req.body;
+      // 2. Front end validation should prevent this occurrence, but we return success if empty string or not param is passed
       if(!link) {
-        return res.status(500).json({ success: false });
+        return res.status(200).json({ success: true });
       }
-      
+      // 3. Use MongoDb to perform a direct comparison on all paper links, trimming leading and trailing white space from the request body
       const papers = await Data.find({ type: "paper", link: link.trim() }).count();
-
+      // 4. If any results are found, return error that the link exists on the Gateway already
       if(papers > 0)
-        return res.status(200).json({ duplicateLink: "This link is already associated to another paper on the HDR-UK Innovation Gateway" });
-      
+        return res.status(200).json({ success: true, error: "This link is already associated to another paper on the HDR-UK Innovation Gateway" });
+      // 5. Otherwise return valid
       return res.status(200).json({ success: true });
-
     } catch (error) {
       console.error(error);
       return res.status(500).json({ success: false, error: 'Paper link validation failed' });

--- a/src/resources/paper/paper.route.js
+++ b/src/resources/paper/paper.route.js
@@ -56,6 +56,34 @@ router.get(
 );
 
 // @router   GET /api/v1/
+// @desc     Validates that a paper link does not exist on the gateway
+// @access   Private
+router.post(
+  '/validate',
+  passport.authenticate('jwt'),
+  utils.checkIsInRole(ROLES.Admin, ROLES.Creator),
+  async (req, res) => {
+    try {
+      const { link } = req.body;
+      if(!link) {
+        return res.status(500).json({ success: false });
+      }
+      
+      const papers = await Data.find({ type: "paper", link: link.trim() }).count();
+
+      if(papers > 0)
+        return res.status(200).json({ duplicateLink: "This link is already associated to another paper on the HDR-UK Innovation Gateway" });
+      
+      return res.status(200).json({ success: true });
+
+    } catch (error) {
+      console.error(error);
+      return res.status(500).json({ success: false, error: 'Paper link validation failed' });
+    }
+  }
+);
+
+// @router   GET /api/v1/
 // @desc     Returns List of Paper Objects No auth
 //           This unauthenticated route was created specifically for API-docs
 // @access   Public


### PR DESCRIPTION
**PR**

Prevent users from adding the same paper twice

**Solution**

- Added paper endpoint api/v1/papers/validate which accepts "link" as a string.
- Endpoint returns an error if a direct matching link is found against an active or under review paper (link is trimmed of white space prior to comparison)

**Future**

- We could consider applying more validation to the URL field perhaps in the form of an input mask