### PR TITLE
IG-472 - Multiple datasets during Data Access Request

### DIFF
--- a/src/resources/publisher/publisher.controller.js
+++ b/src/resources/publisher/publisher.controller.js
@@ -24,11 +24,16 @@ module.exports = {
     getPublisherDatasets: async(req, res) => {
         try {
             // 1. Get the datasets for the publisher from the database
-            const datasets = await Data.find({ type: 'dataset', 'datasetfields.publisher': req.params.id }).select('datasetid name description datasetfields.abstract -_id');
+            let datasets = await Data.find({ type: 'dataset', 'datasetfields.publisher': req.params.id }).select('datasetid name description datasetfields.abstract _id datasetfields.publisher');
             if(!datasets) {
                 return res.status(404).json({ success: false });
             }
-            // 2. Return datasets
+            // 2. Map datasets to flatten datasetfields nested object
+            datasets = datasets.map(dataset => {
+				let { _id, datasetid, name, description, datasetfields: { abstract, publisher }} = dataset;
+				return { _id, datasetid, name, description, abstract, publisher };
+			});
+            // 3. Return publisher datasets
             return res.status(200).json({ success: true, datasets });
         } catch (err) {
             console.error(err.message);

--- a/src/resources/publisher/publisher.controller.js
+++ b/src/resources/publisher/publisher.controller.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import { PublisherModel } from './publisher.model';
+import { Data } from '../tool/data.model';
 import _ from 'lodash';
 
 module.exports = {
@@ -13,6 +14,22 @@ module.exports = {
             }
             // 2. Return publisher
             return res.status(200).json({ success: true, publisher });
+        } catch (err) {
+            console.error(err.message);
+            return res.status(500).json(err);
+        }
+    },
+
+    // GET api/v1/publishers/:id/datasets
+    getPublisherDatasets: async(req, res) => {
+        try {
+            // 1. Get the datasets for the publisher from the database
+            const datasets = await Data.find({ type: 'dataset', 'datasetfields.publisher': req.params.id }).select('datasetid name description datasetfields.abstract -_id');
+            if(!datasets) {
+                return res.status(404).json({ success: false });
+            }
+            // 2. Return datasets
+            return res.status(200).json({ success: true, datasets });
         } catch (err) {
             console.error(err.message);
             return res.status(500).json(err);

--- a/src/resources/publisher/publisher.model.js
+++ b/src/resources/publisher/publisher.model.js
@@ -1,6 +1,10 @@
 import { model, Schema } from 'mongoose'
 
 const PublisherSchema = new Schema({
+  id: {
+    type: Number,
+    unique: true
+  },
   name: String,
   active: { 
       type: Boolean, 

--- a/src/resources/publisher/publisher.route.js
+++ b/src/resources/publisher/publisher.route.js
@@ -10,4 +10,9 @@ const router = express.Router();
 // @access  Private
 router.get('/:id', passport.authenticate('jwt'), publisherController.getPublisherById);
 
+// @route   GET api/publishers/:id/datasets
+// @desc    GET all datasets owned by publisher
+// @access  Private
+router.get('/:id/datasets', passport.authenticate('jwt'), publisherController.getPublisherDatasets);
+
 module.exports = router

--- a/src/resources/team/team.model.js
+++ b/src/resources/team/team.model.js
@@ -1,15 +1,19 @@
 import { model, Schema } from 'mongoose'
 
 const TeamSchema = new Schema({
-    members: [{
-        memberid: {type: Schema.Types.ObjectId,
-          ref: 'User'},
-        roles: [String]
-      }],
-    active: { 
-        type: Boolean, 
-        default: true 
-    },
+  id: {
+    type: Number,
+    unique: true
+  },
+  members: [{
+      memberid: {type: Schema.Types.ObjectId,
+        ref: 'User'},
+      roles: [String]
+    }],
+  active: { 
+      type: Boolean, 
+      default: true 
+  },
 }, {
   toJSON:     { virtuals: true },
   toObject:   { virtuals: true }

--- a/src/resources/topic/topic.controller.js
+++ b/src/resources/topic/topic.controller.js
@@ -39,24 +39,22 @@ module.exports = {
                 console.error(`Failed to find related tool(s) with objectId(s): ${relatedObjectIds.join(', ')}`);
                 return undefined;
             }
-            // 4. Deconstruct first tool to extract generic info for topic
-            let { datasetfields: { publisher: publisherId }} = tools[0];
-            // 5. Iterate through each tool
+            // 4. Iterate through each tool
             tools.forEach(tool => {
-                // 6. Switch based on related object type
+                // 5. Switch based on related object type
                 switch(tool.type) {
-                    // 7. If dataset, we require the publisher
+                    // 6. If dataset, we require the publisher
                     case 'dataset':
-                        let { name: title, datasetid = '' } = tool;
-                        subTitle = _.isEmpty(subTitle) ? title : `${subTitle}, ${title}`
-                        datasets.push({ datasetId: datasetid, publisher: publisherId });
-                        tags.push(title);
+                        let { name: datasetTitle, datasetid = '' } = tool;
+                        subTitle = _.isEmpty(subTitle) ? datasetTitle : `${subTitle}, ${datasetTitle}`
+                        datasets.push({ datasetId: datasetid, publisher: title });
+                        tags.push(datasetTitle);
                         break;
                     default:
                         console.log('default');
                 }
             });
-            // 8. Get recipients for topic/message using the first tool (same team exists as each publisher is the same)
+            // 7. Get recipients for topic/message using the first tool (same team exists as each publisher is the same)
             let { publisher = '' } = tools[0];
             if(_.isEmpty(publisher)) {
                 console.error(`No publisher associated to this dataset`);
@@ -74,7 +72,7 @@ module.exports = {
             }
             // Future extension could be to iterate through tools at this point to generate a topic for each publisher
             // This also requires refactor of above code to break down dataset titles into individual messages
-            // 9. Create new topic against related objects with recipients
+            // 8. Create new topic against related objects with recipients
             const topic = await TopicModel.create({
                 title,
                 subTitle,
@@ -85,7 +83,7 @@ module.exports = {
                 datasets,
                 tags
             });
-            // 8. Return created object
+            // 9. Return created object
             return topic;
         } catch (err) {
             console.error(err.message);


### PR DESCRIPTION
**PR**

Add the ability to select multiple datasets during a data access request to a single custodian

**Solution (Branch WIP but stable with these commits)**

- Added publisher route and controller
- Added endpoint to retrieve all datasets for a publisher (used in multiselect)
- Updated publisher and team model to include unique numeric ID

**Next commits**

- Data persistence for multiple datasets when submitting and reloading Data Access Request forms


