### PR TITLE
Added endpoint for returning DARs for any publisher

### DIFF
--- a/src/resources/datarequest/datarequest.route.js
+++ b/src/resources/datarequest/datarequest.route.js
@@ -17,7 +17,7 @@ const router = express.Router();
 // @access  Private
 router.get('/', passport.authenticate('jwt'), async (req, res) => {
     try {
-    // 1. Deconstruct the 
+    // 1. Deconstruct the request
     let { id: userId } = req.user;
     // 2. Find all data access request applications created with single dataset version
     let singleDatasetApplications = await DataRequestModel.find( { $and: [{ userId: parseInt(userId) }, { "dataSetId":{$ne:null} }] } ).populate('dataset');

--- a/src/resources/publisher/publisher.controller.js
+++ b/src/resources/publisher/publisher.controller.js
@@ -74,7 +74,7 @@ module.exports = {
         return res.status(200).json({ success: true, data: applications });
         } catch(err) {
             console.error(err);
-            return res.status(500).json({ success: false, message: 'An error occurred searching for user applications' });
+            return res.status(500).json({ success: false, message: 'An error occurred searching for custodian applications' });
         }
     }
 }

--- a/src/resources/publisher/publisher.route.js
+++ b/src/resources/publisher/publisher.route.js
@@ -15,4 +15,9 @@ router.get('/:id', passport.authenticate('jwt'), publisherController.getPublishe
 // @access  Private
 router.get('/:id/datasets', passport.authenticate('jwt'), publisherController.getPublisherDatasets);
 
+// @route   GET api/publishers/:id/dataaccessrequests
+// @desc    GET all data access requests to a publisher
+// @access  Private
+router.get('/:id/dataaccessrequests', passport.authenticate('jwt'), publisherController.getPublisherDataAccessRequests);
+
 module.exports = router


### PR DESCRIPTION
**PR**

Backend work to support teams in account area.  This allows us to request all applications that are attached to any custodian by passing in the custodian name.  

Security is implemented such that a requesting user must be a member of the custodian team to get a valid response otherwise they will receive a 401.

**Solution**

- Added new endpoint to support requirements in publisher route.



