### PR TITLE
Added phrase encapsulation for hyphenated words

### DIFF
--- a/src/resources/search/search.router.js
+++ b/src/resources/search/search.router.js
@@ -14,6 +14,13 @@ const router = express.Router();
 router.get('/', async (req, res) => {
     var authorID = parseInt(req.query.userID);
     var searchString = req.query.search || ""; //If blank then return all
+    //If searchString is applied, format any hyphenated words to enclose them as a phrase
+    if(searchString.includes('-')) {
+        // Matches on any whole word containing a hyphen
+        const regex = /(?=\S*[-])([a-zA-Z'-]+)/g;  
+        // Surround matching words in quotation marks
+        searchString = searchString.replace(regex, "\"$1\"");
+    }
     var tab = req.query.tab || "";
     let searchQuery = { $and: [{ activeflag: 'active' }] };
 


### PR DESCRIPTION
**PR**

Issues reported by users that searching for "Cog-uk" returned more results than expected.  This was down to the default behaviour of Mongo to remove hyphens and treat the above as 'contains Cog OR uk'.

**Solution**

- Regex added to detect search words that include a hyphen and replaces them with the original word wrapped in quotation marks.  Mongo then treats the original hyphenated as a phrase and performs 'contains Cog-uk'.