### PR TITLE
Fixed unauth issue by removing auth requirement on publisher endpoint

### DIFF
--- a/src/resources/publisher/publisher.route.js
+++ b/src/resources/publisher/publisher.route.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 // @route   GET api/publishers/:id
 // @desc    GET A publishers by :id
-// @access  Private
+// @access  Public
 router.get('/:id', publisherController.getPublisherById);
 
 // @route   GET api/publishers/:id/datasets

--- a/src/resources/publisher/publisher.route.js
+++ b/src/resources/publisher/publisher.route.js
@@ -8,7 +8,7 @@ const router = express.Router();
 // @route   GET api/publishers/:id
 // @desc    GET A publishers by :id
 // @access  Private
-router.get('/:id', passport.authenticate('jwt'), publisherController.getPublisherById);
+router.get('/:id', publisherController.getPublisherById);
 
 // @route   GET api/publishers/:id/datasets
 // @desc    GET all datasets owned by publisher


### PR DESCRIPTION
This public endpoint only exposes the following info:

- publisher name
- publisher DAR pre-submission modal content
- publisher allows/does not allow messaging

None of this info is sensitive and is required for this page to operate properly when a user has not signed in yet. 

We will need to revisit this if the publisher data model is extended to include sensitive data.