### PR TITLE
IG-740 + IG-744 - Adding users' team roles (manager/reviewer)

### DIFF
--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -1,10 +1,10 @@
-import express from 'express'
-import { to } from 'await-to-js'
-import { verifyPassword } from '../auth/utils'
-import { login } from '../auth/strategies/jwt'
-import { getUserByEmail } from '../user/user.repository'
-import { getRedirectUrl } from '../auth/utils'
-import passport from "passport";
+import express from 'express';
+import { to } from 'await-to-js';
+import { verifyPassword } from '../auth/utils';
+import { login } from '../auth/strategies/jwt';
+import { getUserByEmail } from '../user/user.repository';
+import { getRedirectUrl } from '../auth/utils';
+import passport from 'passport';
 
 const router = express.Router();
 
@@ -12,61 +12,86 @@ const router = express.Router();
 // @desc     login user
 // @access   Public
 router.post('/login', async (req, res) => {
-    const { email, password } = req.body
+	const { email, password } = req.body;
 
-    const [err, user] = await to(getUserByEmail(email))
+	const [err, user] = await to(getUserByEmail(email));
 
-    const authenticationError = () => {
-        return res
-            .status(500)
-            .json({ success: false, data: "Authentication error!" })
-    }
+	const authenticationError = () => {
+		return res
+			.status(500)
+			.json({ success: false, data: 'Authentication error!' });
+	};
 
-    if (!(await verifyPassword(password, user.password))) {
-        console.error('Passwords do not match')
-        return authenticationError()
-    }
+	if (!(await verifyPassword(password, user.password))) {
+		console.error('Passwords do not match');
+		return authenticationError();
+	}
 
-    const [loginErr, token] = await to(login(req, user))
+	const [loginErr, token] = await to(login(req, user));
 
-    if (loginErr) {
-        console.error('Log in error', loginErr)
-        return authenticationError()
-    }
+	if (loginErr) {
+		console.error('Log in error', loginErr);
+		return authenticationError();
+	}
 
-    return res
-        .status(200)
-        .cookie('jwt', token, {
-            httpOnly: true
-        })
-        .json({
-            success: true,
-            data: getRedirectUrl(req.user.role)
-        })
-
+	return res
+		.status(200)
+		.cookie('jwt', token, {
+			httpOnly: true,
+		})
+		.json({
+			success: true,
+			data: getRedirectUrl(req.user.role),
+		});
 });
 
 // @router   POST /api/auth/logout
 // @desc     logout user
 // @access   Private
 router.get('/logout', function (req, res) {
-    req.logout();
-    res.clearCookie('jwt');
-    return res.json({ success: true });
+	req.logout();
+	res.clearCookie('jwt');
+	return res.json({ success: true });
 });
 
 // @router   GET /api/auth/status
 // @desc     Return the logged in status of the user and their role.
 // @access   Private
 router.get('/status', function (req, res, next) {
-    passport.authenticate('jwt', function (err, user, info) {
-        if (err || !user) {
-            return res.json({ success: true, data: [{ role: "Reader", id: null, name: null, loggedIn: false }] });
-        }
-        else {
-            return res.json({ success: true, data: [{ role: req.user.role, id: req.user.id, name: req.user.firstname + " " + req.user.lastname, loggedIn: true, teams: req.user.teams }] });
-        }
-    })(req, res, next);
+	passport.authenticate('jwt', function (err, user, info) {
+		if (err || !user) {
+			return res.json({
+				success: true,
+				data: [{ role: 'Reader', id: null, name: null, loggedIn: false }],
+			});
+		} else {
+            // 1. Reformat teams array for frontend
+            let { teams } = req.user;
+            if(teams) {
+                teams = teams.map((team) => {
+                    let { publisher, type, members } = team;
+                    let member = members.find(member => {
+                        return member.memberid.toString() === req.user._id.toString();
+                    });
+                    let { roles } = member;
+                    return { publisher, type, roles };
+                });
+            }
+            // 2. Return user info
+			return res.json({
+				success: true,
+				data: [
+					{
+						role: req.user.role,
+						id: req.user.id,
+						name: req.user.firstname + ' ' + req.user.lastname,
+						loggedIn: true,
+						teams,
+					},
+				],
+			});
+		}
+	})(req, res, next);
 });
-  
-module.exports = router
+
+module.exports = router;

--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -74,7 +74,7 @@ router.get('/status', function (req, res, next) {
                         return member.memberid.toString() === req.user._id.toString();
                     });
                     let { roles } = member;
-                    return { publisher, type, roles };
+                    return { ...publisher.toObject(), type, roles };
                 });
             }
             // 2. Return user info

--- a/src/resources/team/team.model.js
+++ b/src/resources/team/team.model.js
@@ -8,8 +8,9 @@ const TeamSchema = new Schema({
   members: [{
       memberid: {type: Schema.Types.ObjectId,
         ref: 'User'},
-      roles: [String]
+      roles: { type: [String], enum: ['reviewer','manager'] }
     }],
+  type: String,
   active: { 
       type: Boolean, 
       default: true 

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -3,7 +3,7 @@ import { UserModel } from './user.model';
 export async function getUserById(id) {
     const user = await UserModel.findById(id).populate({ 
         path: 'teams',
-        select: 'publisher type -_id', 
+        select: 'publisher type members -_id', 
           populate: { 
             path: 'publisher',
             select: 'name'


### PR DESCRIPTION
**PR**

Extend teams to include roles including auth payload to UI

**Solution**

- Extended auth route to return desired payload to include a users roles within each team
  _Main modifications from line 69 to 90 (reformatting affected whole file)_
- Extended team model to include an array of roles driven by enum (currently reviewer and manager only)

**Sample Payload**

`{
      "role": "Admin",
      "id": 6689395059831886,
      "name": "Robin Kavanagh",
      "loggedIn": true,
      "teams": [
        {
          "_id": "5f3f98068af2ef61552e1d75",
          "name": "ALLIANCE > BARTS",
          "type": "publisher",
          "roles": [
            "reviewer"
          ]
        },
        {
          "_id": "5f3ff10f78d7db8866a26fe7",
          "name": "ALLIANCE > SAIL",
          "type": "publisher",
          "roles": [
            "reviewer"
          ]
        },
        {
          "_id": "5f58f23f55ae131f3ffacf11",
          "name": "HDR UK",
          "type": "publisher",
          "roles": [
            "reviewer"
          ]
        }
      ]
    }`

**Notes**

On Dev MongoDb, performed the following manual updates

- added Dev team as reviewers on BARTS, HDR UK, SAIL
- added Dev team as managers on HQIP
