### PR TITLE
IG-745 + IG-751 Completed manager override capability for workflow phase or for entire workflow

### DIFF
--- a/src/resources/bpmnworkflow/bpmnworkflow.controller.js
+++ b/src/resources/bpmnworkflow/bpmnworkflow.controller.js
@@ -105,7 +105,7 @@ module.exports = {
     },
     postStartManagerReview: async (bpmContext) => {
         // Start manager-review process
-        let { applicationStatus, managerId, publisher, notifyManager } = bpmContext;
+        let { applicationStatus, managerId, publisher, notifyManager, taskId } = bpmContext;
         let data = {
             "variables": {
                 "applicationStatus": {
@@ -133,14 +133,8 @@ module.exports = {
     },
     postManagerApproval: async (bpmContext) => {
         // Manager has approved sectoin
-        let { applicationStatus, managerId, publisher } = bpmContext;
-        let data = {
-            "dataRequestStatus": applicationStatus,
-            "dataRequestManagerId": managerId,
-            "dataRequestPublisher": publisher,
-            "managerApproved": true
-        }
-        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/manager/completed/${businessKey}`, data)
+        let { businessKey } = bpmContext;
+        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/manager/completed/${businessKey}`, bpmContext)
         .catch((err) => {
             console.error(err);
         })

--- a/src/resources/datarequest/datarequest.model.js
+++ b/src/resources/datarequest/datarequest.model.js
@@ -38,6 +38,9 @@ const DataRequestSchema = new Schema({
   dateFinalStatus: {
     type: Date
   },
+  dateReviewStart: {
+    type: Date
+  },
   publisher: {
     type: String,
     default: ""

--- a/src/resources/datarequest/datarequest.route.js
+++ b/src/resources/datarequest/datarequest.route.js
@@ -8,47 +8,57 @@ const router = express.Router();
 
 // @route   GET api/v1/data-access-request
 // @desc    GET Access requests for user
-// @access  Private
+// @access  Private - Applicant (Gateway User) and Custodian Manager/Reviewer
 router.get('/', passport.authenticate('jwt'), datarequestController.getAccessRequestsByUser);
 
 // @route   GET api/v1/data-access-request/:requestId
 // @desc    GET a single data access request by Id
-// @access  Private
+// @access  Private - Applicant (Gateway User) and Custodian Manager/Reviewer
 router.get('/:requestId', passport.authenticate('jwt'), datarequestController.getAccessRequestById);
 
 // @route   GET api/v1/data-access-request/dataset/:datasetId
 // @desc    GET Access request for user
-// @access  Private
+// @access  Private - Applicant (Gateway User) and Custodian Manager/Reviewer
 router.get('/dataset/:dataSetId', passport.authenticate('jwt'), datarequestController.getAccessRequestByUserAndDataset);
 
 // @route   GET api/v1/data-access-request/datasets/:datasetIds
 // @desc    GET Access request with multiple datasets for user
-// @access  Private
+// @access  Private - Applicant (Gateway User) and Custodian Manager/Reviewer
 router.get('/datasets/:datasetIds', passport.authenticate('jwt'), datarequestController.getAccessRequestByUserAndMultipleDatasets);
 
 // @route   PATCH api/v1/data-access-request/:id
 // @desc    Update application passing single object to update database entry with specified key
-// @access  Private
+// @access  Private - Applicant (Gateway User)
 router.patch('/:id', passport.authenticate('jwt'), datarequestController.updateAccessRequestDataElement);
 
 // @route   PUT api/v1/data-access-request/:id
 // @desc    Update request record by Id for status changes
-// @access  Private
+// @access  Private - Custodian Manager and Applicant (Gateway User)
 router.put('/:id', passport.authenticate('jwt'), datarequestController.updateAccessRequestById);
 
 // @route   PUT api/v1/data-access-request/:id/assignworkflow
 // @desc    Update access request workflow
-// @access  Private
+// @access  Private - Custodian Manager
 router.put('/:id/assignworkflow', passport.authenticate('jwt'), datarequestController.assignWorkflow);
 
 // @route   PUT api/v1/data-access-request/:id/vote
 // @desc    Update access request with user vote
-// @access  Private
+// @access  Private - Custodian Reviewer/Manager
 router.put('/:id/vote', passport.authenticate('jwt'), datarequestController.updateAccessRequestReviewVote);
+
+// @route   PUT api/v1/data-access-request/:id/startreview
+// @desc    Update access request with review started
+// @access  Private - Custodian Manager
+router.put('/:id/startreview', passport.authenticate('jwt'), datarequestController.updateAccessRequestStartReview);
+
+// @route   PUT api/v1/data-access-request/:id/stepoverride
+// @desc    Update access request with current step overriden (manager ends current phase regardless of votes cast)
+// @access  Private - Custodian Manager
+router.put('/:id/stepoverride', passport.authenticate('jwt'), datarequestController.updateAccessRequestStepOverride);
 
 // @route   POST api/v1/data-access-request/:id
 // @desc    Submit request record
-// @access  Private
+// @access  Private - Applicant (Gateway User)
 router.post('/:id', passport.authenticate('jwt'), datarequestController.submitAccessRequestById);
 
 module.exports = router;

--- a/src/resources/workflow/workflow.controller.js
+++ b/src/resources/workflow/workflow.controller.js
@@ -358,7 +358,7 @@ module.exports = {
 		// Establish base payload for Camunda
 		// (1) phaseApproved is passed as true when the manager is overriding the current step/phase
 		//		this short circuits the review process in the workflow and closes any remaining user tasks 
-		//		i.e. reviewers within the active step
+		//		i.e. reviewers within the active step OR when the last reviewer in the step submits a vote
 		// (2) managerApproved is passed as true when the manager is approving the entire application 
 		//		from any point within the review process
 		// (3) finalPhaseApproved is passed as true when the final step is completed naturally through all

--- a/src/resources/workflow/workflow.model.js
+++ b/src/resources/workflow/workflow.model.js
@@ -20,6 +20,7 @@ const StepSchema = new Schema({
   reminderOffset: { type: Number, required: true, default: 3 }, // Number of days before deadline that SLAs are triggered by Camunda
   // Items below not required for step definition
   active: { type: Boolean, default: false },
+  completed: { type: Boolean, default: false },
   startDateTime: { type: Date },
   endDateTime: { type: Date },
   recommendations: [{


### PR DESCRIPTION
**PR**

The DAR PUT endpoint should be extended to:

- Allow a manager to make a final decision before a workflow is assigned or when a phase is in progress.  
- A manager should also be able to end a phase with a single decision, ignoring all other voters.  
- A manager should also be able to make a final decision with workflow in progress.

**Solution**

- Added endpoint for start review (triggered by manager on submitted applications)
- Added endpoint to override an application workflow step 
- Updated associated workflow/step model to track completion state of each step and the start date/time of pre-review  
