### PR TITLE
IG-791 - Removed subscribe link from DAR emails and negated opt-in status

### DIFF
--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -1243,13 +1243,8 @@ module.exports = {
 				emailRecipients = [
 					accessRecord.mainApplicant,
 					...custodianUsers,
-					...accessRecord.authors,
-				].filter(function (user) {
-					let {
-						additionalInfo: { emailNotifications },
-					} = user;
-					return emailNotifications === true;
-				});
+					...accessRecord.authors
+				];
 				let { dateSubmitted } = accessRecord;
 				if (!dateSubmitted) ({ updatedAt: dateSubmitted } = accessRecord);
 				// Create object to pass through email data
@@ -1272,7 +1267,7 @@ module.exports = {
 					hdrukEmail,
 					`Data Access Request for ${datasetTitles} was ${context.applicationStatus} by ${publisher}`,
 					html,
-					true
+					false
 				);
 				break;
 			case 'Submitted':
@@ -1340,13 +1335,8 @@ module.exports = {
 						// Send email to main applicant and contributors if they have opted in to email notifications
 						emailRecipients = [
 							accessRecord.mainApplicant,
-							...accessRecord.authors,
-						].filter(function (user) {
-							let {
-								additionalInfo: { emailNotifications },
-							} = user;
-							return emailNotifications === true;
-						});
+							...accessRecord.authors
+						];
 					}
 					// Establish email context object
 					options = { ...options, userType: emailRecipientType };
@@ -1365,7 +1355,7 @@ module.exports = {
 							hdrukEmail,
 							`Data Access Request has been submitted to ${publisher} for ${datasetTitles}`,
 							html,
-							true
+							false
 						);
 					}
 				}
@@ -1400,12 +1390,6 @@ module.exports = {
 					let addedUsers = await UserModel.find({
 						id: { $in: addedAuthors },
 					}).populate('additionalInfo');
-					emailRecipients = addedUsers.filter(function (user) {
-						let {
-							additionalInfo: { emailNotifications },
-						} = user;
-						return emailNotifications === true;
-					});
 
 					await notificationBuilder.triggerNotificationMessage(
 						addedUsers.map((user) => user.id),
@@ -1414,11 +1398,11 @@ module.exports = {
 						accessRecord._id
 					);
 					await emailGenerator.sendEmail(
-						emailRecipients,
+						addedUsers,
 						hdrukEmail,
 						`You have been added as a contributor for a Data Access Request to ${publisher} by ${firstname} ${lastname}`,
 						html,
-						true
+						false
 					);
 				}
 				// Notifications for removed contributors
@@ -1429,12 +1413,6 @@ module.exports = {
 					let removedUsers = await UserModel.find({
 						id: { $in: removedAuthors },
 					}).populate('additionalInfo');
-					emailRecipients = removedUsers.filter(function (user) {
-						let {
-							additionalInfo: { emailNotifications },
-						} = user;
-						return emailNotifications === true;
-					});
 
 					await notificationBuilder.triggerNotificationMessage(
 						removedUsers.map((user) => user.id),
@@ -1443,11 +1421,11 @@ module.exports = {
 						accessRecord._id
 					);
 					await emailGenerator.sendEmail(
-						emailRecipients,
+						removedUsers,
 						hdrukEmail,
 						`You have been removed as a contributor from a Data Access Request to ${publisher} by ${firstname} ${lastname}`,
 						html,
-						true
+						false
 					);
 				}
 				break;

--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -1325,12 +1325,7 @@ module.exports = {
 				for (let emailRecipientType of emailRecipientTypes) {
 					// Send emails to custodian team members who have opted in to email notifications
 					if (emailRecipientType === 'dataCustodian') {
-						emailRecipients = [...custodianUsers].filter(function (user) {
-							let {
-								additionalInfo: { emailNotifications },
-							} = user;
-							return emailNotifications === true;
-						});
+						emailRecipients = [...custodianUsers];
 					} else {
 						// Send email to main applicant and contributors if they have opted in to email notifications
 						emailRecipients = [


### PR DESCRIPTION
**PR**

The DAR emails aren't marketing emails, so no option should be provided for opting out of them.

Agreed during demo for Sprint 11 by David Seymour, Gerry Reilly, Peggy and Susheel.

**Solution**

Removed opt-in status check for email generations
Removed unsubscribe link from email body