### PR TITLE
IG-804-Add-auth-for-Camunda

### DIFF
--- a/src/resources/auth/strategies/jwt.js
+++ b/src/resources/auth/strategies/jwt.js
@@ -14,9 +14,13 @@ const strategy = () => {
     }
 
     const verifyCallback = async (req, jwtPayload, cb) => {
+        if(typeof jwtPayload.data === 'string') {
+            jwtPayload.data = JSON.parse(jwtPayload.data);
+        }
         const [err, user] = await to(getUserById(jwtPayload.data._id))
 
         if (err) {
+            console.log("error");
             return cb(err)
         }
         req.user = user

--- a/src/resources/auth/strategies/jwt.js
+++ b/src/resources/auth/strategies/jwt.js
@@ -20,7 +20,6 @@ const strategy = () => {
         const [err, user] = await to(getUserById(jwtPayload.data._id))
 
         if (err) {
-            console.log("error");
             return cb(err)
         }
         req.user = user

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -28,6 +28,17 @@ const signToken = (user) => {
     )
 }
 
+const camundaToken = () => {
+    return jwt.sign(
+        { username: "HDRAdmin", groupIds: ["camunda-admin"], tenantIds: []},
+        process.env.JWTSecret,  
+        { //Here change it so only id
+            algorithm: 'HS256',
+            expiresIn: 604800
+        }
+    )
+}
+
 const hashPassword = async password => {
     if (!password) {
         throw new Error('Password was not provided')
@@ -74,4 +85,4 @@ const getRedirectUrl = role => {
     }
 }
 
-export { setup, signToken, hashPassword, verifyPassword, checkIsInRole, getRedirectUrl, whatIsRole }
+export { setup, signToken, camundaToken, hashPassword, verifyPassword, checkIsInRole, getRedirectUrl, whatIsRole }

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -30,7 +30,10 @@ const signToken = (user) => {
 
 const camundaToken = () => {
     return jwt.sign(
-        { username: "HDRAdmin", groupIds: ["camunda-admin"], tenantIds: []},
+        // This structure must not change or the authenication between camunda and the gateway will fail
+        // username: An admin user the exists within the camunda-admin group
+        // groupIds: The admin group that has been configured on the camunda portal.
+        { username: process.env.BPMN_ADMIN_USER, groupIds: ["camunda-admin"], tenantIds: []},
         process.env.JWTSecret,  
         { //Here change it so only id
             algorithm: 'HS256',

--- a/src/resources/bpmnworkflow/bpmnworkflow.controller.js
+++ b/src/resources/bpmnworkflow/bpmnworkflow.controller.js
@@ -1,17 +1,22 @@
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
 import _ from 'lodash';
+import { utils } from "../auth";
 
 axiosRetry(axios, { retries: 3, retryDelay: () => {
     return 3000;
   }});
 
 const bpmnBaseUrl = process.env.BPMNBASEURL;
+//Generate Bearer token for camunda endpoints
+const config = {
+	headers: { Authorization: `Bearer ${utils.camundaToken()}` },
+};
 
 module.exports = {
     //Generic Get Task Process Endpoints
     getProcess: async (businessKey) => {
-        return await axios.get(`${bpmnBaseUrl}/engine-rest/task?processInstanceBusinessKey=${businessKey.toString()}`);
+        return await axios.get(`${bpmnBaseUrl}/engine-rest/task?processInstanceBusinessKey=${businessKey.toString()}`, config);
     },
 
     //Simple Workflow Endpoints
@@ -39,7 +44,7 @@ module.exports = {
             },
             "businessKey": businessKey.toString()
         }
-        await axios.post(`${bpmnBaseUrl}/engine-rest/process-definition/key/GatewayWorkflowSimple/start`, data)
+        await axios.post(`${bpmnBaseUrl}/engine-rest/process-definition/key/GatewayWorkflowSimple/start`, data, config)
             .catch((err) => { 
                 console.error(err);
             });
@@ -71,7 +76,7 @@ module.exports = {
                 }
             }
         }
-        await axios.post(`${bpmnBaseUrl}/engine-rest/task/${taskId}/complete`, data)
+        await axios.post(`${bpmnBaseUrl}/engine-rest/task/${taskId}/complete`, data, config)
             .catch((err) => { 
                 console.error(err);
             });
@@ -98,7 +103,7 @@ module.exports = {
             },
             "businessKey": businessKey.toString()
         }
-        await axios.post(`${bpmnBaseUrl}/engine-rest/process-definition/key/GatewayReviewWorkflowComplex/start`, data)
+        await axios.post(`${bpmnBaseUrl}/engine-rest/process-definition/key/GatewayReviewWorkflowComplex/start`, data, config)
             .catch((err) => {
                 console.error(err);
             });
@@ -126,7 +131,7 @@ module.exports = {
                 }
             }
         }
-        await axios.post(`${bpmnBaseUrl}/engine-rest/task/${taskId}/complete`, data)
+        await axios.post(`${bpmnBaseUrl}/engine-rest/task/${taskId}/complete`, data, config)
             .catch((err) => { 
                 console.error(err);
             });
@@ -134,7 +139,7 @@ module.exports = {
     postManagerApproval: async (bpmContext) => {
         // Manager has approved sectoin
         let { businessKey } = bpmContext;
-        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/manager/completed/${businessKey}`, bpmContext)
+        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/manager/completed/${businessKey}`, bpmContext. config)
         .catch((err) => {
             console.error(err);
         })
@@ -142,7 +147,7 @@ module.exports = {
     postStartStepReview: async (bpmContext) => {
         //Start Step-Review process
         let { businessKey } = bpmContext;
-        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/complete/review/${businessKey}`, bpmContext)
+        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/complete/review/${businessKey}`, bpmContext, config)
             .catch((err) => {
                 console.error(err);
             });
@@ -150,7 +155,7 @@ module.exports = {
     postCompleteReview: async (bpmContext) => {
         //Start Next-Step process
         let { businessKey } = bpmContext;
-        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/reviewer/complete/${businessKey}`, bpmContext)
+        await axios.post(`${bpmnBaseUrl}/api/gateway/workflow/v1/reviewer/complete/${businessKey}`, bpmContext, config)
         .catch((err) => {
             console.error(err);
         });

--- a/src/resources/user/user.roles.js
+++ b/src/resources/user/user.roles.js
@@ -1,7 +1,8 @@
 const ROLES = {
     Admin: 'Admin',
     DataCustodian: 'DataCustodian',
-    Creator: 'Creator'
+    Creator: 'Creator',
+    System: 'System'
   }
   
 export { ROLES }


### PR DESCRIPTION
## PR
Add JWT auth to the camunda endpoints on the gateway-api. This is to allow secure and authenticated requests to be made. 

## Solution
Added token generation to the auth utils for camunda. A username must be passed that exists within the camunda admin group. 