### PR TITLE
Changed aboutApplication from json string to object in MongoDb

### DIFF
--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -174,7 +174,7 @@ module.exports = {
 					...accessRecord.toObject(),
 					jsonSchema: JSON.parse(accessRecord.jsonSchema),
 					questionAnswers: JSON.parse(accessRecord.questionAnswers),
-					aboutApplication: JSON.parse(accessRecord.aboutApplication),
+					aboutApplication: typeof accessRecord.aboutApplication === 'string' ? JSON.parse(accessRecord.aboutApplication) : accessRecord.aboutApplication,
 					datasets: accessRecord.datasets,
 					readOnly,
 					userType,
@@ -252,7 +252,7 @@ module.exports = {
 					jsonSchema,
 					publisher,
 					questionAnswers: '{}',
-					aboutApplication: '{}',
+					aboutApplication: {},
 					applicationStatus: applicationStatuses.INPROGRESS,
 				});
 				// 4. save record
@@ -271,13 +271,17 @@ module.exports = {
 				data = { ...accessRecord.toObject() };
 			}
 
+			if (typeof a_string === 'string') {
+				// this is a string
+			}
+
 			return res.status(200).json({
 				status: 'success',
 				data: {
 					...data,
 					jsonSchema: JSON.parse(data.jsonSchema),
 					questionAnswers: JSON.parse(data.questionAnswers),
-					aboutApplication: JSON.parse(data.aboutApplication),
+					aboutApplication: typeof data.aboutApplication === 'string' ? JSON.parse(data.aboutApplication) : data.aboutApplication,
 					dataset,
 					projectId: data.projectId || helper.generateFriendlyId(data._id),
 					userType: userTypes.APPLICANT,
@@ -352,7 +356,7 @@ module.exports = {
 					jsonSchema,
 					publisher,
 					questionAnswers: '{}',
-					aboutApplication: '{}',
+					aboutApplication: {},
 					applicationStatus: applicationStatuses.INPROGRESS,
 				});
 				// 4. save record
@@ -376,7 +380,7 @@ module.exports = {
 					...data,
 					jsonSchema: JSON.parse(data.jsonSchema),
 					questionAnswers: JSON.parse(data.questionAnswers),
-					aboutApplication: JSON.parse(data.aboutApplication),
+					aboutApplication: typeof data.aboutApplication === 'string' ? JSON.parse(data.aboutApplication) : data.aboutApplication,
 					datasets,
 					projectId: data.projectId || helper.generateFriendlyId(data._id),
 					userType: userTypes.APPLICANT,
@@ -401,8 +405,10 @@ module.exports = {
 			let updateObj;
 			let { aboutApplication, questionAnswers, jsonSchema = '' } = req.body;
 			if (aboutApplication) {
-				let parsedObj = JSON.parse(aboutApplication);
-				let updatedDatasetIds = parsedObj.selectedDatasets.map(
+				if(typeof aboutApplication === 'string') {
+					aboutApplication = JSON.parse(aboutApplication)
+				}
+				let updatedDatasetIds = aboutApplication.selectedDatasets.map(
 					(dataset) => dataset.datasetId
 				);
 				updateObj = { aboutApplication, datasetIds: updatedDatasetIds };
@@ -1380,7 +1386,10 @@ module.exports = {
 
 	createNotifications: async (type, context, accessRecord, user) => {
 		// Project details from about application if 5 Safes
-		let aboutApplication = JSON.parse(accessRecord.aboutApplication);
+		let { aboutApplication } = accessRecord;
+		if(typeof aboutApplication === 'string') {
+			aboutApplication = JSON.parse(accessRecord.aboutApplication);
+		} 
 		let { projectName } = aboutApplication;
 		let { projectId, _id, workflow = {}, dateSubmitted = '' } = accessRecord;
 		if (_.isEmpty(projectId)) {
@@ -2024,8 +2033,10 @@ module.exports = {
 		let { aboutApplication, questionAnswers } = app;
 
 		if (aboutApplication) {
-			let aboutObj = JSON.parse(aboutApplication);
-			({ projectName } = aboutObj);
+			if(typeof aboutApplication === 'string') {
+				aboutApplication = JSON.parse(aboutApplication);
+			}
+			({ projectName } = aboutApplication);
 		}
 		if (_.isEmpty(projectName)) {
 			projectName = `${publisher} - ${name}`;

--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -271,10 +271,6 @@ module.exports = {
 				data = { ...accessRecord.toObject() };
 			}
 
-			if (typeof a_string === 'string') {
-				// this is a string
-			}
-
 			return res.status(200).json({
 				status: 'success',
 				data: {

--- a/src/resources/datarequest/datarequest.model.js
+++ b/src/resources/datarequest/datarequest.model.js
@@ -29,8 +29,8 @@ const DataRequestSchema = new Schema({
     default: "{}"
   },
   aboutApplication: {
-    type: String,
-    default: "{}"
+    type: Object,
+    default: {}
   },
   dateSubmitted: {
     type: Date

--- a/src/resources/publisher/publisher.controller.js
+++ b/src/resources/publisher/publisher.controller.js
@@ -265,9 +265,11 @@ module.exports = {
 				}, []);
 
 				applications = applications.map((app) => {
-					const { aboutApplication, _id } = app;
-					const aboutApplicationObj = JSON.parse(aboutApplication) || {};
-					let { projectName = 'No project name' } = aboutApplicationObj;
+					let { aboutApplication, _id } = app;
+					if(typeof aboutApplication === 'string') {
+						aboutApplication = JSON.parse(aboutApplication) || {};
+					}
+					let { projectName = 'No project name' } = aboutApplication;
 					return { projectName, _id };
 				});
 				let canDelete = applications.length === 0,

--- a/src/resources/workflow/workflow.controller.js
+++ b/src/resources/workflow/workflow.controller.js
@@ -60,9 +60,11 @@ const teamController = require('../team/team.controller');
 				applications = [],
 			} = workflow.toObject();
 			applications = applications.map((app) => {
-				const { aboutApplication, _id } = app;
-				const aboutApplicationObj = JSON.parse(aboutApplication) || {};
-				let { projectName = 'No project name' } = aboutApplicationObj;
+				let { aboutApplication, _id } = app;
+				if(typeof aboutApplication === 'string') {
+					aboutApplication = JSON.parse(aboutApplication) || {};
+				}
+				let { projectName = 'No project name' } = aboutApplication;
 				return { projectName, _id };
 			});
 			// Set operation permissions


### PR DESCRIPTION
- Changed MongoDb model for DAR to hold 'aboutApplication' as an object which is searchable for NCS
- Made existing DARs backward compatible by first parsing json if it is a string instead of an object
- Updates to existing DARs will now save 'aboutApplication' as objects


Tested new and existing DARs, working as expected.