### PR TITLE
SUP-339 - Project uploader shown as ID NOT name

### DIFF
--- a/src/resources/paper/paper.route.js
+++ b/src/resources/paper/paper.route.js
@@ -123,6 +123,14 @@ router.get('/:paperID', async (req, res) => {
 		{ $match: { $and: [{ id: parseInt(req.params.paperID) }, { type: 'paper' }] } },
 		{ $lookup: { from: 'tools', localField: 'authors', foreignField: 'id', as: 'persons' } },
 		{ $lookup: { from: 'tools', localField: 'uploader', foreignField: 'id', as: 'uploaderIs' } },
+		{ $addFields: {
+			"uploader": {
+				$concat: [ 
+					{	$arrayElemAt: [ "$uploaderIs.firstname", 0]}, 
+					" ",
+					{ $arrayElemAt: [ "$uploaderIs.lastname", 0 ]}
+			]}
+		}}
 	]);
 	q.exec((err, data) => {
 		if (data.length > 0) {

--- a/src/resources/project/project.route.js
+++ b/src/resources/project/project.route.js
@@ -81,6 +81,15 @@ router.get('/:projectID', async (req, res) => {
 				as: 'persons',
 			},
 		},
+		{ $lookup: { from: 'tools', localField: 'uploader', foreignField: 'id', as: 'uploaderIs' } },
+		{ $addFields: {
+			"uploader": {
+				$concat: [ 
+					{	$arrayElemAt: [ "$uploaderIs.firstname", 0]}, 
+					" ",
+				{ $arrayElemAt: [ "$uploaderIs.lastname", 0 ]}
+			]}
+		}}
 	]);
 	q.exec((err, data) => {
 		if (data.length > 0) {
@@ -96,7 +105,7 @@ router.get('/:projectID', async (req, res) => {
 							},
 						],
 					},
-				},
+				}
 			]);
 
 			p.exec(async (err, relatedData) => {

--- a/src/resources/tool/tool.route.js
+++ b/src/resources/tool/tool.route.js
@@ -120,6 +120,14 @@ router.get('/:id', async (req, res) => {
 				as: 'uploaderIs',
 			},
 		},
+		{ $addFields: {
+			"uploader": {
+				$concat: [ 
+					{	$arrayElemAt: [ "$uploaderIs.firstname", 0]}, 
+					" ",
+					{ $arrayElemAt: [ "$uploaderIs.lastname", 0 ]}
+			]}
+		}}
 	]);
 	query.exec((err, data) => {
 		if (data.length > 0) {


### PR DESCRIPTION
# PR
[SUPP 339](https://hdruk.atlassian.net/browse/SUPP-339?atlOrigin=eyJpIjoiYzA0NjgyOGZmYzkzNDFjYTgwZGFiZDNlY2IxMjIwMDIiLCJwIjoiaiJ9)

## Solution description
An small issue was reported that the Uploader field within Tool, Projects and Papers was outputting the numeric user id based in tools > users. A solution has been implemented to declare a new field called **uploader** which concats **$uploaderIs** and selects out the users firstname and lastname

![SUPP-339](https://user-images.githubusercontent.com/65283091/104612702-67117f00-567e-11eb-99c1-af10f0f740b0.png)
