### PR TITLE
DAR Stats - Inflating stats code fix for DAR submissions

### DIFF
--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -257,6 +257,8 @@ module.exports = {
 					version,
 					userId,
 					dataSetId,
+					datasetIds: [dataSetId],
+					datasetTitles: [dataset.name],
 					jsonSchema,
 					schemaId,
 					publisher,

--- a/src/resources/datarequest/datarequest.model.js
+++ b/src/resources/datarequest/datarequest.model.js
@@ -7,6 +7,7 @@ const DataRequestSchema = new Schema({
   authorIds: [Number],
   dataSetId: String,
   datasetIds: [{ type: String}],
+  datasetTitles: [{ type: String}],
   projectId: String,
   workflowId: { type : Schema.Types.ObjectId, ref: 'Workflow' },
   workflow: { type: WorkflowSchema },

--- a/src/resources/stats/stats.router.js
+++ b/src/resources/stats/stats.router.js
@@ -127,10 +127,6 @@ router.get('', async (req, res) => {
           if (err) return res.json({ success: false, error: err });
     
           accessRequests.map((accessRequest) => {
-            if (accessRequest.dataSetId && accessRequest.dataSetId.length > 0 && !hdrDatasetIds.includes(accessRequest.dataSetId)) {
-              accessRequestsCount++
-            }
-
             if(accessRequest.datasetIds && accessRequest.datasetIds.length > 0){
               accessRequest.datasetIds.map((datasetid) => {
                 if (!hdrDatasetIds.includes(datasetid)) {


### PR DESCRIPTION
Deprecation of dataSetId field in Data Access Request model has been completed now that production data has been updated.

All previous dataSetId values are now stored in datasetIds array at position 0.

Stat calculation logic modified to count only DARs using the new array.  This fix prevents the inflation of DAR figures on the Gateway home page.