### PR TITLE
IG-1775 - API Express Security Improvements

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -30,6 +30,7 @@ const configuration = require('./configuration');
 const API_PORT = process.env.PORT || 3001;
 const session = require('express-session');
 var app = express();
+app.disable('x-powered-by');
 
 configuration.findAccount = Account.findAccount;
 const oidc = new Provider(process.env.api_url || 'http://localhost:3001', configuration);
@@ -74,6 +75,11 @@ app.use(
 		secret: process.env.JWTSecret,
 		resave: false,
 		saveUninitialized: true,
+		name: 'sessionId',
+		cookie: {
+			secure: process.env.api_url ? true : false,
+			httpOnly: true
+		  }
 	})
 );
 

--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -36,6 +36,7 @@ router.post('/login', async (req, res) => {
 		.status(200)
 		.cookie('jwt', token, {
 			httpOnly: true,
+			secure: process.env.api_url ? true : false,
 		})
 		.json({
 			success: true,

--- a/src/resources/auth/sso/sso.discourse.router.js
+++ b/src/resources/auth/sso/sso.discourse.router.js
@@ -35,6 +35,7 @@ router.get('/', function (req, res, next) {
 					}),
 					{
 						httpOnly: true,
+						secure: process.env.api_url ? true : false,
 					}
 				)
 				.json({ redirectUrl: redirectUrl });

--- a/src/resources/auth/strategies/google.js
+++ b/src/resources/auth/strategies/google.js
@@ -134,6 +134,7 @@ const strategy = app => {
 					.status(200)
 					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
 						httpOnly: true,
+						secure: process.env.api_url ? true : false,
 					})
 					.redirect(redirectUrl);
 			});

--- a/src/resources/auth/strategies/linkedin.js
+++ b/src/resources/auth/strategies/linkedin.js
@@ -132,6 +132,7 @@ const strategy = app => {
 					.status(200)
 					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
 						httpOnly: true,
+						secure: process.env.api_url ? true : false,
 					})
 					.redirect(redirectUrl);
 			});

--- a/src/resources/auth/strategies/oidc.js
+++ b/src/resources/auth/strategies/oidc.js
@@ -136,6 +136,7 @@ const strategy = app => {
 					.status(200)
 					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
 						httpOnly: true,
+						secure: process.env.api_url ? true : false,
 					})
 					.redirect(redirectUrl);
 			});

--- a/src/resources/user/user.register.route.js
+++ b/src/resources/user/user.register.route.js
@@ -122,6 +122,7 @@ router.post('/', async (req, res) => {
 		.status(200)
 		.cookie('jwt', token, {
 			httpOnly: true,
+			secure: process.env.api_url ? true : false,
 		})
 		.json({ success: false, data: redirectURLis });
 });


### PR DESCRIPTION
- Added code to hide 'powered-by' from response headers
- Made all cookies issued by the Gateway HTTP only and secure when deployed to GCP