### PR TITLE
SUPP-334 Validate against short email

### DIFF
--- a/src/resources/utilities/__tests__/helper.util.test.js
+++ b/src/resources/utilities/__tests__/helper.util.test.js
@@ -1,0 +1,24 @@
+import helperUtil from '../helper.util';
+
+describe('Helper Utility functions', () => {
+  test('Censorword function email test, 1@1.co.uk > *@1*****k', () => {
+    let testEmail = '1@1.co.uk';
+    let expectedEmail = '*@1*****k';
+    let resultEmail = helperUtil.censorEmail(testEmail);
+    expect(resultEmail).toEqual(expectedEmail);
+  });
+
+  test('Censorword function email test, 12@1.co.uk > 1*@1*****k', () => {
+    let testEmail = '12@1.co.uk';
+    let expectedEmail = '1*@1*****k';
+    let resultEmail = helperUtil.censorEmail(testEmail);
+    expect(resultEmail).toEqual(expectedEmail);
+  });
+
+  test('Censorword function email test, jamie@1234.co.uk > j***e@1********k', () => {
+    let testEmail = 'jamie@1234.co.uk';
+    let expectedEmail = 'j***e@1********k';
+    let resultEmail = helperUtil.censorEmail(testEmail);
+    expect(resultEmail).toEqual(expectedEmail);
+  });
+});

--- a/src/resources/utilities/helper.util.js
+++ b/src/resources/utilities/helper.util.js
@@ -1,5 +1,10 @@
 const _censorWord = str => {
-	return str[0] + '*'.repeat(str.length - 2) + str.slice(-1);
+	if(str.length === 1) 
+		return '*';
+	else if(str.length === 2) 
+		return `${str[0]}*`;
+	else
+		return str[0] + '*'.repeat(str.length - 2) + str.slice(-1);
 };
 
 const _censorEmail = email => {


### PR DESCRIPTION
# PR
[SUPP-334](https://hdruk.atlassian.net/browse/SUPP-334?atlOrigin=eyJpIjoiYzY0MGVkNjc3MGI3NDcxYWFiZDk4NzAzZDBiYTI5ZGUiLCJwIjoiaiJ9)

## Solution
Reported that issues occured when updating tools and projects and specifically emails. This was due to the censorship being applied to those emails if the user was not a custodian. A check has now been put in place within the **helper.util** file to allow email address to be processed with 1-2 characters. Tests have also been added to validate the fix.

## Tests

- [x] helper.util.test.js

![helper util test-result](https://user-images.githubusercontent.com/65283091/105177712-f5727e80-5b1e-11eb-8a5e-42b9b90f1b58.png)
