### PR TITLE
SUPP-369 - On DAR submission, custodian emails do not contain NCS project details

### DIFF
--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -1750,7 +1750,7 @@ module.exports = {
 						submissionType: constants.submissionTypes.INITIAL,
 					};
 					// Build email template
-					({ html, jsonContent } = await emailGenerator.generateEmail(questions, pages, questionPanels, questionAnswers, options));
+					({ html, jsonContent } = await emailGenerator.generateEmail(aboutApplication, questions, pages, questionPanels, questionAnswers, options));
 					// Send emails to custodian team members who have opted in to email notifications
 					if (emailRecipientType === 'dataCustodian') {
 						emailRecipients = [...custodianManagers];
@@ -1826,7 +1826,7 @@ module.exports = {
 						submissionType: constants.submissionTypes.RESUBMISSION,
 					};
 					// Build email template
-					({ html, jsonContent } = await emailGenerator.generateEmail(questions, pages, questionPanels, questionAnswers, options));
+					({ html, jsonContent } = await emailGenerator.generateEmail(aboutApplication, questions, pages, questionPanels, questionAnswers, options));
 					// Send emails to custodian team members who have opted in to email notifications
 					if (emailRecipientType === 'dataCustodian') {
 						emailRecipients = [...custodianManagers];

--- a/src/resources/utilities/emailGenerator.util.js
+++ b/src/resources/utilities/emailGenerator.util.js
@@ -99,25 +99,27 @@ const _initalQuestionSpread = (questions, pages, questionPanels) => {
 
 				// pass in questionPanels
 				let questionPanel = [...questionPanels].find((i) => i.panelId === qSId);
-				// find page it belongs too
-				let page = [...pages].find((i) => i.pageId === questionPanel.pageId);
+        // find page it belongs too
+        if(questionPanel) {
+          let page = [...pages].find((i) => i.pageId === questionPanel.pageId);
 
-				// if page not found skip and the questionId isnt excluded
-				if (
-					typeof page !== 'undefined' &&
-					!excludedQuestionSetIds.includes(qId)
-				) {
-					// if it is a generated field ie ui driven add back on uniqueId
-					let obj = {
-						page: page.title,
-						section: questionPanel.navHeader,
-						questionSetId: qsFullId,
-						questionSetHeader,
-						...question,
-					};
-					// update flatQuestionList array, spread previous add new object
-					flatQuestionList = [...flatQuestionList, obj];
-				}
+          // if page not found skip and the questionId isnt excluded
+          if (
+            typeof page !== 'undefined' &&
+            !excludedQuestionSetIds.includes(qId)
+          ) {
+            // if it is a generated field ie ui driven add back on uniqueId
+            let obj = {
+              page: page.title,
+              section: questionPanel.navHeader,
+              questionSetId: qsFullId,
+              questionSetHeader,
+              ...question,
+            };
+            // update flatQuestionList array, spread previous add new object
+            flatQuestionList = [...flatQuestionList, obj];
+          }
+        }
 			}
 		}
 	}
@@ -216,9 +218,12 @@ const _buildSubjectTitle = (user, title, submissionType) => {
  * @param   {Object}  options
  * @return  {String} Questions Answered
  */
-const _buildEmail = (fullQuestions, questionAnswers, options) => {
+const _buildEmail = (aboutApplication, fullQuestions, questionAnswers, options) => {
 	let parent;
   let { userType, userName, userEmail, datasetTitles, submissionType } = options;
+  let dateSubmitted = moment().format('D MMM YYYY');
+  let { projectName = 'No project name set', isNationalCoreStudies = false, nationalCoreStudiesProjectId = '' } = aboutApplication;
+  let linkNationalCoreStudies = nationalCoreStudiesProjectId === '' ? '' : `${process.env.homeURL}/project/${nationalCoreStudiesProjectId}`;
   let heading = submissionType === constants.submissionTypes.INITIAL ? `New data access request application` : `Existing data access request application with new updates`;
 	let subject = _buildSubjectTitle(userType, datasetTitles, submissionType);
 	let questionTree = { ...fullQuestions };
@@ -249,15 +254,21 @@ const _buildEmail = (fullQuestions, questionAnswers, options) => {
                 <tr style="width: 100%; text-align: left;">
                   <td bgcolor="#fff" style="padding: 0; border: 0;">
                     <table border="0" border-collapse="collapse" cellpadding="0" cellspacing="0" width="100%">
+                    <tr>
+                        <td style="font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">Project</td>
+                        <td style=" font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">${projectName}</td>
+                      </tr>
                       <tr>
+                        <td style="font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">Related NCS project</td>
+                        <td style=" font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">${isNationalCoreStudies ? `<a style="color: #475da7;" href="${linkNationalCoreStudies}">View NCS project</a>` : 'no'}</td>
+                    </tr>  
+                    <tr>
                         <td style="font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">Dataset(s)</td>
                         <td style=" font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">${datasetTitles}</td>
                       </tr>
                       <tr>
                         <td style="font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">Date of submission</td>
-                        <td style=" font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">${moment().format(
-													'D MMM YYYY'
-												)}</td>
+                        <td style=" font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">${dateSubmitted}</td>
                       </tr>
                       <tr>
                         <td style="font-size: 14px; color: #3c3c3b; padding: 10px 5px; width: 50%; text-align: left; vertical-align: top; border-bottom: 1px solid #d0d3d4;">Applicant</td>
@@ -273,6 +284,7 @@ const _buildEmail = (fullQuestions, questionAnswers, options) => {
 
 	// Create json content payload for attaching to email
 	const jsonContent = {
+    applicationDetails: { projectName, linkNationalCoreStudies, datasetTitles, dateSubmitted, applicantName: userName },
 		questions: { ...fullQuestions },
 		answers: { ...questionAnswers },
 	};
@@ -437,6 +449,7 @@ const _getUserDetails = async (userObj) => {
 };
 
 const _generateEmail = async (
+  aboutApplication,
 	questions,
 	pages,
 	questionPanels,
@@ -464,6 +477,7 @@ const _generateEmail = async (
 	let fullQuestions = _groupByPageSection([...questionList]);
 	// build up  email with  values
 	let { html, jsonContent } = _buildEmail(
+    aboutApplication,
 		fullQuestions,
 		flatQuestionAnswers,
 		options


### PR DESCRIPTION
- Appended 'about application' details into DAR submission email that goes to the Custodian. Now includes project name, and if the application is in relation to an NCS project.
- Added hyperlink to email body to go directly to the NCS project.
- Updated json payload to include 'about application' details in new object.