### PR TITLE
IG-1077 - Third party integration and authorisation via OAuth2.0 client credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "btoa": "^1.2.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
+    "crypto": "^1.0.1",
     "crypto-js": "^4.0.0",
     "discourse-sso": "^1.0.3",
     "dotenv": "^8.2.0",

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -172,9 +172,11 @@ app.use('/api/v1/openid', oidc.callback);
 app.use('/api', router);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
+app.use('/oauth', require('../resources/auth/oauth.route'));
 app.use('/api/v1/auth/sso/discourse', require('../resources/auth/sso/sso.discourse.router'));
 app.use('/api/v1/auth', require('../resources/auth/auth.route'));
 app.use('/api/v1/auth/register', require('../resources/user/user.register.route'));
+
 
 app.use('/api/v1/users', require('../resources/user/user.route'));
 app.use('/api/v1/topics', require('../resources/topic/topic.route'));

--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -3,9 +3,9 @@ import _ from 'lodash';
 import { to } from 'await-to-js';
 import passport from 'passport';
 
-import { verifyPassword, getRedirectUrl, signToken } from '../auth/utils';
+import { verifyPassword, getRedirectUrl } from '../auth/utils';
 import { login } from '../auth/strategies/jwt';
-import { getUserByEmail, getServiceAccount } from '../user/user.repository';
+import { getUserByEmail } from '../user/user.repository';
 
 const router = express.Router();
 
@@ -94,51 +94,6 @@ router.get('/status', function (req, res, next) {
 			});
 		}
 	})(req, res, next);
-});
-
-// @router   POST /api/v1/auth/token
-// @desc     Issues a JWT for a valid authentication attempt using client credentials
-// @access   Public
-router.post('/token', async (req, res) => {
-	// 1. Deconstruct grant type
-	const { grant_type = '' } = req.body;
-	// 2. Allow different grant types to be processed
-	switch(grant_type) {
-		case 'client_credentials':
-			// Deconstruct request body to extract client ID, secret
-			const { client_id = '', client_secret = '' } = req.body;
-			// Ensure client credentials have been passed
-			if (_.isEmpty(client_id) || _.isEmpty(client_secret)) {
-				return res.status(400).json({
-					success: false,
-					message: 'Incomplete client credentials were provided for the authorisation attempt',
-				});
-			}
-			// Find an associated service account based on the credentials passed
-			const serviceAccount = await getServiceAccount(client_id, client_secret);
-			if (_.isNil(serviceAccount)) {
-				return res.status(400).json({
-					success: false,
-					message: 'Invalid client credentials were provided for the authorisation attempt',
-				});
-			}
-			// Construct JWT for service account
-			const token_type = 'jwt', expires_in = 900;
-			const jwt = signToken({ _id: serviceAccount._id, id: serviceAccount.id, timeStamp: Date.now() }, expires_in);
-			const access_token = `Bearer ${jwt}`;
-			
-			// Return payload
-			return res.status(200).json({
-				access_token,
-				token_type,
-				expires_in,
-			});
-	}
-	// Bad request for any other grant type passed
-	return res.status(400).json({
-		success: false,
-		message: 'An invalid grant type has been specified',
-	});
 });
 
 module.exports = router;

--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -123,9 +123,10 @@ router.post('/token', async (req, res) => {
 				});
 			}
 			// Construct JWT for service account
-			const jwt = signToken({ _id: serviceAccount._id, id: serviceAccount.id, timeStamp: Date.now() });
+			const token_type = 'jwt', expires_in = 900;
+			const jwt = signToken({ _id: serviceAccount._id, id: serviceAccount.id, timeStamp: Date.now() }, expires_in);
 			const access_token = `Bearer ${jwt}`;
-			const token_type = 'jwt', expires_in = 604800;
+			
 			// Return payload
 			return res.status(200).json({
 				access_token,

--- a/src/resources/auth/oauth.route.js
+++ b/src/resources/auth/oauth.route.js
@@ -25,7 +25,7 @@ router.post('/token', async (req, res) => {
 				});
 			}
 			// Find an associated service account based on the credentials passed
-			const serviceAccount = await getServiceAccountByClientCredentials(client_id, client_secret);
+			const serviceAccount = await getServiceAccountByClientCredentials(client_id.toString(), client_secret.toString());
 			if (_.isNil(serviceAccount)) {
 				return res.status(400).json({
 					success: false,

--- a/src/resources/auth/oauth.route.js
+++ b/src/resources/auth/oauth.route.js
@@ -2,12 +2,12 @@ import express from 'express';
 import _ from 'lodash';
 
 import { signToken } from './utils';
-import { getServiceAccount } from '../user/user.repository';
+import { getServiceAccountByClientCredentials } from '../user/user.repository';
 
 const router = express.Router();
 
 // @router   POST /oauth/token
-// @desc     Issues a JWT for a valid authentication attempt using client credentials
+// @desc     Issues a JWT for a valid authentication attempt using a user defined grant type
 // @access   Public
 router.post('/token', async (req, res) => {
 	// 1. Deconstruct grant type
@@ -25,7 +25,7 @@ router.post('/token', async (req, res) => {
 				});
 			}
 			// Find an associated service account based on the credentials passed
-			const serviceAccount = await getServiceAccount(client_id, client_secret);
+			const serviceAccount = await getServiceAccountByClientCredentials(client_id, client_secret);
 			if (_.isNil(serviceAccount)) {
 				return res.status(400).json({
 					success: false,

--- a/src/resources/auth/oauth.route.js
+++ b/src/resources/auth/oauth.route.js
@@ -25,7 +25,7 @@ router.post('/token', async (req, res) => {
 				});
 			}
 			// Find an associated service account based on the credentials passed
-			const serviceAccount = await getServiceAccountByClientCredentials(client_id.toString(), client_secret.toString());
+			const serviceAccount = await getServiceAccountByClientCredentials(client_id, client_secret);
 			if (_.isNil(serviceAccount)) {
 				return res.status(400).json({
 					success: false,

--- a/src/resources/auth/oauth.route.js
+++ b/src/resources/auth/oauth.route.js
@@ -1,0 +1,54 @@
+import express from 'express';
+import _ from 'lodash';
+
+import { signToken } from './utils';
+import { getServiceAccount } from '../user/user.repository';
+
+const router = express.Router();
+
+// @router   POST /oauth/token
+// @desc     Issues a JWT for a valid authentication attempt using client credentials
+// @access   Public
+router.post('/token', async (req, res) => {
+	// 1. Deconstruct grant type
+	const { grant_type = '' } = req.body;
+	// 2. Allow different grant types to be processed
+	switch(grant_type) {
+		case 'client_credentials':
+			// Deconstruct request body to extract client ID, secret
+			const { client_id = '', client_secret = '' } = req.body;
+			// Ensure client credentials have been passed
+			if (_.isEmpty(client_id) || _.isEmpty(client_secret)) {
+				return res.status(400).json({
+					success: false,
+					message: 'Incomplete client credentials were provided for the authorisation attempt',
+				});
+			}
+			// Find an associated service account based on the credentials passed
+			const serviceAccount = await getServiceAccount(client_id, client_secret);
+			if (_.isNil(serviceAccount)) {
+				return res.status(400).json({
+					success: false,
+					message: 'Invalid client credentials were provided for the authorisation attempt',
+				});
+			}
+			// Construct JWT for service account
+			const token_type = 'jwt', expires_in = 900;
+			const jwt = signToken({ _id: serviceAccount._id, id: serviceAccount.id, timeStamp: Date.now() }, expires_in);
+			const access_token = `Bearer ${jwt}`;
+			
+			// Return payload
+			return res.status(200).json({
+				access_token,
+				token_type,
+				expires_in,
+			});
+	}
+	// Bad request for any other grant type passed
+	return res.status(400).json({
+		success: false,
+		message: 'An invalid grant type has been specified',
+	});
+});
+
+module.exports = router;

--- a/src/resources/auth/strategies/jwt.js
+++ b/src/resources/auth/strategies/jwt.js
@@ -8,7 +8,7 @@ const JWTStrategy = passportJWT.Strategy;
 
 const strategy = () => {
 	const strategyOptions = {
-		jwtFromRequest: req => req.cookies.jwt,
+		jwtFromRequest: req => req.cookies.jwt || req.headers['authorization'],
 		secretOrKey: process.env.JWTSecret,
 		passReqToCallback: true,
 	};

--- a/src/resources/auth/strategies/jwt.js
+++ b/src/resources/auth/strategies/jwt.js
@@ -7,8 +7,22 @@ import { signToken } from '../utils';
 const JWTStrategy = passportJWT.Strategy;
 
 const strategy = () => {
+	const extractJWT = (req) => {
+		// 1. Default extract jwt from request cookie
+		let { cookies: { jwt = '' }} = req;
+		if(!_.isEmpty(jwt)) {
+			// 2. Return jwt if found in cookie
+			return jwt;
+		}
+		// 2. Fallback/external integration extracts jwt from authorization header
+		let { headers: { authorization = '' }} = req;
+		// If token contains a type, strip it and return jwt
+		jwt = authorization;
+		return jwt;
+	}
+
 	const strategyOptions = {
-		jwtFromRequest: req => req.cookies.jwt || req.headers['authorization'],
+		jwtFromRequest: extractJWT,
 		secretOrKey: process.env.JWTSecret,
 		passReqToCallback: true,
 	};

--- a/src/resources/auth/strategies/jwt.js
+++ b/src/resources/auth/strategies/jwt.js
@@ -3,6 +3,7 @@ import passportJWT from 'passport-jwt';
 import { to } from 'await-to-js';
 import { getUserById } from '../../user/user.repository';
 import { signToken } from '../utils';
+import _ from 'lodash';
 
 const JWTStrategy = passportJWT.Strategy;
 
@@ -16,8 +17,10 @@ const strategy = () => {
 		}
 		// 2. Fallback/external integration extracts jwt from authorization header
 		let { headers: { authorization = '' }} = req;
-		// If token contains a type, strip it and return jwt
-		jwt = authorization;
+		// If token contains bearer type, strip it and return jwt
+		if(authorization.split(' ')[0] === 'Bearer') {
+			jwt = authorization.split(' ')[1];
+		}
 		return jwt;
 	}
 

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -17,11 +17,11 @@ const setup = () => {
 	});
 };
 
-const signToken = user => {
+const signToken = (user, expiresIn = 604800) => {
 	return jwt.sign({ data: user }, process.env.JWTSecret, {
 		//Here change it so only id
 		algorithm: 'HS256',
-		expiresIn: 604800,
+		expiresIn
 	});
 };
 

--- a/src/resources/user/user.model.js
+++ b/src/resources/user/user.model.js
@@ -18,6 +18,9 @@ const UserSchema = new Schema(
 		redirectURL: String,
 		discourseUsername: String,
 		discourseKey: String,
+		isServiceAccount: { type: Boolean, default: false },
+		clientId: String,
+		clientSecret: String
 	},
 	{
 		timestamps: true,

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -31,7 +31,7 @@ export async function getUserByUserId(id) {
 
 export async function getServiceAccountByClientCredentials(clientId, clientSecret) {
 	// 1. Locate service account by clientId, return undefined if no document located
-	const serviceAccount = await UserModel.findOne({ clientId, isServiceAccount: true });
+	const serviceAccount = await UserModel.findOne({ clientId:clientId, isServiceAccount: true });
 	if (_.isNil(serviceAccount)) {
 		return;
 	}
@@ -54,7 +54,7 @@ export async function createServiceAccount(firstname, lastname, email, teamId) {
 		teamRole = 'manager',
 		providerId = 'Service Account';
 	// 2. Ensure team is valid before creating service account
-	const team = await TeamModel.findById(teamId);
+	const team = await TeamModel.findById(teamId:teamId);
 	// 3. Return undefined if no team found
 	if (_.isNil(team)) {
 		return;

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -31,7 +31,8 @@ export async function getUserByUserId(id) {
 
 export async function getServiceAccountByClientCredentials(clientId, clientSecret) {
 	// 1. Locate service account by clientId, return undefined if no document located
-	const serviceAccount = await UserModel.findOne({ clientId:clientId, isServiceAccount: true });
+	const id = clientId.toString();
+	const serviceAccount = await UserModel.findOne({ clientId:id, isServiceAccount: true });
 	if (_.isNil(serviceAccount)) {
 		return;
 	}
@@ -54,7 +55,8 @@ export async function createServiceAccount(firstname, lastname, email, teamId) {
 		teamRole = 'manager',
 		providerId = 'Service Account';
 	// 2. Ensure team is valid before creating service account
-	const team = await TeamModel.findById(teamId:teamId);
+	const id = teamId.toString();
+	const team = await TeamModel.findById(id);
 	// 3. Return undefined if no team found
 	if (_.isNil(team)) {
 		return;

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -23,3 +23,7 @@ export async function getUserByProviderId(providerId) {
 export async function getUserByUserId(id) {
 	return await UserModel.findOne({ id }).exec();
 }
+
+export async function getServiceAccount(clientId, clientSecret) {
+	return await UserModel.findOne({ clientId, clientSecret });
+}  

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -1,4 +1,9 @@
+import _ from 'lodash';
+import bcrypt from 'bcrypt';
+
 import { UserModel } from './user.model';
+import { TeamModel } from '../team/team.model';
+import helper from '../utilities/helper.util';
 
 export async function getUserById(id) {
 	const user = await UserModel.findById(id).populate({
@@ -24,6 +29,62 @@ export async function getUserByUserId(id) {
 	return await UserModel.findOne({ id }).exec();
 }
 
-export async function getServiceAccount(clientId, clientSecret) {
-	return await UserModel.findOne({ clientId, clientSecret });
-}  
+export async function getServiceAccountByClientCredentials(clientId, clientSecret) {
+	// 1. Locate service account by clientId, return undefined if no document located
+	const serviceAccount = await UserModel.findOne({ clientId, isServiceAccount: true });
+	if (_.isNil(serviceAccount)) {
+		return;
+	}
+	// 2. Extract hashed client secret from DB
+	const { clientSecret: hashedClientSecret = '' } = serviceAccount;
+	// 3. Compare client secret to hashed client secret to check for auth match
+	const match = await bcrypt.compare(clientSecret, hashedClientSecret);
+	// 4. Return the service account if matched
+	if (match) {
+		return serviceAccount;
+	}
+	// 5. Return undefined if secret did not match
+	return;
+}
+
+export async function createServiceAccount(firstname, lastname, email, teamId) {
+	// 1. Set up default params
+	const isServiceAccount = true,
+		role = 'creator',
+		teamRole = 'manager',
+		providerId = 'Service Account';
+	// 2. Ensure team is valid before creating service account
+	const team = await TeamModel.findById(teamId);
+	// 3. Return undefined if no team found
+	if (_.isNil(team)) {
+		return;
+	}
+	// 4. Generate Client Id and Client Secret
+	const clientId = helper.generateAlphaNumericString(15);
+	const clientSecret = helper.generateAlphaNumericString(50);
+	// 5. Hash Client Secret for storage in DB
+	const saltRounds = 10;
+	const hashedClientSecret = await bcrypt.hash(clientSecret, saltRounds);
+	// 6. Create service account user with the hashed Client Secret
+	const serviceAccount = await UserModel.create({
+		role,
+		isServiceAccount,
+		providerId,
+		firstname,
+		lastname,
+		email,
+		clientId,
+		clientSecret: hashedClientSecret,
+	});
+	// 7. Create membership for service account to team
+	const newMember = {
+		memberid: serviceAccount._id,
+		roles: [teamRole],
+	};
+	// 8. Add membership for the service account to the team
+	TeamModel.update({ _id: team._id }, { $push: { members: newMember } });
+	// 9. Reinstate unhashed client secret for single return instance
+	serviceAccount.clientSecret = clientSecret;
+	// 10. Return service account details
+	return serviceAccount;
+}

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -100,7 +100,7 @@ router.post('/serviceaccount', passport.authenticate('jwt'), utils.checkIsInRole
 			});
 		}
 		// 2. Create service account
-		const serviceAccount = await createServiceAccount(firstname.toString(), lastname.toString(), email.toString(), teamId.toString());
+		const serviceAccount = await createServiceAccount(firstname, lastname, email, teamId);
 		if(_.isNil(serviceAccount)) {
 			return res.status(400).json({
 				success: false,

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -89,33 +89,33 @@ router.get('/', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin, R
 // @router   POST /api/v1/users/serviceaccount
 // @desc     create service account
 // @access   Private
-router.post('/serviceaccount', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin), async (req, res) => {
-	try {
-		// 1. Validate request body params
-		let { firstname = '', lastname = '', email = '', teamId = '' } = req.body;
-		if (_.isEmpty(firstname) || _.isEmpty(lastname) || _.isEmpty(email) || _.isEmpty(teamId)) {
-			return res.status(400).json({
-				success: false,
-				message: 'You must supply a first name, last name, email address and teamId',
-			});
-		}
-		// 2. Create service account
-		const serviceAccount = await createServiceAccount(firstname, lastname, email, teamId);
-		if(_.isNil(serviceAccount)) {
-			return res.status(400).json({
-				success: false,
-				message: 'Unable to create service account with provided details',
-			});
-		}
-		// 3. Return service account details
-		return res.status(200).json({
-			success: true,
-			serviceAccount
-		});
-	} catch (err) {
-		console.error(err.message);
-		return res.status(500).json(err);
-	}
-});
+// router.post('/serviceaccount', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin), async (req, res) => {
+// 	try {
+// 		// 1. Validate request body params
+// 		let { firstname = '', lastname = '', email = '', teamId = '' } = req.body;
+// 		if (_.isEmpty(firstname) || _.isEmpty(lastname) || _.isEmpty(email) || _.isEmpty(teamId)) {
+// 			return res.status(400).json({
+// 				success: false,
+// 				message: 'You must supply a first name, last name, email address and teamId',
+// 			});
+// 		}
+// 		// 2. Create service account
+// 		const serviceAccount = await createServiceAccount(firstname, lastname, email, teamId);
+// 		if(_.isNil(serviceAccount)) {
+// 			return res.status(400).json({
+// 				success: false,
+// 				message: 'Unable to create service account with provided details',
+// 			});
+// 		}
+// 		// 3. Return service account details
+// 		return res.status(200).json({
+// 			success: true,
+// 			serviceAccount
+// 		});
+// 	} catch (err) {
+// 		console.error(err.message);
+// 		return res.status(500).json(err);
+// 	}
+// });
 
 module.exports = router;

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -1,10 +1,13 @@
 import express from 'express';
-import { ROLES } from '../user/user.roles';
+import _ from 'lodash';
 import passport from 'passport';
+
+import { ROLES } from '../user/user.roles';
 import { utils } from '../auth';
 import { UserModel } from './user.model';
 import { Data } from '../tool/data.model';
 import helper from '../utilities/helper.util';
+import { createServiceAccount } from './user.repository';
 
 const router = express.Router();
 
@@ -81,6 +84,38 @@ router.get('/', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin, R
 
 		return res.json({ success: true, data: users });
 	});
+});
+
+// @router   POST /api/v1/users/serviceaccount
+// @desc     create service account
+// @access   Private
+router.post('/serviceaccount', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin), async (req, res) => {
+	try {
+		// 1. Validate request body params
+		let { firstname = '', lastname = '', email = '', teamId = '' } = req.body;
+		if (_.isEmpty(firstname) || _.isEmpty(lastname) || _.isEmpty(email) || _.isEmpty(teamId)) {
+			return res.status(400).json({
+				success: false,
+				message: 'You must supply a first name, last name, email address and teamId',
+			});
+		}
+		// 2. Create service account
+		const serviceAccount = await createServiceAccount(firstname, lastname, email, teamId);
+		if(_.isNil(serviceAccount)) {
+			return res.status(400).json({
+				success: false,
+				message: 'Unable to create service account with provided details',
+			});
+		}
+		// 3. Return service account details
+		return res.status(200).json({
+			success: true,
+			serviceAccount
+		});
+	} catch (err) {
+		console.error(err.message);
+		return res.status(500).json(err);
+	}
 });
 
 module.exports = router;

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -100,7 +100,7 @@ router.post('/serviceaccount', passport.authenticate('jwt'), utils.checkIsInRole
 			});
 		}
 		// 2. Create service account
-		const serviceAccount = await createServiceAccount(firstname, lastname, email, teamId);
+		const serviceAccount = await createServiceAccount(firstname.toString(), lastname.toString(), email.toString(), teamId.toString());
 		if(_.isNil(serviceAccount)) {
 			return res.status(400).json({
 				success: false,

--- a/src/resources/utilities/helper.util.js
+++ b/src/resources/utilities/helper.util.js
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 const _censorWord = str => {
 	if(str.length === 1) 
 		return '*';
@@ -35,6 +37,10 @@ const _generatedNumericId = () => {
 	return parseInt(Math.random().toString().replace('0.', ''));
 };
 
+const _generateAlphaNumericString = (length) => {
+	return crypto.randomBytes(length).toString('hex').substring(length);
+};
+
 const _hidePrivateProfileDetails = persons => {
 	return persons.map(person => {
 		let personWithPrivateDetailsRemoved = person;
@@ -66,6 +72,7 @@ export default {
 	arraysEqual: _arraysEqual,
 	generateFriendlyId: _generateFriendlyId,
 	generatedNumericId: _generatedNumericId,
+	generateAlphaNumericString: _generateAlphaNumericString,
 	hidePrivateProfileDetails: _hidePrivateProfileDetails,
 	getEnvironment: _getEnvironment,
 };


### PR DESCRIPTION
This ticket introduces a method of authenticating application/clients against the Gateway by associating a team/custodian manager as a service account which is authorised through an OAuth2.0 client credentials flow.

The following work has been completed:

- Added OAuth authorisation route for issuing bearer tokens to client applications (client credentials grant type)
- Modified current security to allow jwt in cookie format and also now in 'Bearer {token}' format via HTTP authorisation request header
- Updated Mongoose schema for User model to include client id and secret as well as 'isServiceAccount' for filter purposes
- Added User repository method to find service accounts based on client credentials passed
- Added endpoint/route to allow Gateway admins to create service accounts for Custodians including generation of client credentials and storage of secrets in hashed format
- Added helper function to allow the generation of alphanumeric strings of parameterised length

Related tech spike doc [here](https://hdruk.atlassian.net/wiki/spaces/IG/pages/1204682757/Third+party+system+integration+for+management+of+DARs)