### PR TITLE
SUPP-394 - DAR - Searching for other publisher datasets now only returns active datasets

### DIFF
--- a/src/resources/publisher/publisher.controller.js
+++ b/src/resources/publisher/publisher.controller.js
@@ -34,6 +34,7 @@ module.exports = {
 			// 1. Get the datasets for the publisher from the database
 			let datasets = await Data.find({
 				type: 'dataset',
+				activeflag: 'active',
 				'datasetfields.publisher': req.params.id,
 			})
 				.populate('publisher')


### PR DESCRIPTION
- Modified MongoDb query to return only active instances of datasets.  This endpoint is used to provide data to the dataset multi-select component in the DAR about application section.