### PR TITLE
Backend logic for Cohort Discovery user validation

### DIFF
--- a/src/config/account.js
+++ b/src/config/account.js
@@ -21,19 +21,23 @@ class Account {
 	 *   or not return them in id tokens but only userinfo and so on.
 	 */
 	async claims(use, scope) {
+		let claimsToSend = scope.split(' ');
 		// eslint-disable-line no-unused-vars
-		if (this.profile) {
-			return {
-				sub: this.accountId, // it is essential to always return a sub claim
-				email: this.profile.email,
-				firstname: this.profile.firstname,
-				lastname: this.profile.lastname,
-			};
-		}
-
-		return {
+		let claim = {
 			sub: this.accountId, // it is essential to always return a sub claim
 		};
+		if (claimsToSend.includes('profile')) {
+			claim.firstname = this.profile.firstname;
+			claim.lastname = this.profile.lastname;
+		}
+		if (claimsToSend.includes('email')) {
+			claim.email = this.profile.email;
+		}
+		if (claimsToSend.includes('rquestroles')) {
+			claim.rquestroles = this.profile.advancedSearchRoles;
+		}
+
+		return claim;
 	}
 
 	static async findByFederated(provider, claims) {

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -63,6 +63,7 @@ export const cookies = {
 export const claims = {
 	email: ['email'],
 	profile: ['firstname', 'lastname'],
+	rquestroles: ['rquestroles'],
 };
 
 export const features = {

--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -89,6 +89,9 @@ router.get('/status', function (req, res, next) {
 						name: req.user.firstname + ' ' + req.user.lastname,
 						loggedIn: true,
 						teams,
+						provider: req.user.provider,
+						advancedSearchRoles: req.user.advancedSearchRoles,
+						acceptedAdvancedSearchTerms: req.user.acceptedAdvancedSearchTerms,
 					},
 				],
 			});

--- a/src/resources/user/user.model.js
+++ b/src/resources/user/user.model.js
@@ -20,7 +20,9 @@ const UserSchema = new Schema(
 		discourseKey: String,
 		isServiceAccount: { type: Boolean, default: false },
 		clientId: String,
-		clientSecret: String
+		clientSecret: String,
+		advancedSearchRoles: [],
+		acceptedAdvancedSearchTerms: Boolean,
 	},
 	{
 		timestamps: true,

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -96,11 +96,8 @@ router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), async (r
 			message: "Can't accept terms of a different user",
 		});
 	}
-	let user = await UserModel.findOneAndUpdate(
-		{ id: req.params.id },
-		{ acceptedAdvancedSearchTerms: req.body.acceptedAdvancedSearchTerms },
-		{ new: true }
-	);
+	const { acceptedAdvancedSearchTerms } = req.body;
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { acceptedAdvancedSearchTerms }, { new: true });
 	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
 	return res.status(200).json({ status: 'success', response: user });
 });
@@ -109,7 +106,8 @@ router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), async (r
 // @desc     Set advanced search roles for a user
 // @access   Private
 router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), async (req, res) => {
-	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles: req.body.advancedSearchRoles }, { new: true });
+	const { advancedSearchRoles } = req.body;
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles }, { new: true });
 	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
 	return res.status(200).json({ status: 'success', response: user });
 });

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -114,8 +114,8 @@ router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), async (r
 	if (typeof advancedSearchRoles !== 'object') {
 		return res.status(400).json({ status: 'error', message: 'Invalid role(s) supplied.' });
 	}
-
-	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles }, { new: true }, err => {
+	let roles = advancedSearchRoles.map(role => role.toString());
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles: roles }, { new: true }, err => {
 		if (err) return res.json({ success: false, error: err });
 	});
 	return res.status(200).json({ status: 'success', response: user });

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -86,6 +86,34 @@ router.get('/', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin, R
 	});
 });
 
+// @router   PATCH /api/v1/users/advancedSearch/terms/:id
+// @desc     Accept the advanced search T&Cs for a user
+// @access   Private
+router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), async (req, res) => {
+	if (parseInt(req.params.id) !== req.user.id) {
+		return res.status(400).json({
+			status: 'error',
+			message: "Can't accept terms of a different user",
+		});
+	}
+	let user = await UserModel.findOneAndUpdate(
+		{ id: req.params.id },
+		{ acceptedAdvancedSearchTerms: req.body.acceptedAdvancedSearchTerms },
+		{ new: true }
+	);
+	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
+	return res.status(200).json({ status: 'success', response: user });
+});
+
+// @router   PATCH /api/v1/users/advancedSearch/roles/:id
+// @desc     Set advanced search roles for a user
+// @access   Private
+router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), async (req, res) => {
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles: req.body.advancedSearchRoles }, { new: true });
+	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
+	return res.status(200).json({ status: 'success', response: user });
+});
+
 // @router   POST /api/v1/users/serviceaccount
 // @desc     create service account
 // @access   Private

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -93,12 +93,16 @@ router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), async (r
 	if (parseInt(req.params.id) !== req.user.id) {
 		return res.status(400).json({
 			status: 'error',
-			message: "Can't accept terms of a different user",
+			message: 'Invalid user id supplied',
 		});
 	}
 	const { acceptedAdvancedSearchTerms } = req.body;
-	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { acceptedAdvancedSearchTerms }, { new: true });
-	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
+	if (typeof acceptedAdvancedSearchTerms !== 'boolean') {
+		return res.status(400).json({ status: 'error', message: 'Invalid input supplied.' });
+	}
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { acceptedAdvancedSearchTerms }, { new: true }, err => {
+		if (err) return res.json({ success: false, error: err });
+	});
 	return res.status(200).json({ status: 'success', response: user });
 });
 
@@ -107,8 +111,13 @@ router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), async (r
 // @access   Private
 router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), async (req, res) => {
 	const { advancedSearchRoles } = req.body;
-	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles }, { new: true });
-	if (!user) return res.status(500).json({ status: 'error', message: 'Request failed' });
+	if (typeof advancedSearchRoles !== 'object') {
+		return res.status(400).json({ status: 'error', message: 'Invalid role(s) supplied.' });
+	}
+
+	let user = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles }, { new: true }, err => {
+		if (err) return res.json({ success: false, error: err });
+	});
 	return res.status(200).json({ status: 'success', response: user });
 });
 


### PR DESCRIPTION
Added new claim 'rquestroles' for OIDC which will be passed to BC Platforms to show that a user has been approved on the gateway for advanced search access.

Also see description in https://github.com/HDRUK/gateway-web/pull/463

