### PR TITLE
IG-1358 - Updated swagger docs for v2 entities

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4,9 +4,9 @@ info:
   description: API for Tools and artefacts repository.
   version: 1.0.0
 servers:
-  - url: https://api.www.healthdatagateway.org/api
-  - url: http://localhost:3001/api
-  - url: https://api.{environment}.healthdatagateway.org:{port}/api
+  - url: https://api.www.healthdatagateway.org/
+  - url: http://localhost:3001/
+  - url: https://api.{environment}.healthdatagateway.org:{port}/
     variables:
       environment:
         default: latest
@@ -710,6 +710,7 @@ paths:
       responses:
         '200':
           description: OK
+  
   /api/v1/publishers/{publisher}/dataaccessrequests:
     get:
       tags:
@@ -1309,53 +1310,6 @@ paths:
               examples:
                 'Unauthorised':
                   value: { 'status': 'failure', 'message': 'Unauthorised' }
-  /api/v1/datasets/{datasetID}:
-    get:
-      summary: Returns Dataset object.
-      tags:
-        - Datasets
-      parameters:
-        - in: path
-          name: datasetID
-          required: true
-          description: The ID of the datset
-          schema:
-            type: string
-            example: '756daeaa-6e47-4269-9df5-477c01cdd271'
-      responses:
-        '200':
-          description: OK
-
-  /api/v1/datasets:
-    get:
-      summary: Returns List of Dataset objects.
-      tags:
-        - Datasets
-      parameters:
-        - in: query
-          name: limit
-          required: false
-          description: Limit the number of results
-          schema:
-            type: integer
-            example: 3
-        - in: query
-          name: offset
-          required: false
-          description: Index to offset the search results
-          schema:
-            type: integer
-            example: 1
-        - in: query
-          name: q
-          required: false
-          description: Filter using search query
-          schema:
-            type: string
-            example: epilepsy
-      responses:
-        '200':
-          description: OK
 
   /api/v1/data-access-request/{datasetID}:
     get:
@@ -1816,6 +1770,179 @@ paths:
         '204':
           description: Ok
 
+  /api/v1/datasets/{datasetID}:
+    get:
+      summary: Returns Dataset object.
+      tags:
+        - Datasets
+      parameters:
+        - in: path
+          name: datasetID
+          required: true
+          description: The ID of the datset
+          schema:
+            type: string
+            example: '756daeaa-6e47-4269-9df5-477c01cdd271'
+      responses:
+        '200':
+          description: OK
+
+  /api/v1/datasets:
+    get:
+      summary: Returns List of Dataset objects.
+      tags:
+        - Datasets
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          description: Limit the number of results
+          schema:
+            type: integer
+            example: 3
+        - in: query
+          name: offset
+          required: false
+          description: Index to offset the search results
+          schema:
+            type: integer
+            example: 1
+        - in: query
+          name: q
+          required: false
+          description: Filter using search query
+          schema:
+            type: string
+            example: epilepsy
+      responses:
+        '200':
+          description: OK
+
+  /api/v2/datasets:
+    get:
+      summary: Returns a list of dataset objects
+      tags:
+        - Datasets v2.0
+      description: Version 2.0 of the datasets API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case.  The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than.  Using dot notation, any field can be queried, please see some examples below.
+      parameters:
+        - name: search
+          in: query
+          description: Full text index search function which searches for partial matches in various dataset fields including name, description and abstract.  The response will contain a metascore indicating the relevancy of the match, by default results are sorted by the most relevant first unless a manual sort query parameter has been added.
+          schema:
+            type: string
+          example: COVID-19
+        - name: page
+          in: query
+          description: A specific page of results to retrieve
+          schema:
+            type: number
+          example: 1
+        - name: limit
+          in: query
+          description: Maximum number of results returned per page
+          schema:
+            type: number
+          example: 10
+        - name: sort
+          in: query
+          description: Fields to apply sort operations to.  Accepts multiple fields in ascending and descending.  E.g. name for ascending or -name for descending.  Multiple fields should be comma separated as shown in the example below.
+          schema:
+            type: string
+          example: datasetfields.publisher,name,-counter
+        - name: fields
+          in: query
+          description: Limit the size of the response by requesting only certain fields.  Note that some additional derived fields are always returned.  Multiple fields should be comma separate as shown in the example below.
+          schema:
+            type: string
+          example: name,counter,datasetid
+        - name: count
+          in: query
+          description: Returns the number of the number of entities matching the query parameters provided instead of the result payload
+          schema:
+            type: boolean
+          example: true
+        - name: datasetid
+          in: query
+          description: Filter by the unique identifier for a single version of a dataset
+          schema:
+            type: string
+          example: 0cfe60cd-038d-4c03-9a95-894c52135922
+        - name: pid
+          in: query
+          description: Filter by the identifier for a dataset that persists across versions
+          schema:
+            type: string
+          example: 621dd611-adcf-4434-b538-eecdbe5f72cf
+        - name: name
+          in: query
+          description: Filter by dataset name
+          schema:
+            type: string
+          example: ARIA Dataset
+        - name: activeflag
+          in: query
+          description: Filter by the status of a single dataset version
+          schema:
+            type: string
+            enum:
+              - active
+              - archive
+          example: active
+        - name: datasetfields.publisher
+          in: query
+          description: Filter by the name of the Custodian holding the dataset
+          schema:
+            type: string
+          example: ALLIANCE > BARTS HEALTH NHS TRUST
+        - name: metadataquality.completeness_percent[gte]
+          in: query
+          description: Filter by the metadata quality completeness percentage using an operator [gte] for greater than or equal to, [gt] for greater than, [lte] for less than or equal to, [lt] for less than, and [eq] for equal to.
+          schema:
+            type: number
+          example: 90.5
+        - name: metadataquality.weighted_completeness_percent[gte]
+          in: query
+          description: Filter by the metadata quality weighted completeness percentage using an operator [gte] for greater than or equal to, [gt] for greater than, [lte] for less than or equal to, [lt] for less than, and [eq] for equal to.
+          schema:
+            type: number
+          example: 71.2
+        - name: metadataquality.weighted_quality_score[gte]
+          in: query
+          description: Filter by the metadata quality score using an operator [gte] for greater than or equal to, [gt] for greater than, [lte] for less than or equal to, [lt] for less than, and [eq] for equal to.
+          schema:
+            type: number
+          example: 35.3
+      responses:
+        '200':
+          description: Successful response containing a list of datasets matching query parameters
+          
+  /api/v2/datasets/{datasetid}:
+    get:
+      summary: Returns a dataset object.
+      tags:
+        - Datasets v2.0
+      parameters:
+        - in: path
+          name: datasetid
+          required: true
+          description: The unqiue identifier for a specific version of a dataset
+          schema:
+            type: string
+            example: af20ebb2-018a-4557-8ced-0bec75dba150
+        - in: query
+          name: raw
+          required: false
+          description: A flag which determines if the response triggered is the raw structure in which the data is stored rather than the dataset v2.0 standard
+          schema:
+            type: boolean
+            example: false
+      description: Version 2.0 of the datasets API introduces the agreed dataset v2.0 schema as defined at the following link -  https://github.com/HDRUK/schemata/edit/master/schema/dataset/2.0.0/dataset.schema.json
+      responses:
+        '200':
+          description: Successful response containing a single dataset object
+        '404':
+          description: A dataset could not be found by the provided dataset identifier
+
   /api/v1/projects:
     post:
       summary: Returns a Project object with ID.
@@ -2031,6 +2158,73 @@ paths:
       responses:
         '200':
           description: OK
+
+  /api/v2/projects:
+    get:
+      summary: Returns a list of project objects
+      tags:
+        - Projects v2.0
+      parameters:
+        - name: search
+          in: query
+          description: Full text index search function which searches for partial matches in various fields including name and description.  The response will contain a metascore indicating the relevancy of the match, by default results are sorted by the most relevant first unless a manual sort query parameter has been added.
+          schema:
+            type: string
+          example: health service
+        - name: page
+          in: query
+          description: A specific page of results to retrieve
+          schema:
+            type: number
+          example: 1
+        - name: limit
+          in: query
+          description: Maximum number of results returned per page
+          schema:
+            type: number
+          example: 10
+        - name: sort
+          in: query
+          description: Fields to apply sort operations to.  Accepts multiple fields in ascending and descending.  E.g. name for ascending or -name for descending.  Multiple fields should be comma separated as shown in the example below.
+          schema:
+            type: string
+          example: name,-counter
+        - name: fields
+          in: query
+          description: Limit the size of the response by requesting only certain fields.  Note that some additional derived fields are always returned.  Multiple fields should be comma separate as shown in the example below.
+          schema:
+            type: string
+          example: name,counter,description
+        - name: count
+          in: query
+          description: Returns the number of the number of entities matching the query parameters provided instead of the result payload
+          schema:
+            type: boolean
+          example: true
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      responses:
+        '200':
+          description: Successful response containing a list of projects matching query parameters
+
+  /api/v2/projects/{id}:
+    get:
+      summary: Returns a project object
+      tags:
+        - Projects v2.0
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The ID of the project
+          schema:
+            type: number
+            example: 100000001
+      description: Returns a project object by matching unique identifier in the default format that is stored as within the Gateway
+      responses:
+        '200':
+          description: Successful response containing a single project object
+        '404':
+          description: A project could not be found by the provided project identifier
 
   /api/v1/papers:
     post:
@@ -2253,6 +2447,73 @@ paths:
         '200':
           description: OK
 
+  /api/v2/papers:
+    get:
+      summary: Returns a list of paper objects
+      tags:
+        - Papers v2.0
+      parameters:
+        - name: search
+          in: query
+          description: Full text index search function which searches for partial matches in various fields including name and description.  The response will contain a metascore indicating the relevancy of the match, by default results are sorted by the most relevant first unless a manual sort query parameter has been added.
+          schema:
+            type: string
+          example: Exploration
+        - name: page
+          in: query
+          description: A specific page of results to retrieve
+          schema:
+            type: number
+          example: 1
+        - name: limit
+          in: query
+          description: Maximum number of results returned per page
+          schema:
+            type: number
+          example: 10
+        - name: sort
+          in: query
+          description: Fields to apply sort operations to.  Accepts multiple fields in ascending and descending.  E.g. name for ascending or -name for descending.  Multiple fields should be comma separated as shown in the example below.
+          schema:
+            type: string
+          example: name,-counter
+        - name: fields
+          in: query
+          description: Limit the size of the response by requesting only certain fields.  Note that some additional derived fields are always returned.  Multiple fields should be comma separate as shown in the example below.
+          schema:
+            type: string
+          example: name,counter,description
+        - name: count
+          in: query
+          description: Returns the number of the number of entities matching the query parameters provided instead of the result payload
+          schema:
+            type: boolean
+          example: true
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      responses:
+        '200':
+          description: Successful response containing a list of papers matching query parameters
+          
+  /api/v2/papers/{id}:
+    get:
+      summary: Returns paper object
+      tags:
+        - Papers v2.0
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The ID of the paper
+          schema:
+            type: number
+            example: 13296138992670704
+      description: Returns a paper object by matching unique identifier in the default format that is stored as within the Gateway
+      responses:
+        '200':
+          description: Successful response containing a single paper object
+        '404':
+          description: A paper could not be found by the provided paper identifier
+
   /api/v1/tools:
     get:
       summary: Return List of Tool objects.
@@ -2341,7 +2602,7 @@ paths:
 
   /api/v1/tools/{id}:
     get:
-      summary: Returns Tool object.
+      summary: Returns Tool object
       tags:
         - Tools
       parameters:
@@ -2467,6 +2728,141 @@ paths:
       responses:
         '200':
           description: OK
+
+  /api/v2/tools:
+    get:
+      summary: Returns a list of tool objects
+      tags:
+        - Tools v2.0
+      parameters:
+        - name: search
+          in: query
+          description: Full text index search function which searches for partial matches in various fields including name and description.  The response will contain a metascore indicating the relevancy of the match, by default results are sorted by the most relevant first unless a manual sort query parameter has been added.
+          schema:
+            type: string
+          example: Regulation
+        - name: page
+          in: query
+          description: A specific page of results to retrieve
+          schema:
+            type: number
+          example: 1
+        - name: limit
+          in: query
+          description: Maximum number of results returned per page
+          schema:
+            type: number
+          example: 10
+        - name: sort
+          in: query
+          description: Fields to apply sort operations to.  Accepts multiple fields in ascending and descending.  E.g. name for ascending or -name for descending.  Multiple fields should be comma separated as shown in the example below.
+          schema:
+            type: string
+          example: name,-counter
+        - name: fields
+          in: query
+          description: Limit the size of the response by requesting only certain fields.  Note that some additional derived fields are always returned.  Multiple fields should be comma separate as shown in the example below.
+          schema:
+            type: string
+          example: name,counter, description
+        - name: count
+          in: query
+          description: Returns the number of the number of entities matching the query parameters provided instead of the result payload
+          schema:
+            type: boolean
+          example: true
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      responses:
+        '200':
+          description: Successful response containing a list of tools matching query parameters
+      
+  /api/v2/tools/{id}:
+    get:
+      summary: Returns a tool object
+      tags:
+        - Tools v2.0
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The ID of the tool
+          schema:
+            type: number
+            example: 100000006
+      description: Returns a tool object by matching unique identifier in the default format that is stored as within the Gateway
+      responses:
+        '200':
+          description: Successful response containing a single tool object
+        '404':
+          description: A tool could not be found by the provided tool identifier
+
+  /api/v2/courses:
+    get:
+      summary: Returns a list of courses
+      parameters:
+        - name: search
+          in: query
+          description: Full text index search function which searches for partial matches in various fields including name and description.  The response will contain a metascore indicating the relevancy of the match, by default results are sorted by the most relevant first unless a manual sort query parameter has been added.
+          schema:
+            type: string
+          example: Research
+        - name: page
+          in: query
+          description: A specific page of results to retrieve
+          schema:
+            type: number
+          example: 1
+        - name: limit
+          in: query
+          description: Maximum number of results returned per page
+          schema:
+            type: number
+          example: 10
+        - name: sort
+          in: query
+          description: Fields to apply sort operations to.  Accepts multiple fields in ascending and descending.  E.g. provider for ascending or -provider for descending.  Multiple fields should be comma separated as shown in the example below.
+          schema:
+            type: string
+          example: provider,-counter
+        - name: fields
+          in: query
+          description: Limit the size of the response by requesting only certain fields.  Note that some additional derived fields are always returned.  Multiple fields should be comma separate as shown in the example below.
+          schema:
+            type: string
+          example: provider,counter,description
+        - name: count
+          in: query
+          description: Returns the number of the number of entities matching the query parameters provided instead of the result payload
+          schema:
+            type: boolean
+          example: true
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      tags:
+        - Courses v2.0
+      responses:
+        '200':
+          description: Successful response containing a list of course objects matching query parameters
+
+  /api/v2/courses/{id}:
+    summary: summary
+    get:
+      summary: Returns a course object
+      description: Returns a course object by matching unique identifier in the default format that is stored as within the Gateway
+      tags:
+        - Courses v2.0
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The ID of the course
+          schema:
+            type: number
+            example: 5540794872521069
+      responses:
+        '200':
+          description: Successful response containing a single course object
+        '404':
+          description: A course could not be found by the provided course identifier
 
 components:
   securitySchemes:


### PR DESCRIPTION
Updated documents for the following endpoints for API v2:

GET https://api.{env}/api/v2/courses/{id}
GET https://api.{env}/api/v2/courses/

GET https://api.{env}/api/v2/papers/{id}
GET https://api.{env}api/v2/papers

GET https://api.{env}/api/v2/projects/{id}
GET https://api.{env}/api/v2/projects

GET https://api.{env}/api/v2/tools/{id}
GET https://api.{env}/api/v2/tools

GET https://api.{env}/api/v2/datasets/{id}
GET https://api.{env}/api/v2/datasets
