### PR TITLE
SUPP-441 - Aggregate dataset versions for popular entities display

### DIFF
--- a/src/resources/stats/stats.router.js
+++ b/src/resources/stats/stats.router.js
@@ -12,286 +12,335 @@ const router = express.Router();
  * This will return a JSON document to show high level stats
  */
 router.get('', async (req, res) => {
-	switch (req.query.rank) {
-		case undefined:
-			var result;
+	try {
+		const { query = {} } = req;
 
-			//get some dates for query
-			var lastDay = new Date();
-			lastDay.setDate(lastDay.getDate() - 1);
+		switch (query.rank) {
+			case undefined:
+				var result;
 
-			var lastWeek = new Date();
-			lastWeek.setDate(lastWeek.getDate() - 7);
+				//get some dates for query
+				var lastDay = new Date();
+				lastDay.setDate(lastDay.getDate() - 1);
 
-			var lastMonth = new Date();
-			lastMonth.setMonth(lastMonth.getMonth() - 1);
+				var lastWeek = new Date();
+				lastWeek.setDate(lastWeek.getDate() - 7);
 
-			var lastYear = new Date();
-			lastYear.setYear(lastYear.getYear() - 1);
+				var lastMonth = new Date();
+				lastMonth.setMonth(lastMonth.getMonth() - 1);
 
-			var aggregateQuerySearches = [
-				{
-					$facet: {
-						lastDay: [
-							{ $match: { datesearched: { $gt: lastDay } } },
-							{
-								$group: {
-									_id: 'lastDay',
-									count: { $sum: 1 },
+				var lastYear = new Date();
+				lastYear.setYear(lastYear.getYear() - 1);
+
+				var aggregateQuerySearches = [
+					{
+						$facet: {
+							lastDay: [
+								{ $match: { datesearched: { $gt: lastDay } } },
+								{
+									$group: {
+										_id: 'lastDay',
+										count: { $sum: 1 },
+									},
 								},
-							},
-						],
-						lastWeek: [
-							{ $match: { datesearched: { $gt: lastWeek } } },
-							{
-								$group: {
-									_id: 'lastWeek',
-									count: { $sum: 1 },
+							],
+							lastWeek: [
+								{ $match: { datesearched: { $gt: lastWeek } } },
+								{
+									$group: {
+										_id: 'lastWeek',
+										count: { $sum: 1 },
+									},
 								},
-							},
-						],
-						lastMonth: [
-							{ $match: { datesearched: { $gt: lastMonth } } },
-							{
-								$group: {
-									_id: 'lastMonth',
-									count: { $sum: 1 },
+							],
+							lastMonth: [
+								{ $match: { datesearched: { $gt: lastMonth } } },
+								{
+									$group: {
+										_id: 'lastMonth',
+										count: { $sum: 1 },
+									},
 								},
-							},
-						],
-						lastYear: [
-							{ $match: { datesearched: { $gt: lastYear } } },
-							{
-								$group: {
-									_id: 'lastYear',
-									count: { $sum: 1 },
+							],
+							lastYear: [
+								{ $match: { datesearched: { $gt: lastYear } } },
+								{
+									$group: {
+										_id: 'lastYear',
+										count: { $sum: 1 },
+									},
 								},
-							},
-						],
+							],
+						},
 					},
-				},
-			];
+				];
 
-			//set the aggregate queries
-			var aggregateQueryTypes = [
-				{
-					$match: {
-						$and: [
-							{ activeflag: 'active' },
-							{ 'datasetfields.publisher': { $ne: 'OTHER > HEALTH DATA RESEARCH UK' } },
-							{ 'datasetfields.publisher': { $ne: 'HDR UK' } },
-						],
+				//set the aggregate queries
+				var aggregateQueryTypes = [
+					{
+						$match: {
+							$and: [
+								{ activeflag: 'active' },
+								{ 'datasetfields.publisher': { $ne: 'OTHER > HEALTH DATA RESEARCH UK' } },
+								{ 'datasetfields.publisher': { $ne: 'HDR UK' } },
+							],
+						},
 					},
-				},
-				{ $group: { _id: '$type', count: { $sum: 1 } } },
-			];
+					{ $group: { _id: '$type', count: { $sum: 1 } } },
+				];
 
-			var q = RecordSearchData.aggregate(aggregateQuerySearches);
+				var q = RecordSearchData.aggregate(aggregateQuerySearches);
 
-			var aggregateAccessRequests = [
-				{
-					$match: {
-						$or: [
-							{ applicationStatus: 'submitted' },
-							{ applicationStatus: 'approved' },
-							{ applicationStatus: 'rejected' },
-							{ applicationStatus: 'inReview' },
-							{ applicationStatus: 'approved with conditions' },
-						],
+				var aggregateAccessRequests = [
+					{
+						$match: {
+							$or: [
+								{ applicationStatus: 'submitted' },
+								{ applicationStatus: 'approved' },
+								{ applicationStatus: 'rejected' },
+								{ applicationStatus: 'inReview' },
+								{ applicationStatus: 'approved with conditions' },
+							],
+						},
 					},
-				},
-			];
+				];
 
-			var y = DataRequestModel.aggregate(aggregateAccessRequests);
+				var y = DataRequestModel.aggregate(aggregateAccessRequests);
 
-			q.exec((err, dataSearches) => {
-				if (err) return res.json({ success: false, error: err });
+				q.exec((err, dataSearches) => {
+					if (err) return res.json({ success: false, error: err });
 
-				var x = Data.aggregate(aggregateQueryTypes);
-				x.exec((errx, dataTypes) => {
-					if (errx) return res.json({ success: false, error: errx });
+					var x = Data.aggregate(aggregateQueryTypes);
+					x.exec((errx, dataTypes) => {
+						if (errx) return res.json({ success: false, error: errx });
 
-					var counts = {}; //hold the type (i.e. tool, person, project, access requests) counts data
-					for (var i = 0; i < dataTypes.length; i++) {
-						//format the result in a clear and dynamic way
-						counts[dataTypes[i]._id] = dataTypes[i].count;
-					}
+						var counts = {}; //hold the type (i.e. tool, person, project, access requests) counts data
+						for (var i = 0; i < dataTypes.length; i++) {
+							//format the result in a clear and dynamic way
+							counts[dataTypes[i]._id] = dataTypes[i].count;
+						}
 
-					y.exec(async (err, accessRequests) => {
-						let hdrDatasetID = await getHdrDatasetId();
-						let hdrDatasetIds = [];
-						hdrDatasetID.map(hdrDatasetid => {
-							hdrDatasetIds.push(hdrDatasetid.datasetid);
-						});
-						let accessRequestsCount = 0;
+						y.exec(async (err, accessRequests) => {
+							let hdrDatasetID = await getHdrDatasetId();
+							let hdrDatasetIds = [];
+							hdrDatasetID.map(hdrDatasetid => {
+								hdrDatasetIds.push(hdrDatasetid.datasetid);
+							});
+							let accessRequestsCount = 0;
 
-						if (err) return res.json({ success: false, error: err });
+							if (err) return res.json({ success: false, error: err });
 
-						accessRequests.map(accessRequest => {
-							if (accessRequest.datasetIds && accessRequest.datasetIds.length > 0) {
-								accessRequest.datasetIds.map(datasetid => {
-									if (!hdrDatasetIds.includes(datasetid)) {
-										accessRequestsCount++;
-									}
-								});
+							accessRequests.map(accessRequest => {
+								if (accessRequest.datasetIds && accessRequest.datasetIds.length > 0) {
+									accessRequest.datasetIds.map(datasetid => {
+										if (!hdrDatasetIds.includes(datasetid)) {
+											accessRequestsCount++;
+										}
+									});
+								}
+
+								counts['accessRequests'] = accessRequestsCount;
+							});
+
+							if (typeof dataSearches[0].lastDay[0] === 'undefined') {
+								dataSearches[0].lastDay[0] = { count: 0 };
+							}
+							if (typeof dataSearches[0].lastWeek[0] === 'undefined') {
+								dataSearches[0].lastWeek[0] = { count: 0 };
+							}
+							if (typeof dataSearches[0].lastMonth[0] === 'undefined') {
+								dataSearches[0].lastMonth[0] = { count: 0 };
+							}
+							if (typeof dataSearches[0].lastYear[0] === 'undefined') {
+								dataSearches[0].lastYear[0] = { count: 0 };
 							}
 
-							counts['accessRequests'] = accessRequestsCount;
-						});
-
-						if (typeof dataSearches[0].lastDay[0] === 'undefined') {
-							dataSearches[0].lastDay[0] = { count: 0 };
-						}
-						if (typeof dataSearches[0].lastWeek[0] === 'undefined') {
-							dataSearches[0].lastWeek[0] = { count: 0 };
-						}
-						if (typeof dataSearches[0].lastMonth[0] === 'undefined') {
-							dataSearches[0].lastMonth[0] = { count: 0 };
-						}
-						if (typeof dataSearches[0].lastYear[0] === 'undefined') {
-							dataSearches[0].lastYear[0] = { count: 0 };
-						}
-
-						result = res.json({
-							success: true,
-							data: {
-								typecounts: counts,
-								daycounts: {
-									day: dataSearches[0].lastDay[0].count,
-									week: dataSearches[0].lastWeek[0].count,
-									month: dataSearches[0].lastMonth[0].count,
-									year: dataSearches[0].lastYear[0].count,
+							result = res.json({
+								success: true,
+								data: {
+									typecounts: counts,
+									daycounts: {
+										day: dataSearches[0].lastDay[0].count,
+										week: dataSearches[0].lastWeek[0].count,
+										month: dataSearches[0].lastMonth[0].count,
+										year: dataSearches[0].lastYear[0].count,
+									},
 								},
-							},
+							});
 						});
 					});
 				});
-			});
 
-			return result;
-			break;
+				return result;
+				break;
 
-		case 'recent':
-			var q = RecordSearchData.aggregate([
-				{ $match: { $or: [{ 'returned.tool': { $gt: 0 } }, { 'returned.project': { $gt: 0 } }, { 'returned.person': { $gt: 0 } }] } },
-				{
-					$group: {
-						_id: { $toLower: '$searched' },
-						count: { $sum: 1 },
-						returned: { $first: '$returned' },
+			case 'recent':
+				var q = RecordSearchData.aggregate([
+					{ $match: { $or: [{ 'returned.tool': { $gt: 0 } }, { 'returned.project': { $gt: 0 } }, { 'returned.person': { $gt: 0 } }] } },
+					{
+						$group: {
+							_id: { $toLower: '$searched' },
+							count: { $sum: 1 },
+							returned: { $first: '$returned' },
+						},
 					},
-				},
-				{ $sort: { datesearched: 1 } },
-			]).limit(10);
+					{ $sort: { datesearched: 1 } },
+				]).limit(10);
 
-			q.exec((err, data) => {
-				if (err) return res.json({ success: false, error: err });
-				return res.json({ success: true, data: data });
-			});
-			break;
+				q.exec((err, data) => {
+					if (err) return res.json({ success: false, error: err });
+					return res.json({ success: true, data: data });
+				});
+				break;
 
-		case 'popular':
-			var q = Data.find({ counter: { $gt: 0 } })
-				.sort({ counter: -1 })
-				.limit(10);
+			case 'popular':
+				const popularType = {};
+				if (query.type) popularType = { type: query.type };
+				const popularData = await Data.aggregate([
+					{
+						$match: {
+							...popularType,
+							counter: {
+								$gt: 0,
+							},
+							name: {
+								$exists: true,
+							},
+							pid: {
+								$ne: 'fd8d0743-344a-4758-bb97-f8ad84a37357', //PID for HDR-UK Papers dataset
+							},
+						},
+					},
+					{
+						$project: {
+							_id: 0,
+							type: 1,
+							bio: 1,
+							firstname: 1,
+							lastname: 1,
+							name: 1,
+							categories: 1,
+							pid: 1,
+							id: 1,
+							counter: 1,
+						},
+					},
+					{
+						$group: {
+							_id: '$name',
+							type: { $first: '$type' },
+							name: { $first: '$name' },
+							pid: { $first: '$pid' },
+							bio: {$first: '$bio' },
+							firstname: { $first: '$firstname' },
+							lastname: { $first: '$lastname' },
+							id: { $first: '$id' },
+							categories: { $first: '$categories' },
+							counter: { $sum: '$counter' },
+						},
+					},
+					{
+						$sort: {
+							counter: -1,
+							name: 1,
+						},
+					},
+					{
+						$limit: 10,
+					},
+				]);
 
-			if (req.query.type) {
-				q = Data.find({ $and: [{ type: req.query.type, counter: { $gt: 0 } }] })
-					.sort({ counter: -1 })
+				return res.json({ success: true, data: popularData });
+
+			case 'updates':
+				var q = Data.find({ activeflag: 'active', counter: { $gt: 0 } })
+					.sort({ updatedon: -1 })
 					.limit(10);
-			}
 
-			q.exec((err, data) => {
-				if (err) return res.json({ success: false, error: err });
-				return res.json({ success: true, data: data });
-			});
-			break;
+				if (req.query.type) {
+					q = Data.find({ $and: [{ type: req.query.type, activeflag: 'active', updatedon: { $gt: 0 } }] })
+						.sort({ counter: -1 })
+						.limit(10);
+				}
 
-		case 'updates':
-			var q = Data.find({ activeflag: 'active', counter: { $gt: 0 } })
-				.sort({ updatedon: -1 })
-				.limit(10);
+				q.exec((err, data) => {
+					if (err) return res.json({ success: false, error: err });
+					return res.json({ success: true, data: data });
+				});
+				break;
 
-			if (req.query.type) {
-				q = Data.find({ $and: [{ type: req.query.type, activeflag: 'active', updatedon: { $gt: 0 } }] })
-					.sort({ counter: -1 })
-					.limit(10);
-			}
+			case 'unmet':
+				switch (req.query.type) {
+					case 'Datasets':
+						req.entity = 'dataset';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
 
-			q.exec((err, data) => {
-				if (err) return res.json({ success: false, error: err });
-				return res.json({ success: true, data: data });
-			});
-			break;
+					case 'Tools':
+						req.entity = 'tool';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
 
-		case 'unmet':
-			switch (req.query.type) {
-				case 'Datasets':
-					req.entity = 'dataset';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
+					case 'Projects':
+						req.entity = 'project';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
 
-				case 'Tools':
-					req.entity = 'tool';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
+					case 'Courses':
+						req.entity = 'course';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
 
-				case 'Projects':
-					req.entity = 'project';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
+					case 'Papers':
+						req.entity = 'paper';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
 
-				case 'Courses':
-					req.entity = 'course';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
-
-				case 'Papers':
-					req.entity = 'paper';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
-
-				case 'People':
-					req.entity = 'person';
-					await getUnmetSearches(req)
-						.then(data => {
-							return res.json({ success: true, data: data });
-						})
-						.catch(err => {
-							return res.json({ success: false, error: err });
-						});
-					break;
-			}
+					case 'People':
+						req.entity = 'person';
+						await getUnmetSearches(req)
+							.then(data => {
+								return res.json({ success: true, data: data });
+							})
+							.catch(err => {
+								return res.json({ success: false, error: err });
+							});
+						break;
+				}
+		}
+	} catch (err) {
+		console.error(err.message);
+		return res.json({ success: false, error: err.message });
 	}
 });
 

--- a/src/resources/stats/stats.router.js
+++ b/src/resources/stats/stats.router.js
@@ -194,7 +194,7 @@ router.get('', async (req, res) => {
 				break;
 
 			case 'popular':
-				const popularType = {};
+				let popularType = {};
 				if (query.type) popularType = { type: query.type };
 				const popularData = await Data.aggregate([
 					{


### PR DESCRIPTION
- Updated popular entity counter logic to group entities by type and name when counting their popularity, collapsing dataset versions together for correct aggregation returning only a single dataset with pid.
- Reduced response payload to minimal size for performance enhancement.