### PR TITLE
SUPP-451 - DAR - Fix custodian actions buttons in review

### DIFF
--- a/src/resources/datarequest/amendment/amendment.controller.js
+++ b/src/resources/datarequest/amendment/amendment.controller.js
@@ -113,7 +113,8 @@ const setAmendment = async (req, res) => {
 					accessRecordObj.jsonSchema,
 					userType,
 					accessRecordObj.applicationStatus,
-					userRole
+					userRole,
+					activeParty
 				);
 				// 12. Count the number of answered/unanswered amendments
 				const { answeredAmendments = 0, unansweredAmendments = 0 } = countUnsubmittedAmendments(accessRecord, userType);

--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -128,7 +128,8 @@ module.exports = {
 				accessRecord.jsonSchema,
 				userType,
 				accessRecord.applicationStatus,
-				userRole
+				userRole,
+				activeParty
 			);
 			// 14. Return application form
 			return res.status(200).json({
@@ -231,7 +232,7 @@ module.exports = {
 			// 6. Parse json to allow us to modify schema
 			data.jsonSchema = JSON.parse(data.jsonSchema);
 			// 7. Append question actions depending on user type and application status
-			data.jsonSchema = datarequestUtil.injectQuestionActions(data.jsonSchema, constants.userTypes.APPLICANT, data.applicationStatus);
+			data.jsonSchema = datarequestUtil.injectQuestionActions(data.jsonSchema, constants.userTypes.APPLICANT, data.applicationStatus, null, constants.userTypes.APPLICANT);
 			// 8. Return payload
 			return res.status(200).json({
 				status: 'success',
@@ -337,7 +338,7 @@ module.exports = {
 			// 6. Parse json to allow us to modify schema
 			data.jsonSchema = JSON.parse(data.jsonSchema);
 			// 7. Append question actions depending on user type and application status
-			data.jsonSchema = datarequestUtil.injectQuestionActions(data.jsonSchema, constants.userTypes.APPLICANT, data.applicationStatus);
+			data.jsonSchema = datarequestUtil.injectQuestionActions(data.jsonSchema, constants.userTypes.APPLICANT, data.applicationStatus, null, constants.userTypes.APPLICANT);
 			// 8. Return payload
 			return res.status(200).json({
 				status: 'success',
@@ -1686,6 +1687,7 @@ module.exports = {
 						jsonSchema,
 						constants.userTypes.APPLICANT, // current user type
 						constants.applicationStatuses.INPROGRESS,
+						null,
 						constants.userTypes.APPLICANT // active party
 					);
 					// 10. Return necessary object to reflect schema update

--- a/src/resources/datarequest/utils/__tests__/datarequest.util.test.js
+++ b/src/resources/datarequest/utils/__tests__/datarequest.util.test.js
@@ -22,7 +22,13 @@ describe('injectQuestionActions', () => {
 		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.INREVIEW, '', [guidance]],
 		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.WITHDRAWN, '', [guidance]],
 		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.SUBMITTED, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.APPROVED, constants.roleTypes.MANAGER, [guidance]],
+		[
+			data[0].jsonSchema,
+			constants.userTypes.CUSTODIAN,
+			constants.applicationStatuses.APPROVED,
+			constants.roleTypes.MANAGER,
+			[guidance],
+		],
 		[
 			data[0].jsonSchema,
 			constants.userTypes.CUSTODIAN,
@@ -35,7 +41,16 @@ describe('injectQuestionActions', () => {
 			constants.userTypes.CUSTODIAN,
 			constants.applicationStatuses.INREVIEW,
 			constants.roleTypes.MANAGER,
+			constants.userTypes.CUSTODIAN,
 			[guidance, requestAmendment],
+		],
+		[
+			data[0].jsonSchema,
+			constants.userTypes.CUSTODIAN,
+			constants.applicationStatuses.INREVIEW,
+			constants.roleTypes.MANAGER,
+			constants.userTypes.APPLICANT,
+			[guidance],
 		],
 		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.WITHDRAWN, constants.roleTypes.MANAGER, [guidance]],
 		[
@@ -43,7 +58,8 @@ describe('injectQuestionActions', () => {
 			constants.userTypes.CUSTODIAN,
 			constants.applicationStatuses.SUBMITTED,
 			constants.roleTypes.MANAGER,
-			[guidance, requestAmendment],
+			constants.userTypes.CUSTODIAN,
+			[guidance],
 		],
 		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.APPROVED, constants.roleTypes.REVIEWER, [guidance]],
 		[
@@ -59,9 +75,9 @@ describe('injectQuestionActions', () => {
 	];
 	test.each(cases)(
 		'given a jsonSchema object %p and the user is a/an %p, and the application status is %p, it returns the correct question actions',
-		(data, userType, applicationStatus, role, expectedResults) => {
+		(data, userType, applicationStatus, role, activeParty, expectedResults) => {
 			// Act
-			const result = datarequestUtil.injectQuestionActions(data, userType, applicationStatus, role);
+			const result = datarequestUtil.injectQuestionActions(data, userType, applicationStatus, role, activeParty);
 			// Assert
 			expectedResults.forEach(expectedResult => {
 				expect(result.questionActions).toContainEqual(expectedResult);

--- a/src/resources/datarequest/utils/__tests__/datarequest.util.test.js
+++ b/src/resources/datarequest/utils/__tests__/datarequest.util.test.js
@@ -16,17 +16,18 @@ describe('injectQuestionActions', () => {
 		order: 2,
 	};
 	const cases = [
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.INPROGRESS, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.APPROVED, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.APPROVEDWITHCONDITIONS, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.INREVIEW, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.WITHDRAWN, '', [guidance]],
-		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.SUBMITTED, '', [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.INPROGRESS, '', constants.userTypes.APPLICANT, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.APPROVED, '', constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.APPROVEDWITHCONDITIONS, '', constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.INREVIEW, '', constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.WITHDRAWN, '', constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.APPLICANT, constants.applicationStatuses.SUBMITTED, '', constants.userTypes.CUSTODIAN, [guidance]],
 		[
 			data[0].jsonSchema,
 			constants.userTypes.CUSTODIAN,
 			constants.applicationStatuses.APPROVED,
 			constants.roleTypes.MANAGER,
+			constants.userTypes.CUSTODIAN,
 			[guidance],
 		],
 		[
@@ -34,6 +35,7 @@ describe('injectQuestionActions', () => {
 			constants.userTypes.CUSTODIAN,
 			constants.applicationStatuses.APPROVEDWITHCONDITIONS,
 			constants.roleTypes.MANAGER,
+			constants.userTypes.CUSTODIAN,
 			[guidance],
 		],
 		[
@@ -52,7 +54,7 @@ describe('injectQuestionActions', () => {
 			constants.userTypes.APPLICANT,
 			[guidance],
 		],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.WITHDRAWN, constants.roleTypes.MANAGER, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.WITHDRAWN, constants.roleTypes.MANAGER, constants.userTypes.CUSTODIAN, [guidance]],
 		[
 			data[0].jsonSchema,
 			constants.userTypes.CUSTODIAN,
@@ -61,17 +63,18 @@ describe('injectQuestionActions', () => {
 			constants.userTypes.CUSTODIAN,
 			[guidance],
 		],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.APPROVED, constants.roleTypes.REVIEWER, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.APPROVED, constants.roleTypes.REVIEWER, constants.userTypes.CUSTODIAN, [guidance]],
 		[
 			data[0].jsonSchema,
 			constants.userTypes.CUSTODIAN,
 			constants.applicationStatuses.APPROVEDWITHCONDITIONS,
 			constants.roleTypes.REVIEWER,
+			constants.userTypes.CUSTODIAN,
 			[guidance],
 		],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.INREVIEW, constants.roleTypes.REVIEWER, [guidance]],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.WITHDRAWN, constants.roleTypes.REVIEWER, [guidance]],
-		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.SUBMITTED, constants.roleTypes.REVIEWER, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.INREVIEW, constants.roleTypes.REVIEWER, constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.WITHDRAWN, constants.roleTypes.REVIEWER, constants.userTypes.CUSTODIAN, [guidance]],
+		[data[0].jsonSchema, constants.userTypes.CUSTODIAN, constants.applicationStatuses.SUBMITTED, constants.roleTypes.REVIEWER, constants.userTypes.CUSTODIAN, [guidance]],
 	];
 	test.each(cases)(
 		'given a jsonSchema object %p and the user is a/an %p, and the application status is %p, it returns the correct question actions',

--- a/src/resources/datarequest/utils/datarequest.util.js
+++ b/src/resources/datarequest/utils/datarequest.util.js
@@ -3,10 +3,14 @@ import constants from '../../utilities/constants.util';
 import teamController from '../../team/team.controller';
 import moment from 'moment';
 
-const injectQuestionActions = (jsonSchema, userType, applicationStatus, role = '') => {
+const injectQuestionActions = (jsonSchema, userType, applicationStatus, role = '', activeParty) => {
 	let formattedSchema = {};
 	if (userType === constants.userTypes.CUSTODIAN) {
-		formattedSchema = { ...jsonSchema, questionActions: constants.userQuestionActions[userType][role][applicationStatus] };
+		if (applicationStatus === constants.applicationStatuses.INREVIEW) {
+			formattedSchema = { ...jsonSchema, questionActions: constants.userQuestionActions[userType][role][applicationStatus][activeParty] };
+		} else {
+			formattedSchema = { ...jsonSchema, questionActions: constants.userQuestionActions[userType][role][applicationStatus]};
+		}
 	} else {
 		formattedSchema = { ...jsonSchema, questionActions: constants.userQuestionActions[userType][applicationStatus] };
 	}
@@ -89,7 +93,7 @@ const findQuestion = (questionsArr, questionId) => {
 					return typeof option.conditionalQuestions !== 'undefined' && option.conditionalQuestions.length > 0;
 				})
 				.forEach(option => {
-					if(!child) {
+					if (!child) {
 						child = findQuestion(option.conditionalQuestions, questionId);
 					}
 				});
@@ -176,15 +180,10 @@ const buildQuestionAlert = (userType, iterationStatus, completed, amendment, use
 		updatedBy = matchCurrentUser(user, updatedBy);
 		// 5. Update the generic question alerts to match the scenario
 		let relevantActioner = !_.isNil(updatedBy) ? updatedBy : userType === constants.userTypes.CUSTODIAN ? requestedBy : publisher;
-		questionAlert.text = questionAlert.text.replace(
-			'#NAME#',
-			relevantActioner
-		);
+		questionAlert.text = questionAlert.text.replace('#NAME#', relevantActioner);
 		questionAlert.text = questionAlert.text.replace(
 			'#DATE#',
-			userType === !_.isNil(dateUpdated)
-				? moment(dateUpdated).format('Do MMM YYYY')
-				: moment(dateRequested).format('Do MMM YYYY')
+			userType === !_.isNil(dateUpdated) ? moment(dateUpdated).format('Do MMM YYYY') : moment(dateRequested).format('Do MMM YYYY')
 		);
 		// 6. Return the built question alert
 		return questionAlert;

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -16,15 +16,26 @@ const _userQuestionActions = {
 					order: 1,
 				},
 			],
-			inReview: [
-				{
-					key: 'guidance',
-					icon: 'far fa-question-circle',
-					color: '#475da7',
-					toolTip: 'Guidance',
-					order: 1,
-				},
-			],
+			inReview: {
+				custodian: [
+					{
+						key: 'guidance',
+						icon: 'far fa-question-circle',
+						color: '#475da7',
+						toolTip: 'Guidance',
+						order: 1,
+					},
+				],
+				applicant: [
+					{
+						key: 'guidance',
+						icon: 'far fa-question-circle',
+						color: '#475da7',
+						toolTip: 'Guidance',
+						order: 1,
+					},
+				],
+			},
 			approved: [
 				{
 					key: 'guidance',
@@ -96,7 +107,7 @@ const _userQuestionActions = {
 						color: '#475da7',
 						toolTip: 'Guidance',
 						order: 1,
-					}
+					},
 				],
 			},
 			approved: [

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -71,30 +71,34 @@ const _userQuestionActions = {
 					toolTip: 'Guidance',
 					order: 1,
 				},
-				{
-					key: 'requestAmendment',
-					icon: 'fas fa-exclamation-circle',
-					color: '#F0BB24',
-					toolTip: 'Request applicant updates answer',
-					order: 2,
-				},
 			],
-			inReview: [
-				{
-					key: 'guidance',
-					icon: 'far fa-question-circle',
-					color: '#475da7',
-					toolTip: 'Guidance',
-					order: 1,
-				},
-				{
-					key: 'requestAmendment',
-					icon: 'fas fa-exclamation-circle',
-					color: '#F0BB24',
-					toolTip: 'Request applicant updates answer',
-					order: 2,
-				},
-			],
+			inReview: {
+				custodian: [
+					{
+						key: 'guidance',
+						icon: 'far fa-question-circle',
+						color: '#475da7',
+						toolTip: 'Guidance',
+						order: 1,
+					},
+					{
+						key: 'requestAmendment',
+						icon: 'fas fa-exclamation-circle',
+						color: '#F0BB24',
+						toolTip: 'Request applicant updates answer',
+						order: 2,
+					},
+				],
+				applicant: [
+					{
+						key: 'guidance',
+						icon: 'far fa-question-circle',
+						color: '#475da7',
+						toolTip: 'Guidance',
+						order: 1,
+					}
+				],
+			},
 			approved: [
 				{
 					key: 'guidance',
@@ -272,7 +276,7 @@ const _notificationTypes = {
 	MEMBERROLECHANGED: 'MemberRoleChanged',
 	WORKFLOWASSIGNED: 'WorkflowAssigned',
 	WORKFLOWCREATED: 'WorkflowCreated',
-	INPROGRESS: 'InProgress'
+	INPROGRESS: 'InProgress',
 };
 
 const _applicationStatuses = {
@@ -302,7 +306,7 @@ const _formActions = {
 	REMOVEREPEATABLESECTION: 'removeRepeatableSection',
 	ADDREPEATABLEQUESTIONS: 'addRepeatableQuestions',
 	REMOVEREPEATABLEQUESTIONS: 'removeRepeatableQuestions',
-}
+};
 
 const _darPanelMapper = {
 	safesettings: 'Safe settings',


### PR DESCRIPTION
Issue reported by HSCNI where the Custodian was able to click 'request update' on an application form at an incorrect point in the application process.  Clicking this button triggered an error response by the backend which was handled correctly.

**Development**

- Updated object mapper that serves the correct action buttons in a variety of situations to also take into account the current active party viewing an application form that is in review status.

- Updated tests for functionality to include new parameter and new test case.