### PR TITLE
IG-1668 Set default value for emails

### DIFF
--- a/src/resources/team/team.controller.js
+++ b/src/resources/team/team.controller.js
@@ -561,6 +561,9 @@ const formatTeamNotifications  = (team) => {
 			// 2. check subscribedEmails has length
 			if(!_.isEmpty(subscribedEmails))
 				teamNotificationEmails = [...subscribedEmails].map(email => ({ value: email, error: ''}));
+			else
+				teamNotificationEmails = [{ value: '', error: ''}]
+				
 			// 3. return optimal payload for formated notification
 			let formattedNotification = {
 				notificationType,


### PR DESCRIPTION
# PR
Extension of IG-1668 missing default email value

## Notes
During demo prep we came across an issue for default values for notification emails being missing on inital load. An API update for the default value has been introduced to stop a rendering issue with the FE.

