### PR TITLE
IG-1807 - DAR - Add origin application id to applications that are created via cloning

### DIFF
--- a/src/resources/datarequest/datarequest.model.js
+++ b/src/resources/datarequest/datarequest.model.js
@@ -80,6 +80,7 @@ const DataRequestSchema = new Schema(
 				questionAnswers: { type: Object, default: {} },
 			},
 		],
+		originId: { type: Schema.Types.ObjectId, ref: 'data_request' }
 	},
 	{
 		timestamps: true,

--- a/src/resources/datarequest/utils/datarequest.util.js
+++ b/src/resources/datarequest/utils/datarequest.util.js
@@ -210,7 +210,7 @@ const matchCurrentUser = (user, auditField) => {
 
 const cloneIntoExistingApplication = (appToClone, appToUpdate) => {
 	// 1. Extract values required to clone into existing application
-	const { questionAnswers } = appToClone;
+	const { questionAnswers, _id } = appToClone;
 	const { jsonSchema: schemaToUpdate } = appToUpdate;
 
 	// 2. Extract and append any user repeated sections from the original form
@@ -220,13 +220,13 @@ const cloneIntoExistingApplication = (appToClone, appToUpdate) => {
 	}
 
 	// 3. Return updated application
-	return { ...appToUpdate, questionAnswers };
+	return { ...appToUpdate, questionAnswers, originId: _id };
 };
 
 const cloneIntoNewApplication = async (appToClone, context) => {
 	// 1. Extract values required to clone existing application
 	const { userId, datasetIds, datasetTitles, publisher } = context;
-	const { questionAnswers } = appToClone;
+	const { questionAnswers, _id } = appToClone;
 
 	// 2. Get latest publisher schema
 	const { jsonSchema, version, _id: schemaId, isCloneable = false, formType } = await getLatestPublisherSchema(publisher);
@@ -246,6 +246,7 @@ const cloneIntoNewApplication = async (appToClone, context) => {
 		aboutApplication: {},
 		amendmentIterations: [],
 		applicationStatus: constants.applicationStatuses.INPROGRESS,
+		originId: _id
 	};
 
 	// 4. Extract and append any user repeated sections from the original form


### PR DESCRIPTION
At the point of cloning an application, we need to store the unique identifier in the new application that is corrected, so that we can formulate a link back to the original application.

This will assist in building reporting capability around the usage of this function.

**Development**

1. Updated Mongoose document for DAR to include a new object id called ‘originId’ or similar
2. Updated cloning endpoint to save _id of original document into the originId of the new application entity

