### PR TITLE
IG-1661 Added commercial usage filter

### DIFF
--- a/src/resources/dataset/dataset.model.js
+++ b/src/resources/dataset/dataset.model.js
@@ -15,6 +15,7 @@ const datasetSchema = new Schema(
 		source: String,
 		is5Safes: Boolean,
 		hasTechnicalDetails: Boolean,
+		commercialUse: Boolean,
 		resultsInsights: String,
 		link: String,
 		type: String,

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -2,7 +2,6 @@ import { Data } from '../tool/data.model';
 import { PublisherModel } from '../publisher/publisher.model';
 import { TeamModel } from '../team/team.model';
 import { UserModel } from '../user/user.model';
-import teamController from '../team/team.controller';
 import randomstring from 'randomstring';
 import { filtersService } from '../filters/dependency';
 import notificationBuilder from '../utilities/notificationBuilder';
@@ -823,6 +822,9 @@ module.exports = {
 								let technicalDetails = await module.exports.buildTechnicalDetails(dataset.structuralMetadata);
 								let metadataQuality = await module.exports.buildMetadataQuality(dataset, datasetv2Object, dataset.pid);
 
+								// call filterCommercialUsage to determine commericalUse field only pass in v2 a
+								let commercialUse =  filtersService.computeCommericalUse({}, datasetv2Object);
+
 								let updatedDataset = await Data.findOneAndUpdate(
 									{ _id: id },
 									{
@@ -834,6 +836,7 @@ module.exports = {
 										tags: {
 											features: dataset.questionAnswers['properties/summary/keywords'] || [],
 										},
+										commercialUse,
 										hasTechnicalDetails: !_.isEmpty(technicalDetails) ? true : false,
 										'timestamps.updated': Date.now(),
 										'timestamps.published': Date.now(),

--- a/src/resources/filters/__mocks__/filters.mocks.js
+++ b/src/resources/filters/__mocks__/filters.mocks.js
@@ -1,0 +1,236 @@
+export const datasets_commercial = [
+	{
+		id: 1,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'GENERAL RESEARCH USE',
+				},
+			},
+		},
+	},
+	{
+		id: 2,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'COMMERCIAL RESEARCH USE',
+				},
+			},
+		},
+	},
+	{
+		id: 3,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['COMMERCIAL RESEARCH USE', 'NO RESTRICTION'],
+				},
+			},
+		},
+	},
+	{
+		id: 4,
+		datautility: {
+			allowable_uses: 'Gold',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['RESEARCH USE ONLY'],
+				},
+			},
+		},
+	},
+	{
+		id: 5,
+		datautility: {
+			allowable_uses: 'Bronze',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: '',
+				},
+			},
+		},
+	},
+	{
+		id: 6,
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'USER SPECIFIC RESTRICTION',
+				},
+			},
+		},
+	},
+	{
+		id: 7,
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'USER SPECIFIC RESTRICTION',
+				},
+			},
+		},
+	},
+	{
+		id: 8,
+		datautility: {
+			allowable_uses: 'Gold',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'NOT FOR PROFIT USE',
+				},
+			},
+		},
+	},
+	{
+		id: 9,
+		datautility: {
+			allowable_uses: 'Bronze',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['NOT FOR PROFIT USE', 'COMMERCIAL RESEARCH USE'],
+				},
+			},
+		},
+	},
+];
+
+export const datasets_commercial_expected = [
+	{
+		id: 1,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'GENERAL RESEARCH USE',
+				},
+			},
+		},
+		commercialUse: false,
+	},
+	{
+		id: 2,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'COMMERCIAL RESEARCH USE',
+				},
+			},
+		},
+		commercialUse: true,
+	},
+	{
+		id: 3,
+		datautility: {
+			allowable_uses: '',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['COMMERCIAL RESEARCH USE', 'NO RESTRICTION'],
+				},
+			},
+		},
+		commercialUse: true,
+	},
+	{
+		id: 4,
+		datautility: {
+			allowable_uses: 'Gold',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['RESEARCH USE ONLY'],
+				},
+			},
+		},
+		commercialUse: true,
+	},
+	{
+		id: 5,
+		datautility: {
+			allowable_uses: 'Bronze',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: '',
+				},
+			},
+		},
+		commercialUse: false,
+	},
+	{
+		id: 6,
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'USER SPECIFIC RESTRICTION',
+				},
+			},
+		},
+		commercialUse: false,
+	},
+	{
+		id: 7,
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'USER SPECIFIC RESTRICTION',
+				},
+			},
+		},
+		commercialUse: false,
+	},
+	{
+		id: 8,
+		datautility: {
+			allowable_uses: 'Gold',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: 'NOT FOR PROFIT USE',
+				},
+			},
+		},
+		commercialUse: true,
+	},
+	{
+		id: 9,
+		datautility: {
+			allowable_uses: 'Bronze',
+		},
+		datasetv2: {
+			accessibility: {
+				usage: {
+					dataUseLimitation: ['NOT FOR PROFIT USE', 'COMMERCIAL RESEARCH USE'],
+				},
+			},
+		},
+		commercialUse: false,
+	},
+];

--- a/src/resources/filters/__tests__/filters.service.test.js
+++ b/src/resources/filters/__tests__/filters.service.test.js
@@ -1,0 +1,20 @@
+import FilterRepository from '../filters.repository';
+import FiltersService from '../filters.service';
+import { datasets_commercial, datasets_commercial_expected } from '../__mocks__/filters.mocks';
+
+describe('Filter service tests', () => {
+	test('Test Commerical usage filter for datasets, returns updated filter status for commerical usage for a dataset', () => {
+		// Arrange
+		let commericalOutput = [];
+		const filterRepository = new FilterRepository();
+		const filterService = new FiltersService(filterRepository);
+		// Format and call our function computCommericalUse
+		for (let dataset of datasets_commercial) {
+			let { datautility = {}, datasetv2 = {} } = dataset;
+			let commercialUse = filterService.computeCommericalUse(datautility, datasetv2);
+			commericalOutput.push({ ...dataset, commercialUse });
+		}
+		// Assert
+		expect(commericalOutput).toEqual(datasets_commercial_expected);
+	});
+});

--- a/src/resources/filters/filters.controller.js
+++ b/src/resources/filters/filters.controller.js
@@ -2,7 +2,7 @@ import Controller from '../base/controller';
 
 export default class FiltersController extends Controller {
 	constructor(filtersService) {
-        super(filtersService);
+    super(filtersService);
 		this.filtersService = filtersService;
 	}
 

--- a/src/resources/filters/filters.mapper.js
+++ b/src/resources/filters/filters.mapper.js
@@ -11,6 +11,7 @@ export const datasetFilters = [
 		selectedCount: 0,
 		filters: [],
 		highlighted: [],
+		beta: false
 	},
 	{
 		id: 2,
@@ -25,6 +26,7 @@ export const datasetFilters = [
 		selectedCount: 0,
 		filters: [],
 		highlighted: [],
+		beta: false
 	},
 	{
 		id: 3,
@@ -39,6 +41,7 @@ export const datasetFilters = [
 		selectedCount: 0,
 		filters: [],
 		highlighted: [],
+		beta: false
 	},
 	{
 		id: 4,
@@ -49,6 +52,7 @@ export const datasetFilters = [
 		closed: true,
 		isSearchable: false,
 		selectedCount: 0,
+		beta: false,
 		filters: [
 			{
 				id: 5,
@@ -100,6 +104,7 @@ export const datasetFilters = [
 		closed: true,
 		isSearchable: false,
 		selectedCount: 0,
+		beta: false,
 		filters: [
 			{
 				id: 9,
@@ -177,6 +182,7 @@ export const datasetFilters = [
 		closed: true,
 		isSearchable: false,
 		selectedCount: 0,
+		beta: false,
 		filters: [
 			{
 				id: 15,
@@ -216,6 +222,7 @@ export const datasetFilters = [
 		closed: true,
 		isSearchable: false,
 		selectedCount: 0,
+		beta: false,
 		filters: [
 			{
 				id: 18,
@@ -267,6 +274,7 @@ export const datasetFilters = [
 		closed: true,
 		isSearchable: false,
 		selectedCount: 0,
+		beta: false,
 		filters: [
 			{
 				id: 22,
@@ -498,5 +506,20 @@ export const datasetFilters = [
 		selectedCount: 0,
 		filters: [{ id: 999, label: 'Contains Technical Metadata', value: 'Contains Technical Metadata', checked: false }],
 		highlighted: ['contains technical metadata'],
+		beta: false
+	},
+	{
+		id: 40,
+		label: 'Commerical use',
+		key: 'commercialUse',
+		dataPath: 'commercialUse',
+		type: 'boolean',
+		tooltip: null,
+		closed: true,
+		isSearchable: false,
+		selectedCount: 0,
+		filters: [{ id: 998, label: 'Consented for commerical uses', value: 'Consented for commerical uses', checked: false }],
+		highlighted: ['consented for commerical uses'],
+		beta: true
 	},
 ];

--- a/src/resources/filters/filters.repository.js
+++ b/src/resources/filters/filters.repository.js
@@ -13,8 +13,8 @@ export default class FiltersRepository extends Repository {
 	}
 
 	async updateFilterSet(filters, type) {
-		await Filters.findOneAndUpdate({ id: type }, { keys: filters }, { upsert: true }, (err) => {
-			if(err) {
+		await Filters.findOneAndUpdate({ id: type }, { keys: filters }, { upsert: true }, err => {
+			if (err) {
 				console.error(err.message);
 			}
 		});

--- a/src/resources/filters/filters.service.js
+++ b/src/resources/filters/filters.service.js
@@ -1,5 +1,6 @@
-import { isArray, isEmpty, isNil, uniq } from 'lodash';
+import { isArray, isEmpty, isNil, uniq, has, isString, isObject } from 'lodash';
 import helper from '../utilities/helper.util';
+import { commericalConstants, validCommericalUseOptions } from './utils/filters.util';
 
 export default class FiltersService {
 	constructor(filtersRepository, datasetRepository) {
@@ -11,10 +12,68 @@ export default class FiltersService {
 		// 1. Get filters from repository for the entity type and query provided
 		const options = { lean: false };
 		let filters = await this.filtersRepository.getFilters(id, query, options);
-		if(filters) {
+		if (filters) {
 			filters = filters.mapDto();
 		}
 		return filters;
+	}
+
+	/**
+	 * [computeCommericalUse - Calculates and sets commericalUse value]
+	 *
+	 * @param   {Object}  dataUtility  [dataUtility Object]
+	 * @param   {Object}  datasetv2    [datasetv2 Object]
+	 * @return  {boolean}
+	 */
+	computeCommericalUse(dataUtility = {}, datasetv2 = {}) {
+		// LOGIC agreed on IG-1661
+		// 1. check object contains the fields we need to compute against for commericalUse
+		let hasAllowableUses = has(dataUtility, 'allowable_uses');
+		let hasDataUseLimitation = has(datasetv2, 'accessibility.usage.dataUseLimitation');
+		// Not to be computed until further notice
+		//let hasDataUseRequirements = has(datasetv2, 'accessibility.usage.dataUseRequirements');
+
+		// 2. check allowable_uses
+		if (hasAllowableUses) {
+			const { allowable_uses = '' } = dataUtility;
+			const allowableUses = allowable_uses.trim().toUpperCase();
+			if (allowableUses === commericalConstants.gold || allowableUses === commericalConstants.platinum) {
+				return true;
+			}
+		}
+		// 3. check data_use_limitation set commercialUse true"
+		if (hasDataUseLimitation) {
+			// destructure out dataUseLimitation value
+			const {
+				accessibility: {
+					usage: { dataUseLimitation },
+				},
+			} = datasetv2;
+
+			return this.calculateCommercialUsage(dataUseLimitation);
+		}
+		return false;
+	}
+
+	/**
+	 * [calculateCommercialUsage]
+	 *
+	 * @param   {Array | String }  dataType  [field type ie data_use_limitation, data_use_requirements]
+	 * @return  {boolean}  return true false based on logic for commericalUsage
+	 */
+	calculateCommercialUsage(dataType) {
+		const isTypeString = isString(dataType);
+		const isTypeArray = isObject(dataType);
+
+		if (
+			isTypeString &&
+			(dataType.trim().toUpperCase() === commericalConstants.noRestriction ||
+				dataType.trim().toUpperCase() === commericalConstants.commercialResearchUse)
+		)
+			return true;
+		else if (isTypeArray && validCommericalUseOptions(dataType)) return true;
+
+		return false;
 	}
 
 	async optimiseFilters(type) {
@@ -29,15 +88,15 @@ export default class FiltersService {
 		// 1. Use cached filters if instructed, need to remove type when all v2 filters come on
 		if (useCache && type === 'dataset') {
 			const options = { lean: true };
-			const { keys: filters = {} } = await this.filtersRepository.getFilters(type, {}, options) || {};
+			const { keys: filters = {} } = (await this.filtersRepository.getFilters(type, {}, options)) || {};
 			return filters;
 		}
-		
+
 		let filters = {},
 			sortedFilters = {},
 			entities = [],
 			fields = '';
-			
+
 		// 2. Query Db for required entity if array of entities has not been passed
 		switch (type) {
 			case 'dataset':

--- a/src/resources/filters/utils/filters.util.js
+++ b/src/resources/filters/utils/filters.util.js
@@ -1,51 +1,83 @@
 import { v4 as uuidv4 } from 'uuid';
+import { isEmpty } from 'lodash';
+
+export const commericalConstants = {
+	notForProfitUse: 'NOT FOR PROFIT USE',
+	noRestriction: 'NO RESTRICTION',
+	commercialResearchUse: 'COMMERCIAL RESEARCH USE',
+	gold: 'GOLD',
+	platinum: 'PLATINUM',
+};
 
 export const findNodeInTree = (tree, key) => {
-  // 1. find if key matches //datasetFeatures
-  let found = tree.find(node => node.alias === key || node.key === key);
-    // 2. if not found do while
-		if (!found) {
-			let i = 0;
-      // 3. make sure current tree loop has a length
-			while(!found && i < tree.length) {
-        // 4. check current iteration has filters to avoid expense recursive call
-				if (tree[i].filters && tree[i].filters.length) {
-          // 5. assign recursive call to found
-					found = findNodeInTree(tree[i].filters, key);
-				}
-        // 6. increment count of i
-				i++;
+	// 1. find if key matches //datasetFeatures
+	let found = tree.find(node => node.alias === key || node.key === key);
+	// 2. if not found do while
+	if (!found) {
+		let i = 0;
+		// 3. make sure current tree loop has a length
+		while (!found && i < tree.length) {
+			// 4. check current iteration has filters to avoid expense recursive call
+			if (tree[i].filters && tree[i].filters.length) {
+				// 5. assign recursive call to found
+				found = findNodeInTree(tree[i].filters, key);
 			}
+			// 6. increment count of i
+			i++;
 		}
-    // 7. return node || recursive call
-		return found;
+	}
+	// 7. return node || recursive call
+	return found;
 };
 
 export const updateTree = (tree, key, values) => {
-  // 1. declare iter 
-  let iter = () => {};
-  // 2. loop tree with callback
-  tree.forEach(iter = (node) => {
-    // 3. if found update filters
-    if (node.key === key) {
-        // 5. set filter values
-        node.filters = values;
-    }
-    // 6. if has filters recall iter with new filters
-    Array.isArray(node.filters) && node.filters.forEach(iter);
-  });
+	// 1. declare iter
+	let iter = () => {};
+	// 2. loop tree with callback
+	tree.forEach(
+		(iter = node => {
+			// 3. if found update filters
+			if (node.key === key) {
+				// 5. set filter values
+				node.filters = values;
+			}
+			// 6. if has filters recall iter with new filters
+			Array.isArray(node.filters) && node.filters.forEach(iter);
+		})
+	);
 
-  return tree;
-}
+	return tree;
+};
 
-export const formatFilterOptions = (filters) => {
-  // 1. map over the filters and build new options to return
-  return [...filters].map((value) => {
-    return {
-      id: uuidv4(),
-      label: value,
-      value: value,
-      checked: false
-    }
-  });
-}
+export const formatFilterOptions = filters => {
+	// 1. map over the filters and build new options to return
+	return [...filters].map(value => {
+		return {
+			id: uuidv4(),
+			label: value,
+			value: value,
+			checked: false,
+		};
+	});
+};
+
+/**
+ * [validCommericalUseOptions]
+ *
+ * @param   {array}  data  [array of selected values]
+ * @return  {boolean}      [return true false]
+ */
+export const validCommericalUseOptions = (data = []) => {
+	if (!isEmpty(data)) {
+		const containsNotForProfit = [...data].includes(commericalConstants.notForProfitUse);
+		const validCommerical = [...data].filter(
+			d =>
+				d.trim().toUpperCase() === commericalConstants.noRestriction || d.trim().toUpperCase() === commericalConstants.commercialResearchUse
+		).length;
+
+		if (containsNotForProfit) return false;
+		else if (validCommerical > 0) return true;
+
+		return false;
+	}
+};

--- a/src/resources/tool/data.model.js
+++ b/src/resources/tool/data.model.js
@@ -77,6 +77,7 @@ const DataSchema = new Schema(
 		source: String,
 		is5Safes: Boolean,
 		hasTechnicalDetails: Boolean,
+		commercialUse: Boolean,
 		datasetid: String,
 		pid: String,
 		datasetVersion: String,


### PR DESCRIPTION
# PR 
Commerical usage filter 

## Notes 

Commercial usage filter will allow researchers to search for datasets allowed for commercial use.
The filters will go in order of the following to compute commercial research.

### Logic 

-    A note on the filter to indicate that the commerical use is in beta use only it is not the finalised version.
-  If a dataset has an allowable_use score of either Gold || Platinum we can set the dataset to be available for commerical use. Carries the heaviest weight.
-  If the dataUtility allowable_use score isn’t available we are only checking the field data_use_limitation for “COMMERCIAL RESEARCH USE || NO RESTRICTIONS“. Otherwise commerical use will be set to false.

For the mean time we are **ignoring data_use_requirements until further notice.** **Nothing is to override the allowable_use score if Gold || Platinum.**

## Tests

- [X] Unit test for filter service commercial usage