### PR TITLE
Fix dataset filter - publisher 

### DIFF
--- a/src/resources/filters/filters.service.js
+++ b/src/resources/filters/filters.service.js
@@ -167,7 +167,6 @@ export default class FiltersService {
 				} = entity;
 				// 3. Create flattened filter props object
 				filterValues = {
-					publisher,
 					phenotypes: [...phenotypes.map(phenotype => phenotype.name)],
 					features,
 					...datautility,
@@ -176,6 +175,7 @@ export default class FiltersService {
 					...temporal,
 					...access,
 					...formatAndStandards,
+					publisher
 				};
 				break;
 		}


### PR DESCRIPTION
# PR
Filter fix

# Note
Filter fix for spreading in publisher, publisher was being replaced in datautility. Moved publisher to bottom of the new spread object.