### PR TITLE
IG-1971

### DIFF
--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -2545,7 +2545,7 @@ module.exports = {
 				await notificationBuilder.triggerNotificationMessage(
 					[accessRecord.userId],
 					`Your Data Access Request for ${datasetTitles} was successfully duplicated 
-					${_.isEmpty(newDatasetTitles) ? `from an existing form` : `into a new form for ${newDatasetTitles.join(',')}, which can now be edited`}`,
+					${_.isEmpty(newDatasetTitles) ? `from an existing form, which can now be edited` : `into a new form for ${newDatasetTitles.join(',')}, which can now be edited`}`,
 					'data access request',
 					newApplicationId
 				);

--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -2544,9 +2544,8 @@ module.exports = {
 				// 1. Create notifications
 				await notificationBuilder.triggerNotificationMessage(
 					[accessRecord.userId],
-					`Your Data Access Request for ${datasetTitles} was successfully duplicated into a new form for ${newDatasetTitles.join(
-						','
-					)}, which can now be edited`,
+					`Your Data Access Request for ${datasetTitles} was successfully duplicated 
+					${_.isEmpty(newDatasetTitles) ? `from an existing form` : `into a new form for ${newDatasetTitles.join(',')}, which can now be edited`}`,
 					'data access request',
 					newApplicationId
 				);

--- a/src/resources/tool/data.repository.js
+++ b/src/resources/tool/data.repository.js
@@ -1,4 +1,5 @@
 import { Data } from './data.model';
+import { cloneDeep } from 'lodash';
 import { MessagesModel } from '../message/message.model';
 import { UserModel } from '../user/user.model';
 import { createDiscourseTopic } from '../discourse/discourse.service';
@@ -155,6 +156,7 @@ const editTool = async (req, res) => {
 			id: id,
 			name: name,
 			authors: authors,
+			type: type,
 		};
 
 		Data.findOneAndUpdate(
@@ -498,11 +500,11 @@ async function sendEmailNotificationToAuthors(tool, toolOwner) {
 async function storeNotificationsForAuthors(tool, toolOwner) {
 	//store messages to alert a user has been added as an author
 	const toolLink = process.env.homeURL + '/tool/' + tool.id;
-
-	//normal user
-	var toolCopy = JSON.parse(JSON.stringify(tool));
+	// clone deep the object tool take a deep clone of properties
+	let toolCopy = cloneDeep(tool);
 
 	toolCopy.authors.push(0);
+
 	asyncModule.eachSeries(toolCopy.authors, async author => {
 		let message = new MessagesModel();
 		message.messageType = 'author';


### PR DESCRIPTION
# PR
IG-1971 Notification updates  

##  Notes
Fixed notifications when updating tool entities, this was observed when actually trying to work out the issue with the 
reported notification from Yokow. When updating an existing tool,  the tool name was passed through as undefined this was due to a missing parameter of **type** when calling editTool function within the API. An update has been made to resolve the issue.

Second fix is the actual reported bug by Yokow, during duplicate existing application form the notification generated was also rendering an incorrect message. This was down to the createNotification function and checking on type duplicateApplication as the message was being generated the newDataSetTitles was assumed populated ie contained a length. A check has been put in place to check the length and format accordingly.

## Images

_Issue with DAR Duplicate notification_

<img width="456" alt="ISSUE_Notification_Issue_DAR" src="https://user-images.githubusercontent.com/65283091/120493107-95d08d80-c3b2-11eb-94d5-92d1c6ad13dc.png">

<img width="478" alt="FIXED_Notification_Issue_DAR" src="https://user-images.githubusercontent.com/65283091/120492765-41c5a900-c3b2-11eb-9b57-5b7fbee49d3e.png">

_Issue with tool updating and notification message_

<img width="475" alt="ISSUE_TOOL_NOTIFICATION" src="https://user-images.githubusercontent.com/65283091/120492801-4ab67a80-c3b2-11eb-9eee-a6d88dc2d000.png">

<img width="417" alt="FIXED_TOOL_NOTIFICATION" src="https://user-images.githubusercontent.com/65283091/120492822-5013c500-c3b2-11eb-882b-4b1cf99dec11.png">


