### PR TITLE
IG-1927 First message and message emails updated

### DIFF
--- a/src/resources/message/message.controller.js
+++ b/src/resources/message/message.controller.js
@@ -109,12 +109,23 @@ module.exports = {
 					}
 				}
 
+				// Create object to pass through email data
+				let options = {
+					firstMessage,
+					firstname,
+					lastname,
+					messageDescription,
+					openMessagesLink: process.env.homeURL + '/search?search=&tab=Datasets&openUserMessages=true',
+				};
+				// Create email body content
+				let html = emailGenerator.generateMessageNotification(options);
+
 				// 16. Send email
 				emailGenerator.sendEmail(
 					messageRecipients,
 					constants.hdrukEmail,
 					`You have received a new message on the HDR UK Innovation Gateway`,
-					`You have received a new message on the HDR UK Innovation Gateway. <br> Log in to view your messages here : <a href='${process.env.homeURL}'>HDR UK Innovation Gateway</a>`,
+					html,
 					false
 				);
 			}

--- a/src/resources/utilities/emailGenerator.util.js
+++ b/src/resources/utilities/emailGenerator.util.js
@@ -1838,6 +1838,45 @@ const _generateMetadataOnboardingRejected = options => {
 	return body;
 };
 
+const _generateMessageNotification = options => {
+	let { firstMessage, firstname, lastname, messageDescription, openMessagesLink } = options;
+
+	let body = `<div>
+						<img src="https://storage.googleapis.com/hdruk-gateway_prod-cms/web-assets/HDRUK_logo_colour.png" alt="HDR UK Logo" width="127" height="63" style="display: block; margin-left: auto; margin-right: auto; margin-bottom: 24px; margin-top: 24px;">
+						<div style="border: 1px solid #d0d3d4; border-radius: 15px; width: 700px; margin: 0 auto;">
+							<table
+							align="center"
+							border="0"
+							cellpadding="0"
+							cellspacing="40"
+							width="700"
+							word-break="break-all"
+							style="font-family: Arial, sans-serif">
+								<thead>
+									<tr>
+										<th style="border: 0; color: #29235c; font-size: 22px; text-align: left;">
+										${_.isEmpty(firstMessage) ? `New message from ${firstname} ${lastname}` : `Data access request enquiry from ${firstname} ${lastname}`}
+										</th>
+										</tr>
+										<tr>
+										<th style="border: 0; font-size: 14px; font-weight: normal; color: #333333; text-align: left;">
+											<p>${messageDescription.replace(/\n/g, '<br />')}</p>
+										</th>
+									</tr>
+								</thead>
+								<tbody style="overflow-y: auto; overflow-x: hidden;">
+									<tr style="width: 100%; text-align: left;">
+										<td style=" font-size: 14px; color: #3c3c3b; padding: 5px 5px; width: 50%; text-align: left; vertical-align: top;">
+											<a href=${openMessagesLink}>View Messages</a>
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</div>`;
+	return body;
+};
+
 /**
  * [_sendEmail]
  *
@@ -1982,4 +2021,6 @@ export default {
 	generateMetadataOnboardingRejected: _generateMetadataOnboardingRejected,
 	//generateMetadataOnboardingArchived: _generateMetadataOnboardingArchived,
 	//generateMetadataOnboardingUnArchived: _generateMetadataOnboardingUnArchived,
+	//Messages
+	generateMessageNotification: _generateMessageNotification,
 };


### PR DESCRIPTION
[IG-1927](https://hdruk.atlassian.net/browse/IG-1927)

- Email sent to notify of messages on the gateway updated to the new email format and to have the HDR logo
- Sub title differs based on if it's a first message
- Link to site with messages open

First message example in outlook:
![image](https://user-images.githubusercontent.com/57766586/121334693-cb74f980-c911-11eb-8c74-373404e42801.png)

Following message from data custodian on gmail:
![image](https://user-images.githubusercontent.com/57766586/121335208-4b9b5f00-c912-11eb-9206-7a0e2ac2b33f.png)

