### PR TITLE
First message email fix for missing notification to submitter

### DIFF
--- a/src/resources/team/team.controller.js
+++ b/src/resources/team/team.controller.js
@@ -653,15 +653,11 @@ const getMemberDetails = (memberIds = [], users = []) => {
 	if (!_.isEmpty(memberIds) && !_.isEmpty(users)) {
 		return [...users].reduce(
 			(arr, user) => {
-				const member = [...memberIds].find(m => m.toString() === user._id.toString()) || {};
-				if (!_.isEmpty(member)) {
-					let { email, id } = user;
-					return {
-						memberEmails: [...arr['memberEmails'], { email }],
-						userIds: [...arr['userIds'], id],
-					};
-				}
-				return arr;
+				let { email, id } = user;
+				return {
+					memberEmails: [...arr['memberEmails'], { email }],
+					userIds: [...arr['userIds'], id],
+				};
 			},
 			{ memberEmails: [], userIds: [] }
 		);


### PR DESCRIPTION
**Issue**

Upon submitting a first message and further messages to a Custodian team, under certain circumstances, the submitter would not be emailed a receipt of their message.

**Development**

- Fixed erroneous filter which was removing the applicant as they were effectively not seen as part of the team to be emailed when default team notifications had been modified.