### PR TITLE
Trust all healthdatagateway.org domains to be able to access API

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -52,7 +52,7 @@ configuration.findAccount = Account.findAccount;
 const oidc = new Provider(process.env.api_url || 'http://localhost:3001', configuration);
 oidc.proxy = true;
 
-var domains = [process.env.homeURL];
+var domains = [/\.healthdatagateway\.org$/, process.env.homeURL];
 
 var rx = /^([http|https]+:\/\/[a-z]+)\.([^/]*)/;
 var arr = rx.exec(process.env.homeURL);


### PR DESCRIPTION
Charles has asked for search.healthdatagateway.org and api.healthdatagateway.org to be domains for production (they are both active - but failing because of cors issues).  This looks like a simple way to get it work without significant rework,

I am slightly sceptical however as i dont see the Access-Control-Allow-Origin header from the API when making a call.