### PR TITLE
Rewrote advancedSearch endpoint to allow an Admin to set a users role…

### DIFF
--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -57,6 +57,20 @@ const checkIsInRole = (...roles) => (req, res, next) => {
 	return next();
 };
 
+const checkIsAdminOrIsUser = () => (req, res, next) => {
+	if (req.user) {
+		if (req.user.role === ROLES.Admin) return next();
+		else if (req.params.userID && req.params.userID === req.user.id.toString()) return next();
+		else if (req.params.id && req.params.id === req.user.id.toString()) return next();
+		else if (req.body.id && req.body.id.toString() === req.user.id.toString()) return next();
+
+		return res.status(401).json({
+			status: 'error',
+			message: 'Unauthorised to perform this action.',
+		});
+	}
+};
+
 const whatIsRole = req => {
 	if (!req.user) {
 		return 'Reader';
@@ -103,4 +117,4 @@ const checkAllowedToAccess = type => async (req, res, next) => {
 	});
 };
 
-export { setup, signToken, camundaToken, checkIsInRole, whatIsRole, checkIsUser, checkAllowedToAccess };
+export { setup, signToken, camundaToken, checkIsInRole, whatIsRole, checkIsUser, checkIsAdminOrIsUser, checkAllowedToAccess };

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -57,20 +57,6 @@ const checkIsInRole = (...roles) => (req, res, next) => {
 	return next();
 };
 
-const checkIsAdminOrIsUser = () => (req, res, next) => {
-	if (req.user) {
-		if (req.user.role === ROLES.Admin) return next();
-		else if (req.params.userID && req.params.userID === req.user.id.toString()) return next();
-		else if (req.params.id && req.params.id === req.user.id.toString()) return next();
-		else if (req.body.id && req.body.id.toString() === req.user.id.toString()) return next();
-
-		return res.status(401).json({
-			status: 'error',
-			message: 'Unauthorised to perform this action.',
-		});
-	}
-};
-
 const whatIsRole = req => {
 	if (!req.user) {
 		return 'Reader';
@@ -117,4 +103,4 @@ const checkAllowedToAccess = type => async (req, res, next) => {
 	});
 };
 
-export { setup, signToken, camundaToken, checkIsInRole, whatIsRole, checkIsUser, checkIsAdminOrIsUser, checkAllowedToAccess };
+export { setup, signToken, camundaToken, checkIsInRole, whatIsRole, checkIsUser, checkAllowedToAccess };

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -5,6 +5,9 @@ import { utils } from '../auth';
 import { UserModel } from './user.model';
 import { Data } from '../tool/data.model';
 import helper from '../utilities/helper.util';
+import { ROLES } from './user.roles';
+import { setCohortDiscoveryAccess } from './user.service';
+import { upperCase } from 'lodash';
 //import { createServiceAccount } from './user.repository';
 
 const router = express.Router();
@@ -98,25 +101,40 @@ router.patch('/advancedSearch/terms/:id', passport.authenticate('jwt'), utils.ch
 	return res.status(200).json({ status: 'success', response: user });
 });
 
-// @router   PATCH /api/v1/users/advancedSearch/roles/:id
-// @desc     Set advanced search roles for a user
+// @router   PATCH /api/v1/users/advancedSearch/customRoles/:id
+// @desc     Allow admin to set custom advanced search roles for a user
 // @access   Private
-router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), utils.checkIsAdminOrIsUser(), async (req, res) => {
+router.patch('/advancedSearch/customRoles/:id', passport.authenticate('jwt'), utils.checkIsInRole(ROLES.Admin), async (req, res) => {
 	const { advancedSearchRoles } = req.body;
 	if (typeof advancedSearchRoles !== 'object') {
 		return res.status(400).json({ status: 'error', message: 'Invalid role(s) supplied.' });
 	}
 
-	const user = await UserModel.findOne({ id: req.params.id });
-	if (user.advancedSearchRoles && user.advancedSearchRoles.includes('BANNED')) {
-		return res.status(403).json({ status: 'error', message: 'User is banned.  No update applied.' });
-	}
+	await setCohortDiscoveryAccess(req.params.id, advancedSearchRoles)
+		.then(response => {
+			return res.status(200).json({ status: 'success', response });
+		})
+		.catch(err => {
+			return res.status(err.statusCode).json({ status: 'error', message: err.message });
+		});
+});
 
-	const roles = advancedSearchRoles.map(role => role.toString());
-	const updatedUser = await UserModel.findOneAndUpdate({ id: req.params.id }, { advancedSearchRoles: roles }, { new: true }, err => {
-		if (err) return res.json({ success: false, error: err });
-	});
-	return res.status(200).json({ status: 'success', response: updatedUser });
+// @router   PATCH /api/v1/users/advancedSearch/roles/:id
+// @desc     Grant basic advanced search role for an Open Athens user
+// @access   Private
+router.patch('/advancedSearch/roles/:id', passport.authenticate('jwt'), utils.checkIsUser(), async (req, res) => {
+	if (upperCase(req.user.provider) !== 'OIDC')
+		return res.status(403).json({ status: 'error', message: 'Only Open Athens users are permitted to use this route.' });
+
+	const advancedSearchRoles = ['GENERAL_ACCESS'];
+
+	await setCohortDiscoveryAccess(req.params.id, advancedSearchRoles)
+		.then(response => {
+			return res.status(200).json({ status: 'success', response });
+		})
+		.catch(err => {
+			return res.status(err.statusCode).json({ status: 'error', message: err.message });
+		});
 });
 
 // @router   POST /api/v1/users/serviceaccount

--- a/src/resources/user/user.route.js
+++ b/src/resources/user/user.route.js
@@ -5,8 +5,6 @@ import { utils } from '../auth';
 import { UserModel } from './user.model';
 import { Data } from '../tool/data.model';
 import helper from '../utilities/helper.util';
-import { ROLES } from './user.roles';
-
 //import { createServiceAccount } from './user.repository';
 
 const router = express.Router();

--- a/src/resources/user/user.service.js
+++ b/src/resources/user/user.service.js
@@ -69,7 +69,8 @@ export async function setCohortDiscoveryAccess(id, roles) {
 			return reject({ statusCode: 403, message: 'User is banned.  No update applied.' });
 		}
 
-		const updatedUser = await UserModel.findOneAndUpdate({ id }, { advancedSearchRoles: roles }, { new: true }, err => {
+		const rolesCleansed = roles.map(role => role.toString());
+		const updatedUser = await UserModel.findOneAndUpdate({ id }, { advancedSearchRoles: rolesCleansed }, { new: true }, err => {
 			if (err) return reject({ statusCode: 500, message: err });
 		}).lean();
 		return resolve(updatedUser);


### PR DESCRIPTION
PATCH /api/v1/users/advancedSearch/roles/:id
Allows an Open Athens user to grant themselves basic advanced search role unless they are banned (used by FE)

PATCH /api/v1/users/advancedSearch/customRoles/:id
Allows an admin to grant anyone any advanced search role(s) unless they are banned