### PR TITLE
2 new endpoints created for Cohort Profiling

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -251,6 +251,8 @@ app.use('/api/v2/filters', require('../resources/filters/filters.route'));
 
 app.use('/api/v1/mailchimp', require('../services/mailchimp/mailchimp.route'));
 
+app.use('/api/v2/cohortprofiling', require('../resources/cohortprofiling/cohortprofiling.route'));
+
 initialiseAuthentication(app);
 
 // launch our backend into a port

--- a/src/resources/cohortprofiling/cohortprofiling.controller.js
+++ b/src/resources/cohortprofiling/cohortprofiling.controller.js
@@ -1,0 +1,59 @@
+import Controller from '../base/controller';
+import { isEmpty } from 'lodash';
+
+export default class CohortProfilingController extends Controller {
+	constructor(cohortProfilingService) {
+		super(cohortProfilingService);
+		this.cohortProfilingService = cohortProfilingService;
+	}
+
+	async getCohortProfilingByVariable(req, res) {
+		try {
+			// Extract parameters from query string
+			const { pid, tableName, variable } = req.params;
+			const { value, sort, limit } = req.query;
+			// If pid, tableName and variable provided, it is a bad request
+			if (!pid || !tableName || !variable) {
+				return res.status(400).json({
+					success: false,
+					message: 'You must provide a pid, table name and variable name',
+				});
+			}
+			// Find Cohort Profiling data
+			const cohortProfiling = await this.cohortProfilingService.getCohortProfilingByVariable(pid, tableName, variable, value, sort, limit);
+			// Return if no cohortProfiling found
+			if (isEmpty(cohortProfiling)) {
+				return res.status(404).json({
+					success: false,
+					message: 'Cohort Profiling data could not be found with the provided parameters',
+				});
+			}
+			// Return Cohort Profiling data
+			return res.status(200).json({
+				success: true,
+				cohortProfiling,
+			});
+		} catch (err) {
+			// Return error response if something goes wrong
+			console.error(err.message);
+			return res.status(500).json({
+				success: false,
+				message: 'A server error occurred, please try again',
+			});
+		}
+	}
+
+	async getCohortProfiling(req, res) {
+		try {
+			// 1. Get Cohort Profiling data from the database
+			const options = { lean: true };
+			let cohortProfiling = await this.cohortProfilingService.getCohortProfiling(req.query, options);
+
+			// 2. Return Cohort Profiling data
+			return res.status(200).json({ success: true, cohortProfiling });
+		} catch (err) {
+			console.error(err.message);
+			return res.status(500).json({ success: false, message: err.message });
+		}
+	}
+}

--- a/src/resources/cohortprofiling/cohortprofiling.model.js
+++ b/src/resources/cohortprofiling/cohortprofiling.model.js
@@ -1,0 +1,26 @@
+import { model, Schema } from 'mongoose';
+
+const CohortProfilingSchema = new Schema(
+	{
+		id: {
+			type: Number,
+			unique: true,
+		},
+		tableName: String,
+		pids: [], // pids of gateway datasets that use this table
+		variables: [
+			{
+				maxLength: Number,
+				completeness: Number,
+				numRows: Number,
+				name: String,
+				values: [{ value: String, frequency: Number }],
+			},
+		],
+	},
+	{
+		collection: 'cohort_profiling',
+	}
+);
+
+export const CohortProfiling = model('cohortprofiling', CohortProfilingSchema);

--- a/src/resources/cohortprofiling/cohortprofiling.repository.js
+++ b/src/resources/cohortprofiling/cohortprofiling.repository.js
@@ -1,0 +1,126 @@
+import Repository from '../base/repository';
+import { CohortProfiling } from './cohortProfiling.model';
+import { isEmpty } from 'lodash';
+
+export default class CohortProfilingRepository extends Repository {
+	constructor() {
+		super(CohortProfiling);
+		this.cohortProfiling = CohortProfiling;
+	}
+
+	async getCohortProfiling(query, options) {
+		return this.find(query, options);
+	}
+
+	buildSortQuery(sort) {
+		const customSort = !isEmpty(sort) ? sort : '-frequency';
+		const sortPathName = customSort.charAt(0) === '-' ? `variables.values.${customSort.substring(1)}` : `variables.values.${customSort}`;
+		const sortOrder = customSort.charAt(0) === '-' ? -1 : 1;
+		return { [sortPathName]: sortOrder };
+	}
+
+	buildMatchQuery(pid, tableName, value) {
+		let matchQuery = {
+			pids: pid,
+			tableName,
+		};
+
+		if (!isEmpty(value)) {
+			matchQuery['variables.values.value'] = new RegExp(`${value}`, 'i');
+		}
+
+		return matchQuery;
+	}
+
+	async calculateTotalFrequency(pid, tableName, variable) {
+		const matchQuery = this.buildMatchQuery(pid, tableName);
+
+		let frequencyData = await CohortProfiling.aggregate([
+			{
+				$match: matchQuery,
+			},
+			{
+				$unwind: {
+					path: '$variables',
+				},
+			},
+			{
+				$match: {
+					'variables.name': variable,
+				},
+			},
+			{
+				$unwind: {
+					path: '$variables.values',
+				},
+			},
+			{
+				$match: matchQuery,
+			},
+
+			{
+				$group: {
+					_id: '',
+					totalFrequency: { $sum: '$variables.values.frequency' },
+				},
+			},
+		]);
+
+		return frequencyData[0].totalFrequency;
+	}
+
+	async getCohortProfilingByVariable(pid, tableName, variable, value, sort, limit) {
+		const sortQuery = this.buildSortQuery(sort);
+		const customLimit = !isEmpty(limit) ? parseInt(limit) : 10;
+		const matchQuery = this.buildMatchQuery(pid, tableName, value);
+		const totalFrequency = await this.calculateTotalFrequency(pid, tableName, variable);
+
+		let cohortProfiling = await CohortProfiling.aggregate([
+			{
+				$match: matchQuery,
+			},
+			{
+				$unwind: {
+					path: '$variables',
+				},
+			},
+			{
+				$match: {
+					'variables.name': variable,
+				},
+			},
+			{
+				$unwind: {
+					path: '$variables.values',
+				},
+			},
+			{
+				$match: matchQuery,
+			},
+			{
+				$addFields: {
+					'variables.values.frequencyAsPercentage': { $divide: ['$variables.values.frequency', totalFrequency] },
+				},
+			},
+			{
+				$sort: sortQuery,
+			},
+
+			{
+				$limit: customLimit,
+			},
+			{
+				$group: {
+					_id: '$_id',
+					name: { $first: '$variables.name' },
+					maxLength: { $first: '$variables.maxLength' },
+					numRows: { $first: '$variables.numRows' },
+					completeness: { $first: '$variables.completeness' },
+					values: { $push: '$variables.values' },
+				},
+			},
+		]);
+
+		return cohortProfiling;
+	}
+}

--- a/src/resources/cohortprofiling/cohortprofiling.route.js
+++ b/src/resources/cohortprofiling/cohortprofiling.route.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import CohortProfilingController from './cohortprofiling.controller';
+import { cohortProfilingService } from './dependency';
+
+const cohortProfilingController = new CohortProfilingController(cohortProfilingService);
+
+const router = express.Router();
+
+// @route   GET api/v2/cohortprofiling/:pid/:tableName:/:variable
+// @desc    GET Cohort Profiling by pid, tableName and variable
+// @access  Public
+router.get('/:pid/:tableName/:variable', (req, res) => cohortProfilingController.getCohortProfilingByVariable(req, res));
+
+// @route   GET api/v2/cohortprofiling
+// @desc    Returns a collection of cohort profiling data based on supplied query parameters
+// @access  Public
+router.get('/', (req, res) => cohortProfilingController.getCohortProfiling(req, res));
+
+module.exports = router;

--- a/src/resources/cohortprofiling/cohortprofiling.service.js
+++ b/src/resources/cohortprofiling/cohortprofiling.service.js
@@ -1,0 +1,15 @@
+import _ from 'lodash';
+
+export default class CohortProfilingService {
+	constructor(cohortProfilingRepository) {
+		this.cohortProfilingRepository = cohortProfilingRepository;
+	}
+
+	async getCohortProfiling(query = {}, options = {}) {
+		return this.cohortProfilingRepository.getCohortProfiling(query, options);
+	}
+
+	async getCohortProfilingByVariable(pid, tableName, variable, value, sort, limit) {
+		return this.cohortProfilingRepository.getCohortProfilingByVariable(pid, tableName, variable, value, sort, limit);
+	}
+}

--- a/src/resources/cohortprofiling/dependency.js
+++ b/src/resources/cohortprofiling/dependency.js
@@ -1,0 +1,5 @@
+import CohortProfilingRepository from './cohortprofiling.repository';
+import CohortProfilingService from './cohortProfiling.service';
+
+export const cohortProfilingRepository = new CohortProfilingRepository();
+export const cohortProfilingService = new CohortProfilingService(cohortProfilingRepository);


### PR DESCRIPTION
Example 1 can be used for front end to drive stars logic.  
Example 2 and 3 use the second end point to get frequency data about the values for a given variable within a table belonging to a dataset.

Example uses:
1.  Get List of tableNames and variables with profiling data for a given pid
http://localhost:3001/api/v2/cohortProfiling?pids=4ef841d3-5e86-4f92-883f-1015ffd4b979&fields=variables.name, tableName,variables.completeness

2. Get profiling data for a single variable given a pid and tableName and variable (top 10 ordered by frequency descending)
http://localhost:3001/api/v2/cohortProfiling/4ef841d3-5e86-4f92-883f-1015ffd4b979/Clinical/var2

3. Get profiling data for a single variable given a pid and tableName and variable.  Filter by value 'yza', sort by value descending and limit to 3 
http://localhost:3001/api/v2/cohortProfiling/4ef841d3-5e86-4f92-883f-1015ffd4b979/Clinical/var2?value=yza&sort=-value&limit=3