### PR TITLE
Added POST GET and DELETE routes for suser search preferences

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -251,6 +251,8 @@ app.use('/api/v2/filters', require('../resources/filters/filters.route'));
 
 app.use('/api/v1/mailchimp', require('../services/mailchimp/mailchimp.route'));
 
+app.use('/api/v1/search-preferences', require('../resources/searchpreferences/searchpreferences.route'));
+
 initialiseAuthentication(app);
 
 // launch our backend into a port

--- a/src/resources/searchpreferences/searchpreferences.model.js
+++ b/src/resources/searchpreferences/searchpreferences.model.js
@@ -1,0 +1,9 @@
+import { model, Schema } from 'mongoose';
+
+const SearchPreferencesSchema = new Schema({
+	name: String,
+	filterCriteria: {},
+	userId: Number,
+});
+
+export const SearchPreferencesModel = model('search_preferences', SearchPreferencesSchema);

--- a/src/resources/searchpreferences/searchpreferences.repository.js
+++ b/src/resources/searchpreferences/searchpreferences.repository.js
@@ -1,0 +1,49 @@
+import { SearchPreferencesModel } from './searchpreferences.model';
+
+const addUserSearchPreference = async req => {
+	return new Promise(async (resolve, reject) => {
+		let searchPreferences = new SearchPreferencesModel();
+		const { name, filterCriteria } = req.body;
+		const { id } = req.user;
+
+		searchPreferences.name = name;
+		searchPreferences.filterCriteria = filterCriteria;
+		searchPreferences.userId = id;
+
+		let newSearchPreferencesObj = await searchPreferences.save();
+		if (!newSearchPreferencesObj) reject(new Error(`Can't persist data object to DB.`));
+
+		resolve(newSearchPreferencesObj);
+	});
+};
+
+const getAllSavedSearchPreferences = async req => {
+	return new Promise(async resolve => {
+		const userId = req.user.id;
+		const userSearchPreferences = await SearchPreferencesModel.find({ userId }).lean();
+		resolve(userSearchPreferences);
+	});
+};
+
+const getSavedSearchPreference = async req => {
+	return new Promise(async resolve => {
+		const { id } = req.params;
+		const userId = req.user.id;
+
+		const userSearchPreferences = await SearchPreferencesModel.findOne({ _id: id, userId }).lean();
+		resolve(userSearchPreferences);
+	});
+};
+
+const deleteUserSearchPreference = async req => {
+	return new Promise(async (resolve, reject) => {
+		const { id } = req.params;
+		const userId = req.user.id;
+
+		const deletedUserSearchPreferences = await SearchPreferencesModel.findOneAndDelete({ _id: id, userId });
+		if (!deletedUserSearchPreferences) reject('Delete operation failed');
+		resolve(id);
+	});
+};
+
+export { addUserSearchPreference, deleteUserSearchPreference, getAllSavedSearchPreferences, getSavedSearchPreference };

--- a/src/resources/searchpreferences/searchpreferences.route.js
+++ b/src/resources/searchpreferences/searchpreferences.route.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-undef */
+import express from 'express';
+import passport from 'passport';
+import {
+	addUserSearchPreference,
+	deleteUserSearchPreference,
+	getAllSavedSearchPreferences,
+	getSavedSearchPreference,
+} from '../searchpreferences/searchpreferences.repository';
+const router = express.Router();
+
+// @router   POST /api/v1/search-preferences
+// @desc     Add search preferences for a user
+// @access   Private
+router.post('/', passport.authenticate('jwt'), async (req, res) => {
+	await addUserSearchPreference(req)
+		.then(response => {
+			return res.json({ success: true, response });
+		})
+		.catch(err => {
+			return res.json({ success: false, err });
+		});
+});
+
+// @router   GET /api/v1/search-preferences
+// @desc     Returns List of all search-preferences for a user
+// @access   Private
+router.get('/', passport.authenticate('jwt'), async (req, res) => {
+	await getAllSavedSearchPreferences(req)
+		.then(data => {
+			return res.json({ success: true, data });
+		})
+		.catch(err => {
+			return res.json({ success: false, err });
+		});
+});
+
+// @router   GET /api/v1/search-preferences
+// @desc     Returns a single search preferences for a user
+// @access   Private
+router.get('/:id', passport.authenticate('jwt'), async (req, res) => {
+	await getSavedSearchPreference(req)
+		.then(data => {
+			return res.json({ success: true, data });
+		})
+		.catch(err => {
+			return res.json({ success: false, err });
+		});
+});
+
+// @router   DELETE /api/v1/search-preferences
+// @desc     Deletes a single search preferences for a user
+// @access   Private
+router.delete('/:id', passport.authenticate('jwt'), async (req, res) => {
+	await deleteUserSearchPreference(req)
+		.then(data => {
+			return res.json({ success: true, data });
+		})
+		.catch(err => {
+			return res.json({ success: false, err });
+		});
+});
+
+module.exports = router;


### PR DESCRIPTION
Storing the preferences in a filterCriteria object including the tab and the sort as this is how it is stored in state on the front-end.  See queryParams 

Example value for queryParams on front-end:
`{projectSort: "latest"
projectcategories: "API"
projectfeatures: "Arbitrage"
search: ""
}`
