### PR TITLE
IG-2004 - DAR - Update party time distribution output for application versions

### DIFF
--- a/src/resources/activitylog/__mocks__/activitylogs.js
+++ b/src/resources/activitylog/__mocks__/activitylogs.js
@@ -1,0 +1,34 @@
+import constants from '../../utilities/constants.util';
+
+module.exports = {
+	partyTimeRanges: [
+		[
+			{ from: '2021-08-09T12:00:00.000+0000', to: '2021-08-09T13:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+			{ from: '2021-08-09T13:00:00.000+0000', to: '2021-08-09T14:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+		],
+		[
+			{ from: '2021-08-09T12:00:00.000+0000', to: '2021-08-09T16:00:00.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-09T16:00:00.000+0000', to: '2021-08-10T04:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+		],
+		[
+			{ from: '2021-08-09T12:00:00.000+0000', to: '2021-08-09T16:00:00.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-09T16:00:00.000+0000', to: '2021-08-10T04:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+			{ from: '2021-08-09T04:00:00.000+0000', to: '2021-08-09T16:00:00.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-09T16:00:00.000+0000', to: '2021-08-09T20:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+		],
+		[
+			{ from: '2021-08-10T12:00:00.000+0000', to: '2021-08-16T12:00:00.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-16T12:00:00.000+0000', to: '2021-08-18T12:00:00.000+0000', party: constants.userTypes.CUSTODIAN },
+		],
+		[
+			{ from: '2021-08-10T12:00:00.000+0000', to: '2021-08-16T12:00:00.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-16T12:00:00.000+0000', to: '2021-08-18T12:00:00.000+0000', party: constants.userTypes.APPLICANT },
+		],
+		[
+			{ from: '2021-08-10T13:11:12.000+0000', to: '2021-08-12T12:18:23.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-12T12:18:23.000+0000', to: '2021-08-15T17:27:10.000+0000', party: constants.userTypes.CUSTODIAN },
+			{ from: '2021-08-15T17:27:10.000+0000', to: '2021-08-20T08:57:45.000+0000', party: constants.userTypes.APPLICANT },
+			{ from: '2021-08-20T08:57:45.000+0000', to: '2021-08-28T10:42:36.000+0000', party: constants.userTypes.CUSTODIAN },
+		],
+	],
+};

--- a/src/resources/activitylog/__tests__/activitylog.service.test.js
+++ b/src/resources/activitylog/__tests__/activitylog.service.test.js
@@ -1,0 +1,39 @@
+import { activityLogService } from '../dependency';
+import { partyTimeRanges } from '../__mocks__/activitylogs';
+import { cloneDeep } from 'lodash';
+import constants from '../../utilities/constants.util';
+
+describe('ActivityLogService', function () {
+	describe('calculateTimeWithParty', function () {
+		// Arrange
+		let data = cloneDeep(partyTimeRanges);
+		const cases = [
+			[data[0], constants.userTypes.APPLICANT, '0%'],
+			[data[0], constants.userTypes.CUSTODIAN, '100%'],
+
+			[data[1], constants.userTypes.APPLICANT, '25%'],
+			[data[1], constants.userTypes.CUSTODIAN, '75%'],
+
+			[data[2], constants.userTypes.APPLICANT, '50%'],
+			[data[2], constants.userTypes.CUSTODIAN, '50%'],
+
+			[data[3], constants.userTypes.APPLICANT, '75%'],
+			[data[3], constants.userTypes.CUSTODIAN, '25%'],
+
+			[data[4], constants.userTypes.APPLICANT, '100%'],
+			[data[4], constants.userTypes.CUSTODIAN, '0%'],
+
+			[data[5], constants.userTypes.APPLICANT, '37%'],
+			[data[5], constants.userTypes.CUSTODIAN, '63%'],
+		];
+		test.each(cases)(
+			'given an array of time ranges for each party and a chosen party type, the correct percentage spent with the party type is returned',
+			(partyDurations, partyType, expectedResult) => {
+				// Act
+				const result = activityLogService.calculateTimeWithParty(partyDurations, partyType);
+				// Assert
+				expect(result).toBe(expectedResult);
+			}
+		);
+	});
+});

--- a/src/resources/datarequest/datarequest.repository.js
+++ b/src/resources/datarequest/datarequest.repository.js
@@ -189,7 +189,9 @@ export default class DataRequestRepository extends Repository {
 
 	getPermittedUsersForVersions(versionIds) {
 		return DataRequestModel.find({ $or: [{ _id: { $in: versionIds } }, { 'amendmentIterations._id': { $in: versionIds } }] })
-			.select('userId authorIds publisher majorVersion applicationType applicationStatus dateSubmitted amendmentIterations._id amendmentIterations.dateSubmitted')
+			.select(
+				'userId authorIds publisher majorVersion applicationType applicationStatus dateSubmitted dateFinalStatus amendmentIterations._id amendmentIterations.dateCreated amendmentIterations.dateReturned amendmentIterations.dateSubmitted'
+			)
 			.populate([
 				{
 					path: 'publisherObj',


### PR DESCRIPTION
Activity log should display the number of days since a version was submitted along with the % time spent with applicants vs custodians.

**Development**

- Added time calculation for parties to activity log output for each major and minor version including unit tests for calculation logic.