### PR TITLE
Icodara 112: Simplified User Journey

### DIFF
--- a/cloudbuild_dynamic.yaml
+++ b/cloudbuild_dynamic.yaml
@@ -28,6 +28,16 @@ steps:
         '${_REGION}',
         '--allow-unauthenticated',
       ]
+  - name: 'node'
+    args: ['npm', 'install']
+  - name: 'node'
+    args: ['-r', 'esm', 'migrations/migrate.js', 'up', '--autosync', 'true']
+    env:
+      - 'MIGRATE_dbConnectionUri=${_MIGRATE_DBCONNECTIONURI}'
+  - name: 'node'
+    args: ['npm', 'test']
+    env:
+      - 'URL=https://${_TEST_URL}'
 images:
   - gcr.io/$PROJECT_ID/${_APP_NAME}:${_ENVIRONMENT}
 timeout: 900s

--- a/migrations/1628148589241-icoda-migration.js
+++ b/migrations/1628148589241-icoda-migration.js
@@ -1,9 +1,8 @@
 import { PublisherModel as Publisher } from "../src/resources/publisher/publisher.model.js";
-import { UserModel as User} from "../src/resources/user/user.model.js";
 import { TeamModel as Team } from "../src/resources/team/team.model.js";
 import { DataRequestSchemaModel as DataReqSchema } from "../src/resources/datarequest/datarequest.schemas.model.js";
 
-const mongoose = require("mongoose");
+
 
 /**
  * Make any changes you need to make to the database here
@@ -13,8 +12,8 @@ async function up () {
   const now = new Date();
 
   try {
-    const publisher = await createPublisher(now);
-    const team = await createTeam(publisher._id, user);
+    const publisher = await createPublisher();
+    const team = await createTeam(publisher._id, now);
     const dataReqSchema = await createDataReqSchema(now);
   } catch (err) {
     console.log("Error occured during the migration. Error message: " + err);
@@ -28,7 +27,7 @@ async function up () {
 async function down () {
 }
 
-function createPublisher(timestamp) {
+function createPublisher() {
   let publisher = {  
         name: `ICODA accreditation`,
         active: true,
@@ -40,9 +39,8 @@ function createPublisher(timestamp) {
   return publisher.save();
 }
 
-function createTeam(publisherId, user, timestamp) {
+function createTeam(publisherId, timestamp) {
   let team = {
-        _id: '',
         active: true,
         members: [
           {
@@ -52,9 +50,6 @@ function createTeam(publisherId, user, timestamp) {
           }
         ],
         type: 'publisher',
-        __v: 17,
-        createdAt: "2021-08-09T11:51:08.004Z",
-        updatedAt: '',
         notifications: []
   }
 
@@ -67,7 +62,6 @@ function createTeam(publisherId, user, timestamp) {
 
 function createDataReqSchema(timestamp) {
   let drs = {
-        id: 6040430027486150,
         status: 'active',
         formType: '5 safe',
         version: 1,
@@ -253,9 +247,6 @@ function createDataReqSchema(timestamp) {
             }
           ]
         },
-        __v: 0,
-        createdAt: "2021-08-09T11:51:08.004Z",
-        updatedAt: '',
         publisher: 'ICODA accreditation'
       }
 

--- a/migrations/1628148589241-icoda-migration.js
+++ b/migrations/1628148589241-icoda-migration.js
@@ -13,8 +13,8 @@ async function up () {
 
   try {
     const publisher = await createPublisher();
-    const team = await createTeam(publisher._id, now);
-    const dataReqSchema = await createDataReqSchema(now);
+    await createTeam(publisher._id, now);
+    await createDataReqSchema(now);
   } catch (err) {
     console.log("Error occured during the migration. Error message: " + err);
   }

--- a/migrations/1628148589241-icoda-migration.js
+++ b/migrations/1628148589241-icoda-migration.js
@@ -1,0 +1,270 @@
+import { PublisherModel as Publisher } from "../src/resources/publisher/publisher.model.js";
+import { UserModel as User} from "../src/resources/user/user.model.js";
+import { TeamModel as Team } from "../src/resources/team/team.model.js";
+import { DataRequestSchemaModel as DataReqSchema } from "../src/resources/datarequest/datarequest.schemas.model.js";
+
+const mongoose = require("mongoose");
+
+/**
+ * Make any changes you need to make to the database here
+ */
+async function up () {
+
+  const now = new Date();
+
+  try {
+    const publisher = await createPublisher(now);
+    const team = await createTeam(publisher._id, user);
+    const dataReqSchema = await createDataReqSchema(now);
+  } catch (err) {
+    console.log("Error occured during the migration. Error message: " + err);
+  }
+
+}
+
+/**
+ * Make any changes that UNDO the up function side effects here (if possible)
+ */
+async function down () {
+}
+
+function createPublisher(timestamp) {
+  let publisher = {  
+        name: `ICODA accreditation`,
+        active: true,
+        imageURL: '',
+        allowsMessaging: true,
+        workflowEnabled: true
+    }
+  publisher = new Publisher(publisher);
+  return publisher.save();
+}
+
+function createTeam(publisherId, user, timestamp) {
+  let team = {
+        _id: '',
+        active: true,
+        members: [
+          {
+            roles: [ 'manager' ],
+            memberid: '',
+            notifications: []
+          }
+        ],
+        type: 'publisher',
+        __v: 17,
+        createdAt: "2021-08-09T11:51:08.004Z",
+        updatedAt: '',
+        notifications: []
+  }
+
+  team = new Team(team);
+  team._id = publisherId;
+  team.updatedAt = timestamp;
+
+  return team.save();
+}
+
+function createDataReqSchema(timestamp) {
+  let drs = {
+        id: 6040430027486150,
+        status: 'active',
+        formType: '5 safe',
+        version: 1,
+        jsonSchema: {
+          pages: [
+            {
+              pageId: 'safepeople',
+              title: 'Safe people',
+              description: 'Who is going to be accessing the data?\n' +
+                '\n' +
+                'Safe People should have the right motivations for accessing research data and understand the legal and ethical considerations when using data that may be sensitive or confidential. Safe People should also have sufficient skills, knowledge and experience to work with the data effectively.  Researchers may need to undergo specific training or accreditation before accessing certain data or research environments and demonstrate that they are part of a bona fide research organisation.\n' +
+                '\n' +
+                'The purpose of this section is to ensure that:\n' +
+                '- details of people who will be accessing the data and the people who are responsible for completing the application are identified\n' +
+                '- any individual or organisation that intends to access  the data requested is identified\n' +
+                '- all identified individuals have the necessary accreditation and/or expertise to work with the data effectively.',
+              active: true
+            }
+          ],
+          formPanels: [
+            { index: 1, pageId: 'safepeople', panelId: 'primaryapplicant' },
+            {
+              panelId: 'safepeople-otherindividuals',
+              pageId: 'safepeople',
+              index: 2
+            }
+          ],
+          questionPanels: [
+            {
+              panelId: 'primaryapplicant',
+              navHeader: 'Primary applicant',
+              questionSets: [ { index: 1, questionSetId: 'primaryapplicant' } ],
+              questionPanelHeaderText: 'TODO: We need a description for this panel',
+              pageId: 'safepeople',
+              panelHeader: ''
+            },
+            {
+              panelHeader: '',
+              pageId: 'safepeople',
+              questionPanelHeaderText: 'TODO: We need a description for this panel',
+              questionSets: [
+                { questionSetId: 'safepeople-otherindividuals', index: 1 },
+                {
+                  questionSetId: 'add-safepeople-otherindividuals',
+                  index: 100
+                }
+              ],
+              panelId: 'safepeople-otherindividuals',
+              navHeader: 'Other individuals'
+            }
+          ],
+          questionSets: [
+            {
+              questions: [
+                {
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantfullname',
+                  question: 'Full name',
+                  validations: [Array]
+                },
+                {
+                  question: 'Job title',
+                  validations: [Array],
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantjobtitle'
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicanttelephone',
+                  question: 'Telephone'
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantorcid',
+                  question: 'ORCID'
+                },
+                {
+                  question: 'Email',
+                  validations: [Array],
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantemail'
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantaccessdata',
+                  question: 'Will you access the data requested?'
+                },
+                {
+                  question: 'Are you an accredited researcher under the Digital Economy Act 2017?',
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantaccreditedresearcher'
+                },
+                {
+                  question: 'Have you undertaken professional training or education on the topic of Information Governance?',
+                  questionId: 'safepeopleprimaryapplicanttraininginformationgovernance',
+                  input: [Object]
+                },
+                {
+                  validations: [Array],
+                  question: 'Your organisation name',
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantorganisationname'
+                },
+                {
+                  question: 'Does your organisation have a current Data Security and Protection Toolkit (DSPT) published assessment?',
+                  validations: [Array],
+                  questionId: 'safepeopleprimaryapplicantorganisationdatasecurityprotectionkit',
+                  input: [Object]
+                },
+                {
+                  question: 'Will your organisation act as data controller?',
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantorganisationdatacontroller'
+                },
+                {
+                  question: 'CV',
+                  input: [Object],
+                  questionId: 'safepeopleprimaryapplicantuploadedcv'
+                }
+              ],
+              questionSetId: 'primaryapplicant',
+              questionSetHeader: 'Primary applicant'
+            },
+            {
+              questions: [
+                {
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualsfullname',
+                  question: 'Full name'
+                },
+                {
+                  question: 'Job title',
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualsjobtitle'
+                },
+                {
+                  question: 'Organisation',
+                  questionId: 'safepeopleotherindividualsorganisation',
+                  input: [Object]
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualsrole',
+                  question: 'Role'
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualsaccessdata',
+                  question: 'Will this person access the data requested?'
+                },
+                {
+                  question: 'Is this person an accredited researcher under the Digital Economy Act 2017?',
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualsaccreditedresearcher'
+                },
+                {
+                  input: [Object],
+                  questionId: 'safepeopleotherindividualstraininginformationgovernance',
+                  question: 'Has this person undertaken professional training or education on the topic of Information Governance?'
+                },
+                {
+                  questionId: 'safepeopleotherindividualsuploadedcv',
+                  input: [Object],
+                  question: 'CV'
+                },
+                {
+                  questionId: 'safepeopleotherindividualsexperience',
+                  input: [Object],
+                  question: "Please provide evidence of this person's expertise and experience relevant to delivering the project"
+                }
+              ],
+              questionSetId: 'safepeople-otherindividuals',
+              questionSetHeader: 'Other individuals'
+            },
+            {
+              questionSetId: 'add-safepeople-otherindividuals',
+              questions: [
+                {
+                  input: [Object],
+                  questionId: 'add-safepeople-otherindividuals'
+                }
+              ]
+            }
+          ]
+        },
+        __v: 0,
+        createdAt: "2021-08-09T11:51:08.004Z",
+        updatedAt: '',
+        publisher: 'ICODA accreditation'
+      }
+
+  drs = new DataReqSchema(drs);
+  drs.createdAt = timestamp;
+  drs.updatedAt = timestamp;
+
+  return drs.save();
+}
+
+
+module.exports = { up, down };

--- a/migrations/migrate.js
+++ b/migrations/migrate.js
@@ -1,0 +1,9 @@
+import cli from 'migrate-mongoose/src/cli'; //lgtm [js/unused-local-variable]
+import mongoose from 'mongoose';
+mongoose.connect(process.env.MIGRATE_dbConnectionUri, {
+	useNewUrlParser: true,
+	useFindAndModify: false,
+	useUnifiedTopology: true,
+	autoIndex: false,
+});
+

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"keygrip": "^1.1.0",
 		"lodash": "^4.17.19",
+		"migrate-mongoose": "^4.0.0",
 		"moment": "^2.27.0",
 		"mongoose": "^5.9.12",
 		"morgan": "^1.10.0",


### PR DESCRIPTION
These changes are made to support icodara-112. I made these changes:

1.  I added mongoose-migrate package to the ICODA project dependencies.
2. I added the same migrate.js as HDR UK (migrate.js is setting the configurations for mongoose-migrate).
3. I wrote the script to populate a new Team, Publisher and DataRequestSchema(for the ICODA accreditation) to the DB.
4. I added the steps for the migration on our GCP console build file (cloudbuild_dynamic.yaml)