### PR TITLE
Fixed file upload error as a result of versioning

### DIFF
--- a/src/resources/datarequest/datarequest.repository.js
+++ b/src/resources/datarequest/datarequest.repository.js
@@ -140,7 +140,7 @@ export default class DataRequestRepository extends Repository {
 	}
 
 	getFilesForApplicationById(id, options = {}) {
-		return DataRequestModel.findById(id, { files: 1, applicationStatus: 1, userId: 1, authorIds: 1 }, options);
+		return DataRequestModel.findById(id, { files: 1, applicationStatus: 1, userId: 1, authorIds: 1, versionTree: 1 }, options);
 	}
 
 	getApplicationFormSchema(publisher) {

--- a/src/resources/utilities/cloudStorage.util.js
+++ b/src/resources/utilities/cloudStorage.util.js
@@ -18,7 +18,7 @@ export const processFile = (file, id, uniqueId) =>
 			path,
 			{
 				gzip: true,
-				destination: `dar-${id}-${uniqueId}_${originalname}`,
+				destination: `dar-${id.toString()}-${uniqueId}_${originalname}`,
 				metadata: { cacheControl: 'none-cache' },
 			},
 			(err, file) => {
@@ -41,10 +41,10 @@ export const getFile = (file, fileId, id) =>
 		//  2. set option for file dest
 		let options = {
 			// The path to which the file should be downloaded
-			destination: `${process.env.TMPDIR}${id}/${fileId}_${file}`,
+			destination: `${process.env.TMPDIR}${id.toString()}/${fileId}_${file}`,
 		};
 		// create tmp
-		const sanitisedId = id.replace(/[^0-9a-z]/gi, '');
+		const sanitisedId = id.toString().replace(/[^0-9a-z]/gi, '');
 
 		const filePath = `${process.env.TMPDIR}${sanitisedId}`;
 


### PR DESCRIPTION
Error occurring as a result of versioning data access request applications where a required variable 'versionTree' was not being included in the database query used to determine which applications to update once file upload had completed/changed status.

**Development**

- Instated missing variable for versioning
- Added conversions from MongoDb ObjectId to string