### PR TITLE
Hotfix - Fix for admin not able to override

### DIFF
--- a/src/resources/auth/auth.route.js
+++ b/src/resources/auth/auth.route.js
@@ -51,8 +51,8 @@ router.get('/status', function (req, res, next) {
 							const foundRole = foundTeam.roles.find(role => role === constants.roleTypes.METADATA_EDITOR);
 							if (isEmpty(foundRole)) {
 								foundTeam.roles.push(constants.roleTypes.METADATA_EDITOR);
-								foundTeam.isAdmin = true;
 							}
+							foundTeam.isAdmin = true;
 						} else {
 							teams.push({
 								_id: newTeam._id,


### PR DESCRIPTION
Fix for admin not able to override because they are already a manager/metadata_editor of the team