### PR TITLE
SUPP-623 Getting previous discourse topic id when creating a new data…

### DIFF
--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -514,7 +514,9 @@ module.exports = {
 
 								let previousDataset = await Data.findOneAndUpdate({ pid: dataset.pid, activeflag: 'active' }, { activeflag: 'archive' });
 								let previousCounter = 0;
+								let previousDiscourseTopicId = 0;
 								if (previousDataset) previousCounter = previousDataset.counter || 0;
+								if (previousDataset) previousDiscourseTopicId = previousDataset.discourseTopicId || 0;
 
 								//get technicaldetails and metadataQuality
 								let technicalDetails = await datasetonboardingUtil.buildTechnicalDetails(dataset.structuralMetadata);
@@ -565,6 +567,7 @@ module.exports = {
 										},
 										datasetv2: datasetv2Object,
 										applicationStatusDesc: applicationStatusDesc,
+										discourseTopicId: previousDiscourseTopicId,
 									},
 									{ new: true }
 								);

--- a/src/resources/discourse/discourse.service.js
+++ b/src/resources/discourse/discourse.service.js
@@ -74,7 +74,7 @@ export async function createDiscourseTopic(tool) {
 		let {
 			datasetfields: { abstract },
 		} = tool;
-		rawIs = `${tool.description || abstract} <br><br> Original content: ${process.env.homeURL}/dataset/${tool.id}`;
+		rawIs = `${tool.description || abstract} <br><br> Original content: ${process.env.homeURL}/dataset/${tool.pid}`;
 		categoryIs = process.env.DISCOURSE_CATEGORY_DATASETS_ID;
 	} else if (tool.type === 'paper') {
 		rawIs = `${tool.description} <br><br> Original content: ${process.env.homeURL}/paper/${tool.id}`;


### PR DESCRIPTION
[SUPP-623](https://hdruk.atlassian.net/browse/SUPP-623)

- Updated dataset onboarding controller to bring through previous discourse topic id when creating a new version
- Updated link for datasets to contain pid