### PR TITLE
DAR - Amend - Copy changes

### DIFF
--- a/src/resources/datarequest/amendment/amendment.service.js
+++ b/src/resources/datarequest/amendment/amendment.service.js
@@ -628,12 +628,12 @@ export default class AmendmentService {
 	}
 
 	highlightQuestionChange(accessRecord, questionId) {
-		const { dateSubmitted, mainApplicant } = accessRecord;
+		const { dateSubmitted } = accessRecord;
 
 		const questionAlert = {
 			status: 'WARNING',
 			options: [],
-			text: `${mainApplicant.firstname} ${mainApplicant.lastname} submitted an amendment on ${moment(dateSubmitted).format('Do MMM YYYY')}`,
+			text: `Applicant has requested this as an amendment to the approved application on ${moment(dateSubmitted).format('Do MMM YYYY')}`,
 		};
 
 		accessRecord.jsonSchema.questionSets.forEach(questionSet => {

--- a/src/resources/datarequest/datarequest.controller.js
+++ b/src/resources/datarequest/datarequest.controller.js
@@ -2477,7 +2477,7 @@ export default class DataRequestController extends Controller {
 					custodianUserIds = custodianManagers.map(user => user.id);
 					await notificationBuilder.triggerNotificationMessage(
 						custodianUserIds,
-						`A Data Access Request has been resubmitted with updates to ${publisher} for ${datasetTitles} by ${appFirstName} ${appLastName}`,
+						`An amendment request has been submitted to ${projectId} by ${appFirstName} ${appLastName}`,
 						'data access request',
 						accessRecord._id
 					);
@@ -2488,7 +2488,7 @@ export default class DataRequestController extends Controller {
 				// Applicant notification
 				await notificationBuilder.triggerNotificationMessage(
 					[accessRecord.userId],
-					`Your Data Access Request for ${datasetTitles} was successfully submitted with amendments to ${publisher}`,
+					`Your amendment request to ${projectId} was successfully submitted to ${publisher}`,
 					'data access request',
 					accessRecord._id
 				);
@@ -2496,7 +2496,7 @@ export default class DataRequestController extends Controller {
 				if (!_.isEmpty(authors)) {
 					await notificationBuilder.triggerNotificationMessage(
 						accessRecord.authors.map(author => author.id),
-						`A Data Access Request you are contributing to for ${datasetTitles} was successfully submitted with amendments to ${publisher} by ${firstname} ${lastname}`,
+						`An amendment request to ${projectId} was successfully submitted to ${publisher} by ${firstname} ${lastname}`,
 						'data access request',
 						accessRecord._id
 					);

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -108,7 +108,7 @@ const _navigationFlags = {
 						displayOrder: 1,
 					},
 				],
-				text: '#NAME# updated this answer on #DATE#',
+				text: '#NAME# made this change on #DATE#',
 			},
 			incomplete: { status: 'DANGER', options: [], text: '#NAME# requested an update on #DATE#' },
 		},

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -71,7 +71,7 @@ const _questionActions = {
 const _navigationFlags = {
 	custodian: {
 		submitted: {
-			completed: { status: 'SUCCESS', options: [], text: '#NAME# updated this answer on #DATE#' },
+			completed: { status: 'SUCCESS', options: [], text: '#NAME# made this change on #DATE#' },
 		},
 		returned: {
 			completed: { status: 'WARNING', options: [], text: '#NAME# requested an update on #DATE#' },
@@ -94,7 +94,7 @@ const _navigationFlags = {
 	},
 	applicant: {
 		submitted: {
-			completed: { status: 'SUCCESS', options: [], text: '#NAME# updated this answer on #DATE#' },
+			completed: { status: 'SUCCESS', options: [], text: '#NAME# made this change on #DATE#' },
 			incomplete: { status: 'DANGER', options: [], text: '#NAME# requested an update on #DATE#' },
 		},
 		returned: {

--- a/src/resources/utilities/emailGenerator.util.js
+++ b/src/resources/utilities/emailGenerator.util.js
@@ -273,8 +273,8 @@ const _getSubmissionDetails = (
 			subject = `You have made updates to your Data Access Request for ${datasetTitles}. The custodian will be in contact about the application.`;
 			break;
 		case constants.submissionTypes.AMENDED:
-			heading = 'Data access request application amended';
-			subject = `${userName} has made amendments to an approved application`;
+			heading = 'New amendment request application';
+			subject = `Applicant has submitted an amendment to an approved application.  Please let the applicant know as soon as there is progress in the review of their submission.`;
 			body = amendBody;
 			break;
 	}
@@ -330,6 +330,7 @@ const _buildEmail = (aboutApplication, fullQuestions, questionAnswers, options) 
 		applicationId,
 	} = options;
 	const dateSubmitted = moment().format('D MMM YYYY');
+  const year = moment().year();
 	const { projectName = 'No project name set', isNationalCoreStudies = false, nationalCoreStudiesProjectId = '' } = aboutApplication;
 	const linkNationalCoreStudies =
 		nationalCoreStudiesProjectId === '' ? '' : `${process.env.homeURL}/project/${nationalCoreStudiesProjectId}`;
@@ -338,7 +339,7 @@ const _buildEmail = (aboutApplication, fullQuestions, questionAnswers, options) 
 	let questionTree = { ...fullQuestions };
 	let answers = { ...questionAnswers };
 	let pages = Object.keys(questionTree);
-	let gatewayAttributionPolicy = `We ask that use of the Innovation Gateway be attributed in any resulting research outputs. Please include the following statement in the acknowledgments: 'Data discovery and access was facilitated by the Health Data Research UK Innovation Gateway - HDRUK Innovation Gateway  | Homepage 2020.'`;
+	let gatewayAttributionPolicy = `We ask that use of the Health Data Research Innovation Gateway (the 'Gateway') be attributed in any resulting research outputs. Please include the following statement in the acknowledgments: 'Data discovery and access was facilitated by the Health Data Research UK Innovation Gateway - HDRUK Innovation Gateway  | Homepage ${year}.'`;
 
 	let table = _getSubmissionDetails(
 		userType,


### PR DESCRIPTION
Changes requested to amend functionality copy:

[Amend - 03.09.21.pptx](https://github.com/HDRUK/gateway-web/files/7109328/Amend.-.03.09.21.pptx)

Comments from client:

- Any in-line change to a question should be flagged with the wording: Applicant has requested this as an amendment to the approved application on XX date.
- It could read applicant has submitted an amendment request to an approved application (to indicate at this stage it is still only a request and needs to be approved before it becomes an amendment).
- In the first in app notification it could just read “your amendment request was successfully submitted” (i.e., remove ‘with updates’). If anything it should refer to what the approved application reference is.
- Same for custodian view – “An amendment request has been submitted to [approved application reference] by[ Applicant]”. It has NOT been re-submitted.