### PR TITLE
IG-2207 - Switch MailChimp Integration to HubSpot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"dependencies": {
 		"@google-cloud/monitoring": "^2.1.0",
 		"@google-cloud/storage": "^5.3.0",
+		"@hubspot/api-client": "^4.1.0",
 		"@sendgrid/mail": "^7.1.0",
 		"@sentry/node": "^6.4.1",
 		"@sentry/tracing": "^6.4.1",

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -251,7 +251,7 @@ app.use('/api/v1/help', require('../resources/help/help.router'));
 
 app.use('/api/v2/filters', require('../resources/filters/filters.route'));
 
-app.use('/api/v1/mailchimp', require('../services/mailchimp/mailchimp.route'));
+app.use('/api/v1/hubspot', require('../services/hubspot/hubspot.route'));
 
 app.use('/api/v1/search-preferences', require('../resources/searchpreferences/searchpreferences.route'));
 

--- a/src/resources/person/person.route.js
+++ b/src/resources/person/person.route.js
@@ -71,7 +71,7 @@ router.put('/', passport.authenticate('jwt'), utils.checkIsUser(), async (req, r
 			}
 		);
 
-		const user = await UserModel.findOneAndUpdate({ id: userId }, { $set: { firstname, lastname, email, feedback, news } });
+		const user = await UserModel.findOneAndUpdate({ id: userId }, { $set: { firstname, lastname, email, feedback, news } }, { new: true });
 
 		// Sync contact in Hubspot
 		hubspotConnector.syncContact(user);

--- a/src/resources/person/person.route.js
+++ b/src/resources/person/person.route.js
@@ -74,7 +74,7 @@ router.put('/', passport.authenticate('jwt'), utils.checkIsUser(), async (req, r
 		const user = await UserModel.findOneAndUpdate({ id: userId }, { $set: { firstname, lastname, email, feedback, news } }, { new: true });
 
 		// Sync contact in Hubspot
-		hubspotConnector.syncContact(user);
+		hubspotConnector.syncContact({ ...user.toObject(), orcid, sector, organisation });
 
 		return res.status(200).json({
 			status: 'success',

--- a/src/resources/user/user.register.route.js
+++ b/src/resources/user/user.register.route.js
@@ -100,7 +100,7 @@ router.post('/', async (req, res) => {
 	});
 
 	// 4. Sync contact in Hubspot
-	await hubspotConnector.syncContact(user);
+	hubspotConnector.syncContact(user);
 	
 	const [loginErr, token] = await to(login(req, user));
 

--- a/src/resources/user/user.register.route.js
+++ b/src/resources/user/user.register.route.js
@@ -100,7 +100,7 @@ router.post('/', async (req, res) => {
 	});
 
 	// 4. Sync contact in Hubspot
-	hubspotConnector.syncContact(user);
+	hubspotConnector.syncContact({ ...user.toObject(), orcid, sector, organisation });
 	
 	const [loginErr, token] = await to(login(req, user));
 

--- a/src/services/hubspot/hubspot.js
+++ b/src/services/hubspot/hubspot.js
@@ -1,0 +1,170 @@
+import Hubspot from '@hubspot/api-client';
+import * as Sentry from '@sentry/node';
+import constants from '../../resources/utilities/constants.util';
+import { UserModel } from '../../resources/user/user.model';
+
+// See Hubspot API documentation for supporting info https://developers.hubspot.com/docs/api/crm
+
+// Default service params
+const apiKey = process.env.HUBSPOT_API_KEY;
+let hubspotClient;
+if (apiKey) hubspotClient = new Hubspot.Client({ apiKey });
+
+/**
+ * Sync A Single Gateway User With Hubspot
+ *
+ * @desc    Adds a Gateway user to the Hubspot CMS
+ * @param 	{Object} 	        gatewayUser 				User object containing bio details and contact subscription preferences
+ */
+const syncContact = async gatewayUser => {
+	if (apiKey) {
+		// GET contact using email from Hubspot in case they already exist as we need to merge subscription preferences rather than replace
+		// If contact found, merge subscription preferences and perform PUT operation
+		// If contact not found, perform POST operation
+	}
+};
+
+/**
+ * Update A Hubspot Contact With Gateway User Details
+ *
+ * @desc    Updates a Hubspot contact record with corresponding Gateway user data using email address for unique match
+ * @param 	{Object} 	        hubspotContact 				Contact object from Hubspot to be updated
+ * @param 	{Object} 	        gatewayUser 				User object containing bio details and contact subscription preferences from Gateway
+ */
+const updateContact = async (hubspotContact, gatewayUser) => {
+	if (apiKey) {
+		// Extract and split hubspotContact communication preference
+		// Modify comms preferences to match gatewayUser settings
+		// Ensure Gateway Registered User is true
+		// PUT operation to update contact in Hubspot
+	}
+};
+
+/**
+ * Create A Hubspot Contact With Gateway User Details
+ *
+ * @desc    Creates a new Hubspot contact record with corresponding Gateway user data using email address for unique match
+ * @param 	{Object} 	        gatewayUser 				User object containing bio details and contact subscription preferences from Gateway
+ */
+const createContact = async gatewayUser => {
+	if (apiKey) {
+		// Build hubspotContact communication preferences
+		// Ensure Gateway Registered User is true
+		// POST operation to create contact in Hubspot
+	}
+};
+
+/**
+ * Sync Gateway Users With Hubspot
+ *
+ * @desc    Synchronises Gateway users with any changes reflected in Hubspot via external subscribe or unsubscribe methods e.g. mail link or sign up form sent via campaign
+ */
+ const syncAllContacts = async => {
+	if (apiKey) {
+		// 1. Track attempted sync in Sentry using log
+		Sentry.addBreadcrumb({
+			category: 'Hubspot',
+			message: `Syncing Gateway users with Hubspot contacts`,
+			level: Sentry.Severity.Log,
+		});
+
+		// Batch GET contacts from Hubspot
+		await batchImportFromHubspot();
+
+		// Batch POST update contacts to Hubspot
+		await batchExportToHubspot();
+	}
+};
+
+
+/**
+ * Trigger Hubspot Import To Update Changes Made Externally From Gateway
+ *
+ * @desc    Triggers an import of all contacts found to match a user record in the Gateway, updating where changes have been made
+ */
+const batchImportFromHubspot = async () => {
+	if (apiKey) {
+		// 1. Get corresponding Gateway subscription variable e.g. feedback, news
+		const subscriptionBoolKey = getSubscriptionBoolKey(subscriptionId);
+		let processedCount = 0;
+		// 2. Iterate bulk update process until all contacts have been processed from MailChimp
+		while (processedCount < memberCount) {
+			const { members = [] } = await mailchimp.get(`lists/${subscriptionId}/members?count=100&offset=${processedCount}`);
+			let ops = [];
+			// 3. For each member returned by MailChimp, create a bulk update operation to update the corresponding Gateway user if they exist
+			members.forEach(member => {
+				const subscribedBoolValue = member.status === 'subscribed' ? true : false;
+				const { email_address: email } = member;
+				ops.push({
+					updateMany: {
+						filter: { email },
+						update: {
+							[subscriptionBoolKey]: subscribedBoolValue,
+						},
+						upsert: false,
+					},
+				});
+			});
+			// 4. Run bulk update
+			await UserModel.bulkWrite(ops);
+			// 5. Increment counter to move onto next chunk of members
+			processedCount = processedCount + members.length;
+		}
+	}
+};
+
+/**
+ * Sync Hubspot Contact Details With User Profile Data From Gateway
+ *
+ * @desc    Updates Contact Details In Hubspot
+ */
+const batchExportToHubspot = async => {
+	if (apiKey) {
+		const subscriptionBoolKey = getSubscriptionBoolKey(subscriptionId);
+		// 1. Get all users from db
+		const users = await UserModel.find().select('id email firstname lastname news feedback').lean();
+		// 2. Build members array providing required metadata for MailChimp
+		const members = users.reduce((arr, user) => {
+			// Get subscription status from user profile
+			const status = user[subscriptionBoolKey]
+				? constants.mailchimpSubscriptionStatuses.SUBSCRIBED
+				: constants.mailchimpSubscriptionStatuses.UNSUBSCRIBED;
+			// Check if the same email address has already been processed (email address can be attached to multiple user accounts)
+			const memberIdx = arr.findIndex(member => member.email_address === user.email);
+			if (status === constants.mailchimpSubscriptionStatuses.SUBSCRIBED) {
+				if (memberIdx === -1) {
+					// If email address has not be processed, return updated membership object
+					return [
+						...arr,
+						{
+							userId: user.id,
+							email_address: user.email,
+							status,
+							tags,
+							merge_fields: {
+								FNAME: user.firstname,
+								LNAME: user.lastname,
+							},
+						},
+					];
+				} else {
+					// If email address has been processed, and the current status is unsubscribed, override membership status
+					if (status === constants.mailchimpSubscriptionStatuses.UNSUBSCRIBED) {
+						arr[memberIdx].status = constants.mailchimpSubscriptionStatuses.UNSUBSCRIBED;
+					}
+					return arr;
+				}
+			}
+			return arr;
+		}, []);
+		// 3. Update subscription members in MailChimp
+		await updateSubscriptionMembers(subscriptionId, members);
+	}
+};
+
+const hubspotConnector = {
+	syncContact,
+	syncAllContacts,
+};
+
+export default hubspotConnector;

--- a/src/services/hubspot/hubspot.route.js
+++ b/src/services/hubspot/hubspot.route.js
@@ -1,0 +1,37 @@
+import express from 'express';
+import * as Sentry from '@sentry/node';
+import hubspotConnector from './hubspot';
+const router = express.Router();
+
+// @router   GET /api/v1/hubspot/sync
+// @desc     Performs a two-way sync of contact details including communication opt in preferences between HubSpot and the Gateway database
+// @access   Public (key required)
+router.post('/sync', async (req, res) => {
+	try {
+		// Check to see if header is in json format
+		let parsedBody = {};
+		if (req.header('content-type') === 'application/json') {
+			parsedBody = req.body;
+		} else {
+			parsedBody = JSON.parse(req.body);
+		}
+		// Check for key
+		if (parsedBody.key !== process.env.HUBSPOT_SYNC_KEY) {
+			return res.status(400).json({ success: false, error: 'Sync could not be started' });
+		}
+		// Throw error if parsing failed
+		if (parsedBody.error === true) {
+			throw new Error('Sync parsing error');
+		}
+		// Run sync job
+		hubspotConnector.syncAllContacts();
+		// Return response indicating job has started (do not await async import)
+		return res.status(200).json({ success: true, message: 'Sync started' });
+	} catch (err) {
+		Sentry.captureException(err);
+		console.error(err.message);
+		return res.status(500).json({ success: false, message: 'Sync failed' });
+	}
+});
+
+module.exports = router;

--- a/src/services/hubspot/hubspot.route.js
+++ b/src/services/hubspot/hubspot.route.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node';
 import hubspotConnector from './hubspot';
 const router = express.Router();
 
-// @router   GET /api/v1/hubspot/sync
+// @router   POST /api/v1/hubspot/sync
 // @desc     Performs a two-way sync of contact details including communication opt in preferences between HubSpot and the Gateway database
 // @access   Public (key required)
 router.post('/sync', async (req, res) => {


### PR DESCRIPTION
**Task description**

Switch integration from MailChimp to Hubspot for managing communication preferences to allow mailing campaigns.

Agreed with HDR to use HubSpot custom ‘Communication preference’ property to record users/contacts active opt status against the Gateway News and Feedback comms options.

**Development/Completed**

- Replacement of MailChimp connector with HubSpot specific implementation, interfacing with the API at the same key points e.g. registration and profile update.
- Batch imported contacts who have currently opted in to feedback on the Gateway.
- Added ‘Gateway Registered User’ property as true to all Hubspot contacts existing on the Gateway.

**For Go-Live**

- Update the nightly job which keeps subscriptions in sync between HubSpot and the Gateway to point at new API route 'api/v1/hubspot/sync'
- Update GCP Gateway API environment variables to include HUBSPOT_API_KEY and HUBSPOT_SYNC_KEY
