### PR TITLE
IG-2300 - Migration script to add sender user type to existing messages

### DIFF
--- a/migrations/1631633422670-message_user_types.js
+++ b/migrations/1631633422670-message_user_types.js
@@ -1,0 +1,39 @@
+import { MessagesModel } from '../src/resources/message/message.model';
+import { TeamModel } from '../src/resources/team/team.model';
+import constants from '../src/resources/utilities/constants.util';
+
+/**
+ * Make any changes you need to make to the database here
+ */
+async function up() {
+	// 1. Find all messages
+	const messages = await MessagesModel.find({ messageType: 'message' }).lean();
+
+	let ops = [];
+
+	for (const message of messages) {
+		const { _id, createdBy } = message;
+
+		const creatorTeamCount = await TeamModel.countDocuments({ 'members.memberid': createdBy });
+		const userType = creatorTeamCount > 0 ? constants.userTypes.CUSTODIAN : constants.userTypes.APPLICANT;
+
+		ops.push({
+			updateOne: {
+				filter: { _id },
+				update: {
+					userType,
+				},
+				upsert: false,
+			},
+		});
+	}
+
+	await MessagesModel.bulkWrite(ops);
+}
+
+/**
+ * Make any changes that UNDO the up function side effects here (if possible)
+ */
+async function down() {}
+
+module.exports = { up, down };


### PR DESCRIPTION
In order to produce a MongoDb chart illustrating the usage of the first message feature, we need to add the user type to existing data in production.  With the user type added, we are able to determine if a custodian team has responded to an enquiry.

**Development**

- Created script to determine if the sender of each message either a custodian or an applicant and updates accordingly.