### PR TITLE
Bug fix - removed CSRF validation

### DIFF
--- a/src/config/server.js
+++ b/src/config/server.js
@@ -86,7 +86,7 @@ app.use(bodyParser.urlencoded({ limit: '10mb', extended: false }));
 
 app.use(logger('dev'));
 app.use(cookieParser());
-app.use(csrf({ cookie: true }));
+//app.use(csrf({ cookie: true }));
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -9,7 +9,6 @@ import cors from 'cors';
 import logger from 'morgan';
 import passport from 'passport';
 import cookieParser from 'cookie-parser';
-import csrf from 'csurf';
 import bodyParser from 'body-parser';
 import { connectToDatabase } from './db';
 import { initialiseAuthentication } from '../resources/auth';
@@ -86,7 +85,6 @@ app.use(bodyParser.urlencoded({ limit: '10mb', extended: false }));
 
 app.use(logger('dev'));
 app.use(cookieParser());
-//app.use(csrf({ cookie: true }));
 app.use(passport.initialize());
 app.use(passport.session());
 


### PR DESCRIPTION
**Issue**
Error occurring posting forms from Gateway React UI to API due to not providing valid CSRF token.  API implementation and expectation of CSRF must happen in sync with UI implementation.  This was introduced as a security recommendation by LGTM.

**Error**
`ForbiddenError: invalid csrf token
[0]     at csrf (/HDR-UK/gateway-api/node_modules/csurf/index.js:112:19)`

**Fix**
- Remove CSRF validation initialisation from Node server config.