### PR TITLE
SUPP-656 - Fix for incorrect message access for custodian teams

### DIFF
--- a/src/resources/message/message.controller.js
+++ b/src/resources/message/message.controller.js
@@ -97,7 +97,7 @@ module.exports = {
 						);
 						if (!_.isEmpty(subscribedMembersByType)) {
 							// build cleaner array of memberIds from subscribedMembersByType
-							const memberIds = [...subscribedMembersByType].map(m => m.memberid);
+							const memberIds = [...subscribedMembersByType.map(m => m.memberid.toString()), topicObj.createdBy.toString()];
 							// returns array of objects [{email: 'email@email.com '}] for members in subscribed emails users is list of full user object
 							const { memberEmails } = teamController.getMemberDetails([...memberIds], [...messageRecipients]);
 							messageRecipients = [...teamNotificationEmails, ...memberEmails];

--- a/src/resources/team/team.controller.js
+++ b/src/resources/team/team.controller.js
@@ -340,7 +340,7 @@ const updateNotifications = async (req, res) => {
 						const subscribedMembersByType = filterMembersByNoticationTypes([...members], [notificationType]);
 						if (!isEmpty(subscribedMembersByType)) {
 							// build cleaner array of memberIds from subscribedMembersByType
-							const memberIds = [...subscribedMembersByType].map(m => m.memberid);
+							const memberIds = [...subscribedMembersByType].map(m => m.memberid.toString());
 							// returns array of objects [{email: 'email@email.com '}] for members in subscribed emails users is list of full user object in team
 							const { memberEmails, userIds } = getMemberDetails([...memberIds], [...users]);
 							// email options and html template
@@ -1064,10 +1064,14 @@ const getMemberDetails = (memberIds = [], users = []) => {
 	if (!isEmpty(memberIds) && !isEmpty(users)) {
 		return [...users].reduce(
 			(arr, user) => {
-				let { email, id } = user;
+				let { email, id, _id } = user;
+				if (memberIds.includes(_id.toString())) {
+					arr['memberEmails'].push({ email });
+					arr['userIds'].push({ id });
+				}
 				return {
-					memberEmails: [...arr['memberEmails'], { email }],
-					userIds: [...arr['userIds'], id],
+					memberEmails: arr['memberEmails'],
+					userIds: arr['userIds'],
 				};
 			},
 			{ memberEmails: [], userIds: [] }

--- a/src/resources/topic/topic.controller.js
+++ b/src/resources/topic/topic.controller.js
@@ -14,7 +14,7 @@ module.exports = {
 			console.error('A topic cannot be created with only the creating user');
 			return [];
 		}
-		let recipients = members.map(m => m.memberid);
+		let recipients = members.filter(mem => mem.roles.includes('manager') || mem.roles.includes('reviewer')).map(m => m.memberid);
 		// 2. Return team recipients plus the user that created the message
 		recipients = [...recipients, createdBy];
 		return recipients;


### PR DESCRIPTION
**Issue**
Reported by ONS that some of their team members were receiving unexpected messages relating to data access requests, when they were responsible only for metadata editing.

**Investigation**
After determining that the users were not in the role of manager and should therefore not have received the messages, we looked at the latest feature development in this area which was to allow opt in/out for individual users and add generic team notifications.  By replicating the problem described, we were able to pinpoint a bug which was including all team members if they were opted in to data access request emails.  The metadata editors should not have been opted in and as an additional step, only managers and reviewers for data access request should be included.

**Development**
- Updated message logic to include only reviewers and managers when creating data access request related messages.
- Removed existing access for ONS members to view messages submitted to the data access request team.
