### PR TITLE
IG-2271 - Data Use Register Bulk Upload API

### DIFF
--- a/src/resources/base/entity.js
+++ b/src/resources/base/entity.js
@@ -1,6 +1,8 @@
+import helper from '../utilities/helper.util';
+
 const transform = require('transformobject').transform;
 
-class Entity {
+export default class Entity {
 
     equals (other) {
         if (other instanceof Entity === false) {
@@ -24,6 +26,8 @@ class Entity {
     transformTo(format, {strict} = {strict: false}) {
         return transform(this, format, { strict });
     }
-}
 
-module.exports = Entity;
+    generateId () {
+        return helper.generatedNumericId();
+    }
+}

--- a/src/resources/dataUseRegister/__mocks__/dataUseRegisterUsers.js
+++ b/src/resources/dataUseRegister/__mocks__/dataUseRegisterUsers.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const uploader = {
+	_id: new mongoose.Types.ObjectId(),
+	firstname: 'James',
+	lastname: 'Smith',
+};
+
+export {
+	uploader
+};

--- a/src/resources/dataUseRegister/__mocks__/dataUseRegisters.js
+++ b/src/resources/dataUseRegister/__mocks__/dataUseRegisters.js
@@ -1,0 +1,363 @@
+export const dataUseRegisterUploads = [
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is the project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This is another test data use register",
+        "projectIdText": "this is the other project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "other lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    }
+]
+
+export const dataUseRegisterUploadsWithDuplicates = [
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is the project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is the project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is the project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is the project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is another project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "another organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    },
+    {
+        "projectTitle": "This a test data use register",
+        "projectIdText": "this is another project id",
+        "datasetNames": [
+            "This is the dataset title", "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+        ],
+        "applicantNames": [
+            " Michael Donnelly", "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+        ],
+        "organisationName": "another organisation name",
+        "organisationSector": "organisation sector",
+        "applicantId": "applicant id",
+        "fundersAndSponsors": "funder1 , funder2 , funder3 ",
+        "accreditedResearcherStatus": "accredited Researcher Status",
+        "sublicenceArrangements": "sublicence Arrangements",
+        "laySummary": "another lay Summary",
+        "publicBenefitStatement": "public Benefit Statement",
+        "requestCategoryType": "request Category Type",
+        "technicalSummary": "technical Summary",
+        "otherApprovalCommittees": "other Approval Committees",
+        "projectStartDate": "2021-09-25",
+        "projectEndDate": "2021-09-30",
+        "latestApprovalDate": "2021-09-21",
+        "dataSensitivityLevel": "data Sensitivity Level",
+        "legalBasisForData": "legal Basis For Data",
+        "dutyOfConfidentiality": "duty Of Confidentiality",
+        "nationalDataOptOut": "national Data Opt Out",
+        "requestFrequency": "request Frequency",
+        "dataProcessingDescription": "data Processing Description",
+        "confidentialDataDescription": "confidential Data Description",
+        "accessDate": "2021-09-26",
+        "dataLocation": "data Location",
+        "privacyEnhancements": "privacy Enhancements",
+        "researchOutputs": "research Outputs"
+    }
+]
+
+export const datasets = [
+    {
+        datasetId: "70b4d407-288a-4945-a4d5-506d60715110",
+		pid: "e55df485-5acd-4606-bbb8-668d4c06380a"
+    },
+    {
+        datasetId: "82ef7d1a-98d8-48b6-9acd-461bf2a399c3",
+		pid: "e55df485-5acd-4606-bbb8-668d4c06380a"
+    },
+    {
+        datasetId: "673626f3-bdac-4d32-9bb8-c890b727c0d1",
+		pid: "594d79a4-92b9-4a7f-b991-abf850bf2b67"
+    },
+    {
+        datasetId: "89e57932-ac48-48ac-a6e5-29795bc38b94",
+		pid: "efbd4275-70e2-4887-8499-18b1fb24ce5b"
+    }
+]
+
+export const relatedObjectDatasets = [
+    {
+        objectId: "70b4d407-288a-4945-a4d5-506d60715110",
+        pid: "e55df485-5acd-4606-bbb8-668d4c06380a",
+        objectType: "dataset",
+        user: "James Smith",
+        updated: "2021-24-09T11:01:58.135Z"
+    },
+    {
+        objectId: "82ef7d1a-98d8-48b6-9acd-461bf2a399c3",
+        pid: "e55df485-5acd-4606-bbb8-668d4c06380a",
+        objectType: "dataset",
+        user: "James Smith",
+        updated: "2021-24-09T11:01:58.135Z"
+    },
+    {
+        objectId: "673626f3-bdac-4d32-9bb8-c890b727c0d1",
+        pid: "594d79a4-92b9-4a7f-b991-abf850bf2b67",
+        objectType: "dataset",
+        user: "James Smith",
+        updated: "2021-24-09T11:01:58.135Z"
+    },
+    {
+        objectId: "89e57932-ac48-48ac-a6e5-29795bc38b94",
+        pid: "efbd4275-70e2-4887-8499-18b1fb24ce5b",
+        objectType: "dataset",
+        user: "James Smith",
+        updated: "2021-24-09T11:01:58.135Z"
+    }
+]
+
+export const nonGatewayDatasetNames = [
+    "dataset one", "dataset two", " dataset three", "dataset four"
+]
+
+export const gatewayDatasetNames = [
+    "http://localhost:3000/dataset/f725187f-7352-482b-a43b-64ebc96e66f2", 
+    "http://localhost:3000/dataset/c6d6bbd3-74ed-46af-841d-ac5e05f4da41", 
+    "http://localhost:3000/dataset/e55df485-5acd-4606-bbb8-668d4c06380a"
+]
+
+export const expectedGatewayDatasets = [
+    { datasetid: "1", name: "dataset 1", pid:"111" },
+    { datasetid: "2", name: "dataset 2", pid:"222" },
+    { datasetid: "3", name: "dataset 3", pid:"333" }
+]
+
+export const nonGatewayApplicantNames = [
+    "applicant one", "applicant two", "applicant three", "applicant four"
+]
+
+export const gatewayApplicantNames = [
+    "http://localhost:3000/person/8495781222000176", "http://localhost:3000/person/4495285946631793"
+]
+
+export const expectedGatewayApplicants = [
+    "89e57932-ac48-48ac-a6e5-29795bc38b94", "0cfe60cd-038d-4c03-9a95-894c52135922"
+]

--- a/src/resources/dataUseRegister/__tests__/dataUseRegister.service.test.js
+++ b/src/resources/dataUseRegister/__tests__/dataUseRegister.service.test.js
@@ -1,0 +1,58 @@
+import sinon from 'sinon';
+
+import DataUseRegisterService from '../dataUseRegister.service';
+import DataUseRegisterRepository from '../dataUseRegister.repository';
+import { dataUseRegisterUploadsWithDuplicates, dataUseRegisterUploads } from '../__mocks__/dataUseRegisters';
+
+describe('DataUseRegisterService', function () {
+	describe('filterDuplicateDataUseRegisters', function () {
+		it('filters out data uses that have matching project Ids', async function () {
+			// Arrange
+			const dataUseRegisterRepository = new DataUseRegisterRepository();
+			const dataUseRegisterService = new DataUseRegisterService(dataUseRegisterRepository);
+
+			// Act
+			const result = dataUseRegisterService.filterDuplicateDataUseRegisters(dataUseRegisterUploadsWithDuplicates);
+
+			// Assert
+			expect(dataUseRegisterUploadsWithDuplicates.length).toEqual(6);
+			expect(result.length).toEqual(2);
+			expect(result[0].projectIdText).not.toEqual(result[1].projectIdText);
+			expect(result[0]).toEqual(dataUseRegisterUploadsWithDuplicates[0]);
+		});
+		it('filters out duplicate data uses that match across the following fields: project title, lay summary, organisation name, dataset names and latest approval date', async function () {
+			// Arrange
+			const dataUseRegisterRepository = new DataUseRegisterRepository();
+			const dataUseRegisterService = new DataUseRegisterService(dataUseRegisterRepository);
+
+			// Act
+			const result = dataUseRegisterService.filterDuplicateDataUseRegisters(dataUseRegisterUploadsWithDuplicates);
+
+			// Assert
+			expect(dataUseRegisterUploadsWithDuplicates.length).toEqual(6);
+			expect(result.length).toEqual(2);
+			expect(result[1]).toEqual(dataUseRegisterUploadsWithDuplicates[4]);
+		});
+	});
+
+	describe('filterExistingDataUseRegisters', function () {
+		it('filters out data uses that are found to already exist in the database', async function () {
+			// Arrange
+			const dataUseRegisterRepository = new DataUseRegisterRepository();
+			const dataUseRegisterService = new DataUseRegisterService(dataUseRegisterRepository);
+
+			const checkDataUseRegisterExistsStub = sinon.stub(dataUseRegisterRepository, 'checkDataUseRegisterExists');
+			checkDataUseRegisterExistsStub.onCall(0).returns(false);
+			checkDataUseRegisterExistsStub.onCall(1).returns(true);
+
+			// Act
+			const result = await dataUseRegisterService.filterExistingDataUseRegisters(dataUseRegisterUploads);
+
+			// Assert
+			expect(checkDataUseRegisterExistsStub.calledTwice).toBe(true);
+			expect(dataUseRegisterUploads.length).toBe(2);
+			expect(result.length).toBe(1);
+			expect(result[0].projectIdText).toEqual(dataUseRegisterUploads[0].projectIdText);
+		});
+	});
+});

--- a/src/resources/dataUseRegister/__tests__/dataUseRegister.util.test.js
+++ b/src/resources/dataUseRegister/__tests__/dataUseRegister.util.test.js
@@ -1,0 +1,81 @@
+import sinon from 'sinon';
+import { cloneDeep } from 'lodash';
+
+import dataUseRegisterUtil from '../dataUseRegister.util';
+import { datasets, relatedObjectDatasets, nonGatewayDatasetNames, gatewayDatasetNames, expectedGatewayDatasets, nonGatewayApplicantNames, gatewayApplicantNames, expectedGatewayApplicants } from '../__mocks__/dataUseRegisters';
+import { uploader } from '../__mocks__/dataUseRegisterUsers';
+import * as userRepository from '../../user/user.repository';
+import { datasetService } from '../../dataset/dependency';
+
+describe('DataUseRegisterUtil', function () {
+	beforeAll(function () {
+		process.env.homeURL = 'http://localhost:3000';
+	});
+
+	describe('getLinkedDatasets', function () {
+		it('returns the names of the datasets that could not be found on the Gateway as named datasets', async function () {
+			// Act
+			const result = await dataUseRegisterUtil.getLinkedDatasets(nonGatewayDatasetNames);
+
+			// Assert
+			expect(result).toEqual({ linkedDatasets: [], namedDatasets: nonGatewayDatasetNames });
+		});
+		it('returns the details of datasets that could be found on the Gateway when valid URLs are given', async function () {
+			// Arrange
+			const getDatasetsByPidsStub = sinon.stub(datasetService, 'getDatasetsByPids');
+			getDatasetsByPidsStub.returns(expectedGatewayDatasets);
+
+			// Act
+			const result = await dataUseRegisterUtil.getLinkedDatasets(gatewayDatasetNames);
+
+			// Assert
+			expect(getDatasetsByPidsStub.calledOnce).toBe(true);
+			expect(result).toEqual({ linkedDatasets: expectedGatewayDatasets, namedDatasets: [] });
+		});
+	});
+
+	describe('getLinkedApplicants', function () {
+		it('returns the names of the applicants that could not be found on the Gateway', async function () {
+			// Act
+			const result = await dataUseRegisterUtil.getLinkedApplicants(nonGatewayApplicantNames);
+
+			// Assert
+			expect(result).toEqual({ gatewayApplicants: [], nonGatewayApplicants: nonGatewayApplicantNames });
+		});
+		it('returns the details of applicants that could be found on the Gateway when valid profile URLs are given', async function () {
+			// Arrange
+			const getUsersByIdsStub = sinon.stub(userRepository, 'getUsersByIds');
+			getUsersByIdsStub.returns([{_id:'89e57932-ac48-48ac-a6e5-29795bc38b94'}, {_id:'0cfe60cd-038d-4c03-9a95-894c52135922'}]);
+
+			// Act
+			const result = await dataUseRegisterUtil.getLinkedApplicants(gatewayApplicantNames);
+
+			// Assert
+			expect(getUsersByIdsStub.calledOnce).toBe(true);
+			expect(result).toEqual({ gatewayApplicants: expectedGatewayApplicants, nonGatewayApplicants: [] });
+		});
+	});
+
+	describe('buildRelatedObjects', function () {
+		it('filters out data uses that are found to already exist in the database', async function () {
+			// Arrange
+			const data = cloneDeep(datasets);
+			sinon.stub(Date, 'now').returns('2021-24-09T11:01:58.135Z');
+
+			// Act
+			const result = dataUseRegisterUtil.buildRelatedObjects(uploader, data);
+
+			// Assert
+			expect(result.length).toBe(data.length);
+			expect(result).toEqual(relatedObjectDatasets);
+		});
+
+		afterEach(function () {
+			sinon.restore();
+		});
+	});
+
+	afterAll(function () {
+		delete process.env.homeURL;
+	});
+});

--- a/src/resources/dataUseRegister/dataUseRegister.controller.js
+++ b/src/resources/dataUseRegister/dataUseRegister.controller.js
@@ -105,25 +105,14 @@ export default class DataUseRegisterController extends Controller {
 	}
 
 	async uploadDataUseRegisters(req, res) {
-		// Model for the data use entity
-
-		// Flag if uploaded version
-
-		// POST to create the data use entries
-
-		// Pre-populate the related resources with a fixed message
-
-		// POST to check for duplicates and return any found datasets, applicants or outputs
 		try {
-			const { placeholder } = req;
-
-			const result = await this.dataUseRegisterService.uploadDataUseRegister(placeholder).catch(err => {
-				logger.logError(err, logCategory);
-			});
-
+			const { teamId, dataUses } = req.body;
+			const requestingUser = req.user;
+			const result = await this.dataUseRegisterService.uploadDataUseRegisters(requestingUser, teamId, dataUses);
 			// Return success
-			return res.status(200).json({
+			return res.status(result.uploadedCount > 0 ? 201 : 200).json({
 				success: true,
+				result,
 			});
 		} catch (err) {
 			// Return error response if something goes wrong

--- a/src/resources/dataUseRegister/dataUseRegister.controller.js
+++ b/src/resources/dataUseRegister/dataUseRegister.controller.js
@@ -103,4 +103,35 @@ export default class DataUseRegisterController extends Controller {
 			});
 		}
 	}
+
+	async uploadDataUseRegisters(req, res) {
+		// Model for the data use entity
+
+		// Flag if uploaded version
+
+		// POST to create the data use entries
+
+		// Pre-populate the related resources with a fixed message
+
+		// POST to check for duplicates and return any found datasets, applicants or outputs
+		try {
+			const { placeholder } = req;
+
+			const result = await this.dataUseRegisterService.uploadDataUseRegister(placeholder).catch(err => {
+				logger.logError(err, logCategory);
+			});
+
+			// Return success
+			return res.status(200).json({
+				success: true,
+			});
+		} catch (err) {
+			// Return error response if something goes wrong
+			logger.logError(err, logCategory);
+			return res.status(500).json({
+				success: false,
+				message: 'A server error occurred, please try again',
+			});
+		}
+	}
 }

--- a/src/resources/dataUseRegister/dataUseRegister.entity.js
+++ b/src/resources/dataUseRegister/dataUseRegister.entity.js
@@ -3,6 +3,8 @@ import Entity from '../base/entity';
 export default class DataUseRegisterClass extends Entity {
 	constructor(obj) {
 		super();
+		if(!obj.id) obj.id = this.generateId();
+		obj.type = 'dataUseRegister';
 		Object.assign(this, obj);
 	}
 }

--- a/src/resources/dataUseRegister/dataUseRegister.model.js
+++ b/src/resources/dataUseRegister/dataUseRegister.model.js
@@ -5,11 +5,11 @@ import constants from './../../resources/utilities/constants.util';
 
 const dataUseRegisterSchema = new Schema(
 	{
-		id: Number,
-		type: String,
+		id: { type: Number, required: true },
+		type: { type: String, required: true },
 		activeflag: { type: String, required: true, enum: Object.values(constants.dataUseRegisterStatus) },
 		updatedon: Date,
-		counter: Number,
+		counter: { type: Number, default: 0 },
 		discourseTopicId: Number,
 		relatedObjects: [
 			{
@@ -22,16 +22,18 @@ const dataUseRegisterSchema = new Schema(
 			},
 		],
 		keywords: [String],
+		manualUpload: Boolean,
 
 		lastActivity: Date,
-		projectTitle: String,
+		projectTitle: { type: String },
 		projectId: { type: Schema.Types.ObjectId, ref: 'data_request' },
 		projectIdText: String, //Project ID
 		datasetTitles: [{ type: String }], //Dataset Name(s)
 		datasetIds: [{ type: String }],
+		datasetPids: [{ type: String }],
 		publisher: { type: Schema.Types.ObjectId, ref: 'Publisher', required: true },
 		user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-		organisationName: String, //Organisation Name
+		organisationName: { type: String }, //Organisation Name
 		organisationSector: String, //Organisation Sector
 		gatewayApplicants: [
 			{
@@ -48,7 +50,7 @@ const dataUseRegisterSchema = new Schema(
 		publicBenefitStatement: String, //Public Benefit Statement
 		requestCategoryType: String, //Request Category Type
 		technicalSummary: String, //Technical Summary
-		otherApprovalCommittees: String, //Other Approval Committees
+		otherApprovalCommittees: [{type: String}], //Other Approval Committees
 		projectStartDate: Date, //Project Start Date
 		projectEndDate: Date, //Project End Date
 		latestApprovalDate: Date, //Latest Approval Date
@@ -62,12 +64,13 @@ const dataUseRegisterSchema = new Schema(
 		accessDate: Date, //Release/Access Date
 		dataLocation: String, //TRE Or Any Other Specified Location
 		privacyEnhancements: String, //How Has Data Been Processed To Enhance Privacy
-		researchOutputs: String, //Link To Research Outputs
+		researchOutputs: [{type: String}], //Link To Research Outputs
 	},
 	{
 		timestamps: true,
 		toJSON: { virtuals: true },
 		toObject: { virtuals: true },
+		strict: false
 	}
 );
 

--- a/src/resources/dataUseRegister/dataUseRegister.repository.js
+++ b/src/resources/dataUseRegister/dataUseRegister.repository.js
@@ -7,16 +7,38 @@ export default class DataUseRegisterRepository extends Repository {
 		this.dataUseRegister = DataUseRegister;
 	}
 
-	async getDataUseRegister(query, options) {
+	getDataUseRegister(query, options) {
 		return this.findOne(query, options);
 	}
 
-	async getDataUseRegisters(query) {
+	getDataUseRegisters(query) {
 		const options = { lean: true };
 		return this.find(query, options);
 	}
 
-	async updateDataUseRegister(id, body) {
+	updateDataUseRegister(id, body) {
 		return this.update(id, body);
+	}
+
+	uploadDataUseRegisters(dataUseRegisters) {
+		return this.dataUseRegister.insertMany(dataUseRegisters);
+	}
+
+	async checkDataUseRegisterExists(dataUseRegister) {
+		const { projectIdText, projectTitle, laySummary, organisationName, datasetTitles, latestApprovalDate } = dataUseRegister;
+		const duplicatesFound = await this.dataUseRegister.countDocuments({
+			$or: [
+				{ projectIdText },
+				{
+					projectTitle,
+					laySummary,
+					organisationName,
+					datasetTitles,
+					latestApprovalDate,
+				},
+			],
+		});
+
+		return duplicatesFound > 0;
 	}
 }

--- a/src/resources/dataUseRegister/dataUseRegister.route.js
+++ b/src/resources/dataUseRegister/dataUseRegister.route.js
@@ -60,6 +60,19 @@ const validateViewRequest = (req, res, next) => {
 	next();
 };
 
+const validateUploadRequest = (req, res, next) => {
+	const { placeholder } = req.body;
+
+	if (!req) {
+		return res.status(400).json({
+			success: false,
+			message: 'You must provide...',
+		});
+	}
+
+	next();
+};
+
 const authorizeView = async (req, res, next) => {
 	const requestingUser = req.user;
 	const { team } = req.query;
@@ -102,6 +115,11 @@ const authorizeUpdate = async (req, res, next) => {
 	next();
 };
 
+const authorizeUpload = async (req, res, next) => {
+	
+	next();
+}
+
 // @route   GET /api/v2/data-use-registers/id
 // @desc    Returns a dataUseRegister based on dataUseRegister ID provided
 // @access  Public
@@ -134,6 +152,18 @@ router.patch(
 	authorizeUpdate,
 	logger.logRequestMiddleware({ logCategory, action: 'Updated dataUseRegister data' }),
 	(req, res) => dataUseRegisterController.updateDataUseRegister(req, res)
+);
+
+// @route   POST /api/v2/data-use-registers/upload
+// @desc    Accepts a bulk upload of data uses with built-in duplicate checking and rejection
+// @access  Public
+router.post(
+	'/upload',
+	passport.authenticate('jwt'),
+	validateUploadRequest,
+	authorizeUpload,
+	logger.logRequestMiddleware({ logCategory, action: 'Bulk uploaded data uses' }),
+	(req, res) => dataUseRegisterController.uploadDataUseRegisters(req, res)
 );
 
 module.exports = router;

--- a/src/resources/dataUseRegister/dataUseRegister.service.js
+++ b/src/resources/dataUseRegister/dataUseRegister.service.js
@@ -21,4 +21,8 @@ export default class DataUseRegisterService {
 
 		return this.dataUseRegisterRepository.updateDataUseRegister({ _id: id }, body);
 	}
+
+	uploadDataUseRegister(placeholder) {
+		return;
+	}
 }

--- a/src/resources/dataUseRegister/dataUseRegister.service.js
+++ b/src/resources/dataUseRegister/dataUseRegister.service.js
@@ -1,3 +1,5 @@
+import dataUseRegisterUtil from './dataUseRegister.util';
+
 export default class DataUseRegisterService {
 	constructor(dataUseRegisterRepository) {
 		this.dataUseRegisterRepository = dataUseRegisterRepository;
@@ -18,11 +20,77 @@ export default class DataUseRegisterService {
 	updateDataUseRegister(id, body = {}) {
 		// Protect for no id passed
 		if (!id) return;
-
+		
 		return this.dataUseRegisterRepository.updateDataUseRegister({ _id: id }, body);
 	}
 
-	uploadDataUseRegister(placeholder) {
-		return;
+	/**
+	 * Upload Data Use Registers
+	 *
+	 * @desc    Accepts multiple data uses to upload and a team identifier indicating which Custodian team to add the data uses to.
+	 *
+	 * @param 	{String} 			teamId 	    	Array of data use objects to filter until uniqueness exists
+	 * @param 	{Array<Object>} 	dataUseUploads 	 Array of data use objects to filter until uniqueness exists
+	 * @returns {Object}		Object containing the details of the upload operation including number of duplicates found in payload, database and number successfully added
+	 */
+	async uploadDataUseRegisters(creatorUser, teamId, dataUseRegisterUploads = []) {
+		const dedupedDataUseRegisters = this.filterDuplicateDataUseRegisters(dataUseRegisterUploads);
+
+		const dataUseRegisters = await dataUseRegisterUtil.buildDataUseRegisters(creatorUser, teamId, dedupedDataUseRegisters);
+
+		const newDataUseRegisters = await this.filterExistingDataUseRegisters(dataUseRegisters);
+
+		const uploadedDataUseRegisters = await this.dataUseRegisterRepository.uploadDataUseRegisters(newDataUseRegisters);
+
+		return {
+			uploadedCount: uploadedDataUseRegisters.length,
+			duplicateCount: dataUseRegisterUploads.length - newDataUseRegisters.length,
+			uploaded: uploadedDataUseRegisters,
+		};
+	}
+
+	/**
+	 * Filter Duplicate Data Uses
+	 *
+	 * @desc    Accepts multiple data uses and outputs a unique list of data uses based on each entities properties.
+	 * 			A duplicate project id is automatically indicates a duplicate entry as the id must be unique.
+	 * 			Alternatively, a combination of matching title, summary, organisation name, dataset titles and latest approval date indicates a duplicate entry.
+	 * @param 	{Array<Object>} 	dataUses 	    	Array of data use objects to filter until uniqueness exists
+	 * @returns {Array<Object>}		Filtered array of data uses assumed unique based on filter criteria
+	 */
+	filterDuplicateDataUseRegisters(dataUses) {
+		return dataUses.reduce((arr, dataUse) => {
+			const isDuplicate = arr.some(
+				el =>
+					el.projectIdText === dataUse.projectIdText ||
+					(el.projectTitle === dataUse.projectTitle &&
+						el.laySummary === dataUse.laySummary &&
+						el.organisationName === dataUse.organisationName &&
+						el.datasetTitles === dataUse.datasetTitles &&
+						el.latestApprovalDate === dataUse.latestApprovalDate)
+			);
+			if (!isDuplicate) arr = [...arr, dataUse];
+			return arr;
+		}, []);
+	}
+
+	/**
+	 * Filter Existing Data Uses
+	 *
+	 * @desc    Accepts multiple data uses, verifying each in turn is considered 'new' to the database, then outputs the list of data uses.
+	 * 			A duplicate project id is automatically indicates a duplicate entry as the id must be unique.
+	 * 			Alternatively, a combination of matching title, summary, organisation name and dataset titles indicates a duplicate entry.
+	 * @param 	{Array<Object>} 	dataUses 	    	Array of data use objects to iterate through and check for existence in database
+	 * @returns {Array<Object>}		Filtered array of data uses assumed to be 'new' to the database based on filter criteria
+	 */
+	async filterExistingDataUseRegisters(dataUses) {
+		const newDataUses = [];
+
+		for (const dataUse of dataUses) {
+			const exists = await this.dataUseRegisterRepository.checkDataUseRegisterExists(dataUse);
+			if (exists === false) newDataUses.push(dataUse);
+		}
+
+		return newDataUses;
 	}
 }

--- a/src/resources/dataUseRegister/dataUseRegister.util.js
+++ b/src/resources/dataUseRegister/dataUseRegister.util.js
@@ -138,7 +138,7 @@ const buildDataUseRegisters = async (creatorUser, teamId, dataUses = []) => {
 const getLinkedDatasets = async (datasetNames = []) => {
 	const unverifiedDatasetPids = [];
 	const namedDatasets = [];
-	const validLinkRegexp = new RegExp(`^${process.env.homeURL.replace('//', '//')}\/dataset\/([a-f|\\d|-]+)\/?$`, 'i');
+	const validLinkRegexp = new RegExp(`^${process.env.homeURL}\/dataset\/([a-f|\\d|-]+)\/?$`, 'i');
 
 	for (const datasetName of datasetNames) {
 		const [, datasetPid] = validLinkRegexp.exec(datasetName) || [];
@@ -170,7 +170,7 @@ const getLinkedDatasets = async (datasetNames = []) => {
 const getLinkedApplicants = async (applicantNames = []) => {
 	const unverifiedUserIds = [];
 	const nonGatewayApplicants = [];
-	const validLinkRegexp = new RegExp(`^${process.env.homeURL.replace('//', '//')}\/person\/(\\d+)\/?$`, 'i');
+	const validLinkRegexp = new RegExp(`^${process.env.homeURL}\/person\/(\\d+)\/?$`, 'i');
 
 	for (const applicantName of applicantNames) {
 		const [, userId] = validLinkRegexp.exec(applicantName) || [];

--- a/src/resources/dataUseRegister/dataUseRegister.util.js
+++ b/src/resources/dataUseRegister/dataUseRegister.util.js
@@ -1,0 +1,217 @@
+import moment from 'moment';
+import { isEmpty } from 'lodash';
+import DataUseRegister from './dataUseRegister.entity';
+import { getUsersByIds } from '../user/user.repository';
+import { datasetService } from '../dataset/dependency';
+
+/**
+ * Build Data Use Registers
+ *
+ * @desc    Accepts a creator user object, the custodian/publisher team identifier to create the data use registers against and an array of data use POJOs to map to data use models.
+ * 			The function drops out invalid dates, empty fields and removes white space from all strings before constructing the model instances.
+ * @param 	{String} 	creatorUser 	    	User object from the authenticated request who is creating the data use registers
+ * @param 	{String} 	teamId 	    			Custodian/publisher team identifier to identify who to create the data uses against
+ * @param 	{String} 	dataUses 	    		Array of data use register shaped POJOs to map to data use models
+ * @returns {Array<Object>}						Array of data use register models
+ */
+const buildDataUseRegisters = async (creatorUser, teamId, dataUses = []) => {
+	const dataUseRegisters = [];
+
+	for (const obj of dataUses) {
+		// Handle dataset linkages
+		const { linkedDatasets = [], namedDatasets = [] } = await getLinkedDatasets(
+			obj.datasetNames &&
+				obj.datasetNames
+					.toString()
+					.split(',')
+					.map(el => {
+						if (!isEmpty(el)) return el.trim();
+					})
+		);
+		const datasetTitles = [...linkedDatasets.map(dataset => dataset.name), ...namedDatasets];
+		const datasetIds = [...linkedDatasets.map(dataset => dataset.datasetid)];
+		const datasetPids = [...linkedDatasets.map(dataset => dataset.pid)];
+
+		// Handle applicant linkages
+		const { gatewayApplicants, nonGatewayApplicants } = await getLinkedApplicants(
+			obj.applicantNames &&
+				obj.applicantNames
+					.toString()
+					.split(',')
+					.map(el => {
+						if (!isEmpty(el)) return el.trim();
+					})
+		);
+
+		// Create related objects
+		const relatedObjects = buildRelatedObjects(creatorUser, linkedDatasets);
+
+		// Handle comma separated fields
+		const fundersAndSponsors =
+			obj.fundersAndSponsors &&
+			obj.fundersAndSponsors
+				.toString()
+				.split(',')
+				.map(el => {
+					if (!isEmpty(el)) return el.trim();
+				});
+		const researchOutputs =
+			obj.researchOutputs &&
+			obj.researchOutputs
+				.toString()
+				.split(',')
+				.map(el => {
+					if (!isEmpty(el)) return el.trim();
+				});
+		const otherApprovalCommittees =
+			obj.otherApprovalCommittees &&
+			obj.otherApprovalCommittees
+				.toString()
+				.split(',')
+				.map(el => {
+					if (!isEmpty(el)) return el.trim();
+				});
+
+		// Handle expected dates
+		const projectStartDate = moment(obj.projectStartDate, 'YYYY-MM-DD');
+		const projectEndDate = moment(obj.projectEndDate, 'YYYY-MM-DD');
+		const latestApprovalDate = moment(obj.latestApprovalDate, 'YYYY-MM-DD');
+		const accessDate = moment(obj.accessDate, 'YYYY-MM-DD');
+
+		// Clean and assign to model
+		dataUseRegisters.push(
+			new DataUseRegister({
+				...(obj.projectTitle && { projectTitle: obj.projectTitle.toString().trim() }),
+				...(obj.projectIdText && { projectIdText: obj.projectIdText.toString().trim() }),
+				...(obj.organisationName && { organisationName: obj.organisationName.toString().trim() }),
+				...(obj.organisationSector && { organisationSector: obj.organisationSector.toString().trim() }),
+				...(obj.applicantId && { applicantId: obj.applicantId.toString().trim() }),
+				...(obj.accreditedResearcherStatus && { accreditedResearcherStatus: obj.accreditedResearcherStatus.toString().trim() }),
+				...(obj.sublicenceArrangements && { sublicenceArrangements: obj.sublicenceArrangements.toString().trim() }),
+				...(obj.laySummary && { laySummary: obj.laySummary.toString().trim() }),
+				...(obj.publicBenefitStatement && { publicBenefitStatement: obj.publicBenefitStatement.toString().trim() }),
+				...(obj.requestCategoryType && { requestCategoryType: obj.requestCategoryType.toString().trim() }),
+				...(obj.technicalSummary && { technicalSummary: obj.technicalSummary.toString().trim() }),
+				...(obj.dataSensitivityLevel && { dataSensitivityLevel: obj.dataSensitivityLevel.toString().trim() }),
+				...(obj.legalBasisForData && { legalBasisForData: obj.legalBasisForData.toString().trim() }),
+				...(obj.nationalDataOptOut && { nationalDataOptOut: obj.nationalDataOptOut.toString().trim() }),
+				...(obj.requestFrequency && { requestFrequency: obj.requestFrequency.toString().trim() }),
+				...(obj.dataProcessingDescription && { dataProcessingDescription: obj.dataProcessingDescription.toString().trim() }),
+				...(obj.confidentialDataDescription && { confidentialDataDescription: obj.confidentialDataDescription.toString().trim() }),
+				...(obj.dataLocation && { dataLocation: obj.dataLocation.toString().trim() }),
+				...(obj.privacyEnhancements && { privacyEnhancements: obj.privacyEnhancements.toString().trim() }),
+				...(projectStartDate.isValid() && { projectStartDate }),
+				...(projectEndDate.isValid() && { projectEndDate }),
+				...(latestApprovalDate.isValid() && { latestApprovalDate }),
+				...(accessDate.isValid() && { accessDate }),
+				...(!isEmpty(datasetTitles) && { datasetTitles }),
+				...(!isEmpty(datasetIds) && { datasetIds }),
+				...(!isEmpty(datasetPids) && { datasetPids }),
+				...(!isEmpty(gatewayApplicants) && { gatewayApplicants }),
+				...(!isEmpty(nonGatewayApplicants) && { nonGatewayApplicants }),
+				...(!isEmpty(fundersAndSponsors) && { fundersAndSponsors }),
+				...(!isEmpty(researchOutputs) && { researchOutputs }),
+				...(!isEmpty(otherApprovalCommittees) && { otherApprovalCommittees }),
+				...(!isEmpty(relatedObjects) && { relatedObjects }),
+				activeflag: 'inReview',
+				publisher: teamId,
+				user: creatorUser._id,
+				updatedon: Date.now(),
+				lastActivity: Date.now(),
+				manualUpload: true
+			})
+		);
+	}
+
+	return dataUseRegisters;
+};
+
+/**
+ * Get Linked Datasets
+ *
+ * @desc    Accepts a comma separated string containing dataset names which can be in the form of text based names or URLs belonging to the Gateway which resolve to a dataset page, or a mix of both.
+ * 			The function separates URLs and uses regex to locate a suspected dataset PID to use in a search against the Gateway database.  If a match is found, the entry is considered a linked dataset.
+ * 			Entries which cannot be matched are returned as named datasets.
+ * @param 	{String} 	datasetNames 	    	A comma separated string representation of the dataset names to attempt to find and link to existing Gateway datasets
+ * @returns {Object}							An object containing linked and named datasets in separate arrays
+ */
+const getLinkedDatasets = async (datasetNames = []) => {
+	const unverifiedDatasetPids = [];
+	const namedDatasets = [];
+	const validLinkRegexp = new RegExp(`^${process.env.homeURL.replace('//', '//')}\/dataset\/([a-f|\\d|-]+)\/?$`, 'i');
+
+	for (const datasetName of datasetNames) {
+		const [, datasetPid] = validLinkRegexp.exec(datasetName) || [];
+		if (datasetPid) {
+			unverifiedDatasetPids.push(datasetPid);
+		} else {
+			namedDatasets.push(datasetName);
+		}
+	}
+
+	const linkedDatasets = isEmpty(unverifiedDatasetPids)
+		? []
+		: (await datasetService.getDatasetsByPids(unverifiedDatasetPids)).map(dataset => {
+				return { datasetid: dataset.datasetid, name: dataset.name, pid: dataset.pid };
+		  });
+
+	return { linkedDatasets, namedDatasets };
+};
+
+/**
+ * Get Linked Applicants
+ *
+ * @desc    Accepts a comma separated string containing applicant names which can be in the form of text based names or URLs belonging to the Gateway which resolve to a users profile page, or a mix of both.
+ * 			The function separates URLs and uses regex to locate a suspected user ID to use in a search against the Gateway database.  If a match is found, the entry is considered a Gateway applicant.
+ * 			Entries which cannot be matched are returned as non Gateway applicants.  Failed attempts at adding URLs which do not resolve are excluded.
+ * @param 	{String} 	datasetNames 	    	A comma separated string representation of the applicant(s) names to attempt to find and link to existing Gateway users
+ * @returns {Object}							An object containing Gateway applicants and non Gateway applicants in separate arrays
+ */
+const getLinkedApplicants = async (applicantNames = []) => {
+	const unverifiedUserIds = [];
+	const nonGatewayApplicants = [];
+	const validLinkRegexp = new RegExp(`^${process.env.homeURL.replace('//', '//')}\/person\/(\\d+)\/?$`, 'i');
+
+	for (const applicantName of applicantNames) {
+		const [, userId] = validLinkRegexp.exec(applicantName) || [];
+		if (userId) {
+			unverifiedUserIds.push(userId);
+		} else {
+			nonGatewayApplicants.push(applicantName);
+		}
+	}
+
+	const gatewayApplicants = isEmpty(unverifiedUserIds) ? [] : (await getUsersByIds(unverifiedUserIds)).map(el => el._id);
+
+	return { gatewayApplicants, nonGatewayApplicants };
+};
+
+/**
+ * Build Related Objects
+ *
+ * @desc    Accepts an array of datasets and outputs an array of related objects which can be assigned to an entity to show the relationship to the datasets.
+ * 			Related objects contain the 'objectId' (dataset version identifier), 'pid', 'objectType' (dataset), 'updated' date and 'user' that created the linkage.
+ * @param 	{Object} 			creatorUser 	A user object to allow the assignment of their name to the creator of the linkage
+ * @param 	{Array<Object>} 	datasets 	    An array of dataset objects containing the necessary properties to assemble a related object record reference
+ * @returns {Array<Object>}						An array containing the assembled related objects relative to the datasets provided
+ */
+const buildRelatedObjects = (creatorUser, datasets = []) => {
+	const { firstname, lastname } = creatorUser;
+	return datasets.map(dataset => {
+		const { datasetId: objectId, pid } = dataset;
+		return {
+			objectId,
+			pid,
+			objectType: 'dataset',
+			user: `${firstname} ${lastname}`,
+			updated: Date.now(),
+		};
+	});
+};
+
+export default {
+	buildDataUseRegisters,
+	getLinkedDatasets,
+	getLinkedApplicants,
+	buildRelatedObjects
+};

--- a/src/resources/dataset/dataset.repository.js
+++ b/src/resources/dataset/dataset.repository.js
@@ -20,7 +20,7 @@ export default class DatasetRepository extends Repository {
 			return {};
 		}
 		// Get dataset versions using pid
-		const query = { pid, fields:'datasetid,datasetVersion,activeflag' };
+		const query = { pid, fields: 'datasetid,datasetVersion,activeflag' };
 		const options = { lean: true };
 		const datasets = await this.find(query, options);
 		// Create revision structure
@@ -33,5 +33,14 @@ export default class DatasetRepository extends Repository {
 			}
 			return obj;
 		}, {});
+	}
+
+	getDatasetsByPids(pids) {
+		return this.dataset.aggregate([
+			{ $match: { pid: { $in: pids } } },
+			{ $project: { pid: 1, datasetid: 1, name: 1, createdAt: 1 } },
+			{ $sort: { createdAt: -1 } },
+			{ $group: { _id: '$pid', pid: { $first: '$pid' }, datasetid: { $first: '$datasetid' }, name: { $first: '$name' } } },
+		]);
 	}
 }

--- a/src/resources/dataset/dataset.service.js
+++ b/src/resources/dataset/dataset.service.js
@@ -110,4 +110,8 @@ export default class DatasetService {
 		});
 		return dataset;
 	}
+
+	getDatasetsByPids(pids) {
+		return this.datasetRepository.getDatasetsByPids(pids);
+	}
 }

--- a/src/resources/user/user.repository.js
+++ b/src/resources/user/user.repository.js
@@ -25,6 +25,10 @@ export async function getUserByUserId(id) {
 	return await UserModel.findOne({ id }).exec();
 }
 
+export async function getUsersByIds(userIds) {
+	return await UserModel.find({ id: { $in: userIds } }, '_id').lean();
+}
+
 export async function getServiceAccountByClientCredentials(clientId, clientSecret) {
 	// 1. Locate service account by clientId, return undefined if no document located
 	const id = clientId.toString();


### PR DESCRIPTION
**Description**

Introducing a new endpoint to the Data Use Register API to allow the bulk upload of data uses via a spreadsheet on the front end.  Majority of validation is carried out on front end as the spreadsheet is parsed.  The backend validation is limited to the Mongoose model definition which is set specifically to not be 'strict'.  The upload validation can be circumvented by an administrator of the Gateway application, meaning the backend validation must be more forgiving.

New data uses are uploaded against the team specified in the payload and are appended with a flag indicating the source was a manual upload in the 'manualUpload' boolean property of the model.

Users have the capability to provide URLs pointing to the Gateway in order to link specific datasets and applicants to the data use.  The API parses these comma separated fields, determining 'gateway' and 'non-gateway' entities.  A successful lookup to a database entity creates a more significant link in the model, which can later be used in lookup or population queries.

Related objects are populated automatically by datasets that are found to exist on the Gateway and are provided in the upload.

**Development**

- Added new endpoint for bulk upload (POST /api/v2/data-use-registers/upload)
- Added middleware in data use register route to challenge authorisation to use bulk upload (team member or admin)
- Added supporting unit tests for service and util functions containing complicated logic