### PR TITLE
SUPP-655 - Response limiting for API v2 entity endpoints

### DIFF
--- a/src/config/middleware.js
+++ b/src/config/middleware.js
@@ -1,0 +1,24 @@
+import { has, isNaN } from 'lodash';
+
+export const resultLimit = (req, res, next, allowedLimit) => {
+    let error;
+    if(has(req.query, 'limit')) {
+        const requestedLimit = parseInt(req.query.limit);
+
+        if(isNaN(requestedLimit)) {
+		    error = `The result limit parameter provided must be a numeric value.`;
+        }
+        else if (requestedLimit > allowedLimit){
+		    error = `Maximum request limit exceeded.  You may only request up to a maximum of ${allowedLimit} records per page.  Please use the page query parameter to request further data.`;
+        }
+    }
+
+	if (error) {
+		return res.status(400).json({
+			success: false,
+			message: error,
+		});
+	}
+
+	next();
+};

--- a/src/resources/base/repository.js
+++ b/src/resources/base/repository.js
@@ -48,7 +48,7 @@ export default class Repository {
 
 		// Pagination
 		const page = query.page * 1 || 1;
-		const limit = query.limit * 1 || null;
+		const limit = query.limit * 1 || 500;
 		const skip = (page - 1) * limit;
 		results = results.skip(skip).limit(limit);
 

--- a/src/resources/cohort/cohort.route.js
+++ b/src/resources/cohort/cohort.route.js
@@ -2,6 +2,7 @@ import express from 'express';
 import CohortController from './cohort.controller';
 import { cohortService } from './dependency';
 import { logger } from '../utilities/logger';
+import { resultLimit } from '../../config/middleware';
 
 const router = express.Router();
 const cohortController = new CohortController(cohortService);
@@ -17,7 +18,7 @@ router.get('/:id', logger.logRequestMiddleware({ logCategory, action: 'Viewed co
 // @route   GET /api/v1/cohorts
 // @desc    Returns a collection of cohorts based on supplied query parameters
 // @access  Public
-router.get('/', logger.logRequestMiddleware({ logCategory, action: 'Viewed cohorts data' }), (req, res) =>
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), logger.logRequestMiddleware({ logCategory, action: 'Viewed cohorts data' }), (req, res) =>
 	cohortController.getCohorts(req, res)
 );
 

--- a/src/resources/cohortprofiling/cohortprofiling.route.js
+++ b/src/resources/cohortprofiling/cohortprofiling.route.js
@@ -1,7 +1,9 @@
 import express from 'express';
 import CohortProfilingController from './cohortprofiling.controller';
 import { cohortProfilingService } from './dependency';
+import { resultLimit } from '../../config/middleware';
 import multer from 'multer';
+
 const upload = multer();
 const cohortProfilingController = new CohortProfilingController(cohortProfilingService);
 
@@ -15,7 +17,7 @@ router.get('/:pid/:tableName/:variable', (req, res) => cohortProfilingController
 // @route   GET api/v1/cohortprofiling
 // @desc    Returns a collection of cohort profiling data based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => cohortProfilingController.getCohortProfiling(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => cohortProfilingController.getCohortProfiling(req, res));
 
 // @route   POST api/v1/cohortprofiling
 // @desc    Consumes a JSON file containing cohort profiling data, transforms it and saves to MongoDB.

--- a/src/resources/course/v2/course.route.js
+++ b/src/resources/course/v2/course.route.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import CourseController from './course.controller';
 import { courseService } from './dependency';
+import { resultLimit } from '../../../config/middleware';
 
 const router = express.Router();
 const courseController = new CourseController(courseService);
@@ -13,6 +14,6 @@ router.get('/:id', (req, res) => courseController.getCourse(req, res));
 // @route   GET /api/v2/courses
 // @desc    Returns a collection of courses based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => courseController.getCourses(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => courseController.getCourses(req, res));
 
 module.exports = router;

--- a/src/resources/dataset/v2/dataset.route.js
+++ b/src/resources/dataset/v2/dataset.route.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import DatasetController from '../dataset.controller';
 import { datasetService } from '../dependency';
+import { resultLimit } from '../../../config/middleware';
 
 const router = express.Router();
 const datasetController = new DatasetController(datasetService);
@@ -13,6 +14,6 @@ router.get('/:id', (req, res) => datasetController.getDataset(req, res));
 // @route   GET /api/v2/datasets
 // @desc    Returns a collection of datasets based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => datasetController.getDatasets(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => datasetController.getDatasets(req, res));
 
 module.exports = router;

--- a/src/resources/paper/v2/paper.route.js
+++ b/src/resources/paper/v2/paper.route.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import PaperController from '../paper.controller';
 import { paperService } from '../dependency';
+import { resultLimit } from '../../../config/middleware';
 
 const router = express.Router();
 const paperController = new PaperController(paperService);
@@ -13,6 +14,6 @@ router.get('/:id', (req, res) => paperController.getPaper(req, res));
 // @route   GET /api/v2/papers
 // @desc    Returns a collection of papers based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => paperController.getPapers(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => paperController.getPapers(req, res));
 
 module.exports = router;

--- a/src/resources/project/v2/project.route.js
+++ b/src/resources/project/v2/project.route.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import ProjectController from '../project.controller';
 import { projectService } from '../dependency';
+import { resultLimit } from '../../../config/middleware';
 
 const router = express.Router();
 const projectController = new ProjectController(projectService);
@@ -13,6 +14,6 @@ router.get('/:id', (req, res) => projectController.getProject(req, res));
 // @route   GET /api/v2/projects
 // @desc    Returns a collection of projects based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => projectController.getProjects(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => projectController.getProjects(req, res));
 
 module.exports = router;

--- a/src/resources/tool/v2/tool.route.js
+++ b/src/resources/tool/v2/tool.route.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import ToolController from './tool.controller';
 import { toolService } from './dependency';
+import { resultLimit } from '../../../config/middleware';
 
 const router = express.Router();
 const toolController = new ToolController(toolService);
@@ -13,6 +14,6 @@ router.get('/:id', (req, res) => toolController.getTool(req, res));
 // @route   GET /api/v2/tools
 // @desc    Returns a collection of tools based on supplied query parameters
 // @access  Public
-router.get('/', (req, res) => toolController.getTools(req, res));
+router.get('/', (req, res, next) => resultLimit(req, res, next, 100), (req, res) => toolController.getTools(req, res));
 
 module.exports = router;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1823,7 +1823,7 @@ paths:
       summary: Returns a list of dataset objects
       tags:
         - Datasets v2.0
-      description: Version 2.0 of the datasets API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case.  The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than.  Using dot notation, any field can be queried, please see some examples below.
+      description: Version 2.0 of the datasets API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case.  The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than.  Using dot notation, any field can be queried, please see some examples below.  Note - This response is limited to 100 records by default.  Please use the 'page' query parameter to access records beyond the first 100.  The 'limit' query parameter can therefore only be specified up to a maximum of 100.
       parameters:
         - name: search
           in: query
@@ -2201,7 +2201,7 @@ paths:
           schema:
             type: boolean
           example: true
-      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.  Note - This response is limited to 100 records by default.  Please use the 'page' query parameter to access records beyond the first 100.  The 'limit' query parameter can therefore only be specified up to a maximum of 100.
       responses:
         '200':
           description: Successful response containing a list of projects matching query parameters
@@ -2489,7 +2489,7 @@ paths:
           schema:
             type: boolean
           example: true
-      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.  Note - This response is limited to 100 records by default.  Please use the 'page' query parameter to access records beyond the first 100.  The 'limit' query parameter can therefore only be specified up to a maximum of 100.
       responses:
         '200':
           description: Successful response containing a list of papers matching query parameters
@@ -2771,7 +2771,7 @@ paths:
           schema:
             type: boolean
           example: true
-      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.  Note - This response is limited to 100 records by default.  Please use the 'page' query parameter to access records beyond the first 100.  The 'limit' query parameter can therefore only be specified up to a maximum of 100.
       responses:
         '200':
           description: Successful response containing a list of tools matching query parameters
@@ -2836,7 +2836,7 @@ paths:
           schema:
             type: boolean
           example: true
-      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.
+      description: Version 2.0 of the courses API introduces a large number of parameterised query string options to aid requests in collecting the data that is most relevant for a given use case. The query parameters defined below support a variety of comparison operators such as equals, contains, greater than, and less than. Using dot notation, any field can be queried, please see some examples below.  Note - This response is limited to 100 records by default.  Please use the 'page' query parameter to access records beyond the first 100.  The 'limit' query parameter can therefore only be specified up to a maximum of 100.
       tags:
         - Courses v2.0
       responses:
@@ -2871,6 +2871,7 @@ components:
       flows:
         clientCredentials:
           tokenUrl: 'https://api.www.healthdatagateway.org/oauth/token'
+          scopes: {}
     cookieAuth:
       type: http
       scheme: jwt

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,0 +1,66 @@
+import { resultLimit } from '../src/config/middleware';
+
+describe('resultLimit', () => {
+	const nextFunction = jest.fn();
+
+	const mockResponse = () => {
+		const res = {};
+		res.status = jest.fn().mockReturnValue(res);
+		res.json = jest.fn().mockReturnValue(res);
+		return res;
+	};
+
+	const allowedLimit = 100;
+
+	it('should return a 400 response code with the correct reason when the requested limit is non numeric', () => {
+		const expectedResponse = {
+			success: false,
+			message: 'The result limit parameter provided must be a numeric value.',
+		};
+
+		const req = { query: { limit: 'one hundred' } };
+		const res = mockResponse();
+
+		resultLimit(req, res, nextFunction, allowedLimit);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+		expect(res.json).toHaveBeenCalledWith(expectedResponse);
+	});
+
+	it('should return a 400 response code with the correct reason when the maximum allowed limit is exceeded', () => {
+		const expectedResponse = {
+			success: false,
+			message: `Maximum request limit exceeded.  You may only request up to a maximum of ${allowedLimit} records per page.  Please use the page query parameter to request further data.`,
+		};
+
+		const req = { query: { limit: 101 } };
+		const res = mockResponse();
+
+		resultLimit(req, res, nextFunction, allowedLimit);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+		expect(res.json).toHaveBeenCalledWith(expectedResponse);
+	});
+
+	it('should invoke the next function when no request limit is provided', () => {
+		const req = {};
+		const res = mockResponse();
+
+		resultLimit(req, res, nextFunction, allowedLimit);
+
+		expect(res.status.mock.calls.length).toBe(0);
+		expect(res.json.mock.calls.length).toBe(0);
+		expect(nextFunction.mock.calls.length).toBe(1);
+	});
+
+	it('should invoke the next function when the requested limit is valid', () => {
+		const req = { query: { limit: 100 } };
+		const res = mockResponse();
+
+		resultLimit(req, res, nextFunction, allowedLimit);
+
+		expect(res.status.mock.calls.length).toBe(0);
+		expect(res.json.mock.calls.length).toBe(0);
+		expect(nextFunction.mock.calls.length).toBe(1);
+	});
+});


### PR DESCRIPTION
**Issue**

Requesting data from public facing GET endpoint '/api/v2/datasets' was throwing error once the response size exceeded 80mb.  Work around for the batch export of datasets was provided using the existing base entity and mongoose implementation allowing a page and limit query param to be passed.  e.g. '/api/v2/datasets?page=1&limit=100'.  

**Solution**

  It was recommended that these public facing endpoints should have a record limit of 100, applying to all v2 endpoints, not just datasets.
  
  **Development**
  
  - Added middleware function to challenge 'limit' query string entry
  - Set a maximum request size (limit) in the base repository to 500 records when no limit is defined by middleware
  - Added unit tests for middleware function
  - Updated all v2 entity GET all routes to implement middleware 