### PR TITLE
IG-2427 - refactor auth strategies for error handling and login

### DIFF
--- a/src/resources/auth/__tests__/auth.utilities.test.js
+++ b/src/resources/auth/__tests__/auth.utilities.test.js
@@ -1,0 +1,72 @@
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
+
+describe('Utilities', () => {
+	describe('catchErrorAndRedirect middleware', () => {
+		it('should be a function', () => {
+			expect(typeof catchLoginErrorAndRedirect).toBe('function');
+		});
+
+		it('should call next once when ( req.auth.err || !req.auth.user ) == false', () => {
+			let res = {};
+			let req = {
+				auth: {
+					user: 'someUser',
+					err: null,
+				},
+			};
+			const next = jest.fn();
+
+			catchLoginErrorAndRedirect(req, res, next);
+
+			// assert
+			expect(next.mock.calls.length).toBe(1);
+		});
+
+		it('should not call next when ( req.auth.err || !req.auth.user ) == true', () => {
+			let res = {};
+			res.status = jest.fn().mockReturnValue(res);
+			res.redirect = jest.fn().mockReturnValue(res);
+			let req = {
+				auth: {
+					user: {},
+					err: 'someErr',
+				},
+				param: {
+					returnpage: 'somePage',
+				},
+			};
+			const next = jest.fn();
+
+			catchLoginErrorAndRedirect(req, res, next);
+
+			// assert
+			expect(next.mock.calls.length).toBe(0);
+			expect(res.status.mock.calls.length).toBe(1);
+			expect(res.redirect.mock.calls.length).toBe(1);
+		});
+	});
+
+	describe('loginAndSignToken middleware', () => {
+		it('should be a function', () => {
+			expect(typeof loginAndSignToken).toBe('function');
+		});
+
+		it('should call res.login once', () => {
+			let res = {};
+			res.status = jest.fn().mockReturnValue(res);
+			res.redirect = jest.fn().mockReturnValue(res);
+			let req = {
+				auth: {
+					user: 'someUser',
+				},
+			};
+			req.login = jest.fn().mockReturnValue(req);
+			const next = jest.fn();
+
+			loginAndSignToken(req, res, next);
+
+			// assert
+			expect(req.login.mock.calls.length).toBe(1);
+		});
+	});
+});

--- a/src/resources/auth/strategies/azure.js
+++ b/src/resources/auth/strategies/azure.js
@@ -67,8 +67,9 @@ const strategy = app => {
 		`/auth/azure/callback`,
 		(req, res, next) => {
 			passport.authenticate('azure_ad_oauth2', (err, user) => {
-				req.err = err;
-				req.user = user;
+				req.auth = {};
+				req.auth.err = err;
+				req.auth.user = user;
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/azure.js
+++ b/src/resources/auth/strategies/azure.js
@@ -67,9 +67,10 @@ const strategy = app => {
 		`/auth/azure/callback`,
 		(req, res, next) => {
 			passport.authenticate('azure_ad_oauth2', (err, user) => {
-				req.auth = {};
-				req.auth.err = err;
-				req.auth.user = user;
+				req.auth = {
+					err: err,
+					user: user,
+				};
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/azure.js
+++ b/src/resources/auth/strategies/azure.js
@@ -3,151 +3,79 @@ import passportAzure from 'passport-azure-ad-oauth2';
 import { to } from 'await-to-js';
 import jwt from 'jsonwebtoken';
 
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
 import { getUserByProviderId } from '../../user/user.repository';
-import { updateRedirectURL } from '../../user/user.service';
-import { getObjectById } from '../../tool/data.repository';
 import { createUser } from '../../user/user.service';
-import { signToken } from '../utils';
 import { ROLES } from '../../user/user.roles';
-import queryString from 'query-string';
-import Url from 'url';
-import { discourseLogin } from '../sso/sso.discourse.service';
 
-const eventLogController = require('../../eventlog/eventlog.controller');
 const AzureStrategy = passportAzure.Strategy;
 
 const strategy = app => {
-    const strategyOptions = {
-        clientID: process.env.AZURE_SSO_CLIENT_ID,
-        clientSecret: process.env.AZURE_SSO_CLIENT_SECRET,
-        callbackURL: `/auth/azure/callback`,
-        proxy: true
-    };
+	const strategyOptions = {
+		clientID: process.env.AZURE_SSO_CLIENT_ID,
+		clientSecret: process.env.AZURE_SSO_CLIENT_SECRET,
+		callbackURL: `/auth/azure/callback`,
+		proxy: true,
+	};
 
-    const verifyCallback = async (accessToken, refreshToken, params, profile, done) => {
+	const verifyCallback = async (accessToken, refreshToken, params, profile, done) => {
+		let decodedToken;
 
-        let decodedToken;
+		try {
+			decodedToken = jwt.decode(params.id_token);
+		} catch (err) {
+			return done('loginError');
+		}
 
-        try {
-            decodedToken = jwt.decode(params.id_token);
-        } catch(err) {
-            return done('loginError');
-        };
+		if (!decodedToken.oid || decodedToken.oid === '') return done('loginError');
 
-        if ( !decodedToken.oid || decodedToken.oid === '' ) return done('loginError');
+		let [err, user] = await to(getUserByProviderId(decodedToken.oid));
+		if (err || user) {
+			return done(err, user);
+		}
 
-        let [err, user] = await to(getUserByProviderId(decodedToken.oid));
-        if (err || user) {
-            return done(err, user)
-        };
+		const [createdError, createdUser] = await to(
+			createUser({
+				provider: 'azure',
+				providerId: decodedToken.oid,
+				firstname: decodedToken.given_name,
+				lastname: decodedToken.family_name,
+				password: null,
+				email: decodedToken.email,
+				role: ROLES.Creator,
+			})
+		);
 
-        const [createdError, createdUser] = await to(
-            createUser({
-                provider: 'azure',
-                providerId: decodedToken.oid,
-                firstname: decodedToken.given_name,
-                lastname: decodedToken.family_name,
-                password: null,
-                email: decodedToken.email,
-                role: ROLES.Creator
-            })
-        );
+		return done(createdError, createdUser);
+	};
 
-        return done(createdError, createdUser);
-    };
+	passport.use('azure_ad_oauth2', new AzureStrategy(strategyOptions, verifyCallback));
 
-    passport.use('azure_ad_oauth2', new AzureStrategy(strategyOptions, verifyCallback));
+	app.get(
+		`/auth/azure`,
+		(req, res, next) => {
+			// Save the url of the user's current page so the app can redirect back to it after authorization
+			if (req.headers.referer) {
+				req.param.returnpage = req.headers.referer;
+			}
+			next();
+		},
+		passport.authenticate('azure_ad_oauth2')
+	);
 
-    app.get(
-        `/auth/azure`,
-        (req, res, next) => {
-            // Save the url of the user's current page so the app can redirect back to it after authorization
-            if (req.headers.referer) {
-                req.param.returnpage = req.headers.referer;
-            }
-            next();
-        },
-        passport.authenticate('azure_ad_oauth2')
-    );
-
-    app.get(
-        `/auth/azure/callback`, (req, res, next) => {
-            passport.authenticate('azure_ad_oauth2', (err, user, info) => {
-
-                if (err || !user) {
-                    //loginError
-                    if (err === 'loginError') return res.status(200).redirect(process.env.homeURL + '/loginerror');
-
-                    // failureRedirect
-                    var redirect = '/';
-                    let returnPage = null;
-                    if (req.param.returnpage) {
-                        returnPage = Url.parse(req.param.returnpage);
-                        redirect = returnPage.path;
-                        delete req.param.returnpage;
-                    };
-
-                    let redirectUrl = process.env.homeURL + redirect;
-
-                    return res.status(200).redirect(redirectUrl);
-                };
-
-                req.login(user, async err => {
-                    if (err) {
-                        return next(err);
-                    }
-
-                    var redirect = '/';
-                    let returnPage = null;
-                    let queryStringParsed = null;
-                    if (req.param.returnpage) {
-                        returnPage = Url.parse(req.param.returnpage);
-                        redirect = returnPage.path;
-                        queryStringParsed = queryString.parse(returnPage.query);
-                    };
-
-                    let [profileErr, profile] = await to(getObjectById(req.user.id));
-                    if (!profile) {
-                        await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
-                        return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
-                    };
-
-                    if (req.param.returnpage) {
-                        delete req.param.returnpage;
-                    };
-
-                    let redirectUrl = process.env.homeURL + redirect;
-                    if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
-                        try {
-                            console.log(req.user)
-                            redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
-                        } catch (err) {
-                            console.error(err.message);
-                            return res.status(500).send('Error authenticating the user.');
-                        }
-                    };
-
-                    //Build event object for user login and log it to DB
-                    let eventObj = {
-                        userId: req.user.id,
-                        event: `user_login_${req.user.provider}`,
-                        timestamp: Date.now(),
-                    };
-
-                    await eventLogController.logEvent(eventObj);
-                    
-                    return res
-                        .status(200)
-                        .cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
-                            httpOnly: true,
-                            secure: process.env.api_url ? true : false,
-                        })
-                        .redirect(redirectUrl);
-                })
-            })(req, res, next);
-        }
-    )
-    return app;
+	app.get(
+		`/auth/azure/callback`,
+		(req, res, next) => {
+			passport.authenticate('azure_ad_oauth2', (err, user) => {
+				req.err = err;
+				req.user = user;
+				next();
+			})(req, res, next);
+		},
+		catchLoginErrorAndRedirect,
+		loginAndSignToken
+	);
+	return app;
 };
 
-export { strategy }
+export { strategy };

--- a/src/resources/auth/strategies/google.js
+++ b/src/resources/auth/strategies/google.js
@@ -62,8 +62,9 @@ const strategy = app => {
 		'/auth/google/callback',
 		(req, res, next) => {
 			passport.authenticate('google', (err, user) => {
-				req.err = err;
-				req.user = user;
+				req.auth = {};
+				req.auth.err = err;
+				req.auth.user = user;
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/google.js
+++ b/src/resources/auth/strategies/google.js
@@ -2,17 +2,11 @@ import passport from 'passport';
 import passportGoogle from 'passport-google-oauth';
 import { to } from 'await-to-js';
 
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
 import { getUserByProviderId } from '../../user/user.repository';
-import { updateRedirectURL } from '../../user/user.service';
-import { getObjectById } from '../../tool/data.repository';
 import { createUser } from '../../user/user.service';
-import { signToken } from '../utils';
 import { ROLES } from '../../user/user.roles';
-import queryString from 'query-string';
-import Url from 'url';
-import { discourseLogin } from '../sso/sso.discourse.service';
 
-const eventLogController = require('../../eventlog/eventlog.controller');
 const GoogleStrategy = passportGoogle.OAuth2Strategy;
 
 const strategy = app => {
@@ -64,83 +58,18 @@ const strategy = app => {
 		})
 	);
 
-	app.get('/auth/google/callback', (req, res, next) => {
-		passport.authenticate('google', (err, user) => {
-			if (err || !user) {
-				//loginError
-				if (err === 'loginError') return res.status(200).redirect(process.env.homeURL + '/loginerror');
-
-				// failureRedirect
-				var redirect = '/';
-				let returnPage = null;
-
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				return res.status(200).redirect(redirectUrl);
-			}
-
-			req.login(user, async err => {
-				if (err) {
-					return next(err);
-				}
-
-				var redirect = '/';
-
-				let returnPage = null;
-				let queryStringParsed = null;
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					queryStringParsed = queryString.parse(returnPage.query);
-				}
-
-				let [, profile] = await to(getObjectById(req.user.id));
-
-				if (!profile) {
-					await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
-					return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
-				}
-
-				if (req.param.returnpage) {
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
-					try {
-						redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
-					} catch (err) {
-						console.error(err.message);
-						return res.status(500).send('Error authenticating the user.');
-					}
-				}
-
-				//Build event object for user login and log it to DB
-				let eventObj = {
-					userId: req.user.id,
-					event: `user_login_${req.user.provider}`,
-					timestamp: Date.now(),
-				};
-				await eventLogController.logEvent(eventObj);
-
-				return res
-					.status(200)
-					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
-						httpOnly: true,
-						secure: process.env.api_url ? true : false,
-					})
-					.redirect(redirectUrl);
-			});
-		})(req, res, next);
-	});
-
+	app.get(
+		'/auth/google/callback',
+		(req, res, next) => {
+			passport.authenticate('google', (err, user) => {
+				req.err = err;
+				req.user = user;
+				next();
+			})(req, res, next);
+		},
+		catchLoginErrorAndRedirect,
+		loginAndSignToken
+	);
 	return app;
 };
 

--- a/src/resources/auth/strategies/google.js
+++ b/src/resources/auth/strategies/google.js
@@ -62,9 +62,10 @@ const strategy = app => {
 		'/auth/google/callback',
 		(req, res, next) => {
 			passport.authenticate('google', (err, user) => {
-				req.auth = {};
-				req.auth.err = err;
-				req.auth.user = user;
+				req.auth = {
+					err: err,
+					user: user,
+				};
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/linkedin.js
+++ b/src/resources/auth/strategies/linkedin.js
@@ -2,17 +2,11 @@ import passport from 'passport';
 import passportLinkedin from 'passport-linkedin-oauth2';
 import { to } from 'await-to-js';
 
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
 import { getUserByProviderId } from '../../user/user.repository';
-import { getObjectById } from '../../tool/data.repository';
-import { updateRedirectURL } from '../../user/user.service';
 import { createUser } from '../../user/user.service';
-import { signToken } from '../utils';
 import { ROLES } from '../../user/user.roles';
-import queryString from 'query-string';
-import Url from 'url';
-import { discourseLogin } from '../sso/sso.discourse.service';
 
-const eventLogController = require('../../eventlog/eventlog.controller');
 const LinkedinStrategy = passportLinkedin.OAuth2Strategy;
 
 const strategy = app => {
@@ -62,83 +56,18 @@ const strategy = app => {
 		})
 	);
 
-	app.get('/auth/linkedin/callback', (req, res, next) => {
-		passport.authenticate('linkedin', (err, user) => {
-			if (err || !user) {
-				//loginError
-				if (err === 'loginError') return res.status(200).redirect(process.env.homeURL + '/loginerror');
-
-				// failureRedirect
-				var redirect = '/';
-				let returnPage = null;
-
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				return res.status(200).redirect(redirectUrl);
-			}
-
-			req.login(user, async err => {
-				if (err) {
-					return next(err);
-				}
-
-				var redirect = '/';
-
-				let returnPage = null;
-				let queryStringParsed = null;
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					queryStringParsed = queryString.parse(returnPage.query);
-				}
-
-				let [, profile] = await to(getObjectById(req.user.id));
-
-				if (!profile) {
-					await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
-					return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
-				}
-
-				if (req.param.returnpage) {
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
-					try {
-						redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
-					} catch (err) {
-						console.error(err.message);
-						return res.status(500).send('Error authenticating the user.');
-					}
-				}
-
-				//Build event object for user login and log it to DB
-				let eventObj = {
-					userId: req.user.id,
-					event: `user_login_${req.user.provider}`,
-					timestamp: Date.now(),
-				};
-				await eventLogController.logEvent(eventObj);
-
-				return res
-					.status(200)
-					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
-						httpOnly: true,
-						secure: process.env.api_url ? true : false,
-					})
-					.redirect(redirectUrl);
-			});
-		})(req, res, next);
-	});
-
+	app.get(
+		'/auth/linkedin/callback',
+		(req, res, next) => {
+			passport.authenticate('linkedin', (err, user) => {
+				req.err = err;
+				req.user = user;
+				next();
+			})(req, res, next);
+		},
+		catchLoginErrorAndRedirect,
+		loginAndSignToken
+	);
 	return app;
 };
 

--- a/src/resources/auth/strategies/linkedin.js
+++ b/src/resources/auth/strategies/linkedin.js
@@ -60,8 +60,9 @@ const strategy = app => {
 		'/auth/linkedin/callback',
 		(req, res, next) => {
 			passport.authenticate('linkedin', (err, user) => {
-				req.err = err;
-				req.user = user;
+				req.auth = {};
+				req.auth.err = err;
+				req.auth.user = user;
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/linkedin.js
+++ b/src/resources/auth/strategies/linkedin.js
@@ -60,9 +60,10 @@ const strategy = app => {
 		'/auth/linkedin/callback',
 		(req, res, next) => {
 			passport.authenticate('linkedin', (err, user) => {
-				req.auth = {};
-				req.auth.err = err;
-				req.auth.user = user;
+				req.auth = {
+					err: err,
+					user: user,
+				};
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/oidc.js
+++ b/src/resources/auth/strategies/oidc.js
@@ -2,20 +2,15 @@ import passport from 'passport';
 import passportOidc from 'passport-openidconnect';
 import { to } from 'await-to-js';
 
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
 import { getUserByProviderId } from '../../user/user.repository';
-import { getObjectById } from '../../tool/data.repository';
-import { updateRedirectURL } from '../../user/user.service';
 import { createUser } from '../../user/user.service';
-import { signToken } from '../utils';
+import { UserModel } from '../../user/user.model';
 import { ROLES } from '../../user/user.roles';
-import queryString from 'query-string';
-import Url from 'url';
-import { discourseLogin } from '../sso/sso.discourse.service';
 import { isNil } from 'lodash';
+
 const OidcStrategy = passportOidc.Strategy;
 const baseAuthUrl = process.env.AUTH_PROVIDER_URI;
-const eventLogController = require('../../eventlog/eventlog.controller');
-import { UserModel } from '../../user/user.model';
 
 const strategy = app => {
 	const strategyOptions = {
@@ -71,83 +66,18 @@ const strategy = app => {
 		passport.authenticate('oidc')
 	);
 
-	app.get('/auth/oidc/callback', (req, res, next) => {
-		passport.authenticate('oidc', (err, user) => {
-			if (err || !user) {
-				//loginError
-				if (err === 'loginError') return res.status(200).redirect(process.env.homeURL + '/loginerror');
-
-				// failureRedirect
-				var redirect = '/';
-				let returnPage = null;
-
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				return res.status(200).redirect(redirectUrl);
-			}
-
-			req.login(user, async err => {
-				if (err) {
-					return next(err);
-				}
-
-				var redirect = '/';
-
-				let returnPage = null;
-				let queryStringParsed = null;
-				if (req.param.returnpage) {
-					returnPage = Url.parse(req.param.returnpage);
-					redirect = returnPage.path;
-					queryStringParsed = queryString.parse(returnPage.query);
-				}
-
-				let [, profile] = await to(getObjectById(req.user.id));
-
-				if (!profile) {
-					await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
-					return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
-				}
-
-				if (req.param.returnpage) {
-					delete req.param.returnpage;
-				}
-
-				let redirectUrl = process.env.homeURL + redirect;
-
-				if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
-					try {
-						redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
-					} catch (err) {
-						console.error(err.message);
-						return res.status(500).send('Error authenticating the user.');
-					}
-				}
-
-				//Build event object for user login and log it to DB
-				let eventObj = {
-					userId: req.user.id,
-					event: `user_login_${req.user.provider}`,
-					timestamp: Date.now(),
-				};
-				await eventLogController.logEvent(eventObj);
-
-				return res
-					.status(200)
-					.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
-						httpOnly: true,
-						secure: process.env.api_url ? true : false,
-					})
-					.redirect(redirectUrl);
-			});
-		})(req, res, next);
-	});
-
+	app.get(
+		'/auth/oidc/callback',
+		(req, res, next) => {
+			passport.authenticate('oidc', (err, user) => {
+				req.err = err;
+				req.user = user;
+				next();
+			})(req, res, next);
+		},
+		catchLoginErrorAndRedirect,
+		loginAndSignToken
+	);
 	return app;
 };
 

--- a/src/resources/auth/strategies/oidc.js
+++ b/src/resources/auth/strategies/oidc.js
@@ -70,9 +70,10 @@ const strategy = app => {
 		'/auth/oidc/callback',
 		(req, res, next) => {
 			passport.authenticate('oidc', (err, user) => {
-				req.auth = {};
-				req.auth.err = err;
-				req.auth.user = user;
+				req.auth = {
+					err: err,
+					user: user,
+				};
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/oidc.js
+++ b/src/resources/auth/strategies/oidc.js
@@ -70,8 +70,9 @@ const strategy = app => {
 		'/auth/oidc/callback',
 		(req, res, next) => {
 			passport.authenticate('oidc', (err, user) => {
-				req.err = err;
-				req.user = user;
+				req.auth = {};
+				req.auth.err = err;
+				req.auth.user = user;
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/orcid.js
+++ b/src/resources/auth/strategies/orcid.js
@@ -74,9 +74,10 @@ const strategy = app => {
 		'/auth/orcid/callback',
 		(req, res, next) => {
 			passport.authenticate('orcid', (err, user, info) => {
-				req.auth = {};
-				req.auth.err = err;
-				req.auth.user = user;
+				req.auth = {
+					err: err,
+					user: user,
+				};
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/orcid.js
+++ b/src/resources/auth/strategies/orcid.js
@@ -74,8 +74,9 @@ const strategy = app => {
 		'/auth/orcid/callback',
 		(req, res, next) => {
 			passport.authenticate('orcid', (err, user, info) => {
-				req.err = err;
-				req.user = user;
+				req.auth = {};
+				req.auth.err = err;
+				req.auth.user = user;
 				next();
 			})(req, res, next);
 		},

--- a/src/resources/auth/strategies/orcid.js
+++ b/src/resources/auth/strategies/orcid.js
@@ -3,155 +3,86 @@ import passportOrcid from 'passport-orcid';
 import { to } from 'await-to-js';
 import axios from 'axios';
 
+import { catchLoginErrorAndRedirect, loginAndSignToken } from '../utils';
 import { getUserByProviderId } from '../../user/user.repository';
-import { updateRedirectURL } from '../../user/user.service';
-import { getObjectById } from '../../tool/data.repository';
 import { createUser } from '../../user/user.service';
-import { signToken } from '../utils';
 import { ROLES } from '../../user/user.roles';
-import queryString from 'query-string';
-import Url from 'url';
-import { discourseLogin } from '../sso/sso.discourse.service';
 
-const eventLogController = require('../../eventlog/eventlog.controller');
-const OrcidStrategy = passportOrcid.Strategy
+const OrcidStrategy = passportOrcid.Strategy;
 
 const strategy = app => {
-    const strategyOptions = {
-        sandbox: process.env.ORCID_SSO_ENV,
-        clientID: process.env.ORCID_SSO_CLIENT_ID,
-        clientSecret: process.env.ORCID_SSO_CLIENT_SECRET,
-        callbackURL: `/auth/orcid/callback`,
-        scope: `/authenticate /read-limited`,
-        proxy: true
-    };
+	const strategyOptions = {
+		sandbox: process.env.ORCID_SSO_ENV,
+		clientID: process.env.ORCID_SSO_CLIENT_ID,
+		clientSecret: process.env.ORCID_SSO_CLIENT_SECRET,
+		callbackURL: `/auth/orcid/callback`,
+		scope: `/authenticate /read-limited`,
+		proxy: true,
+	};
 
-    const verifyCallback = async (accessToken, refreshToken, params, profile, done) => {
+	const verifyCallback = async (accessToken, refreshToken, params, profile, done) => {
+		if (!params.orcid || params.orcid === '') return done('loginError');
 
-        if (!params.orcid || params.orcid === '') return done('loginError');
+		let [err, user] = await to(getUserByProviderId(params.orcid));
+		if (err || user) {
+			return done(err, user);
+		}
+		// Orcid does not include email natively
+		const requestedEmail = await axios
+			.get(`${process.env.ORCID_SSO_BASE_URL}/v3.0/${params.orcid}/email`, {
+				headers: { Authorization: `Bearer ` + accessToken, Accept: 'application/json' },
+			})
+			.then(response => {
+				const email = response.data.email[0].email;
+				return email == undefined || !/\b[a-zA-Z0-9-_.]+\@[a-zA-Z0-9-_]+\.\w+(?:\.\w+)?\b/.test(email) ? '' : email;
+			})
+			.catch(err => {
+				console.log(err);
+				return '';
+			});
 
-        let [err, user] = await to(getUserByProviderId(params.orcid));
-        if (err || user) {
-            return done(err, user);
-        }
-        // Orcid does not include email natively
-        const requestedEmail =
-        await axios.get(
-            `${process.env.ORCID_SSO_BASE_URL}/v3.0/${params.orcid}/email`,
-            { headers: { 'Authorization': `Bearer ` + accessToken, 'Accept': 'application/json' }}
-        ).then((response) => {
-            const email = response.data.email[0].email
-            return ( email == undefined || !/\b[a-zA-Z0-9-_.]+\@[a-zA-Z0-9-_]+\.\w+(?:\.\w+)?\b/.test(email) ) ? '' : email
-        }).catch((err) => {
-            console.log(err);
-            return '';
-        });
+		const [createdError, createdUser] = await to(
+			createUser({
+				provider: 'orcid',
+				providerId: params.orcid,
+				firstname: params.name.split(' ')[0],
+				lastname: params.name.split(' ')[1],
+				password: null,
+				email: requestedEmail,
+				role: ROLES.Creator,
+			})
+		);
 
-        const [createdError, createdUser] = await to(
-            createUser({
-                provider: 'orcid',
-                providerId: params.orcid,
-                firstname: params.name.split(' ')[0],
-                lastname: params.name.split(' ')[1],
-                password: null,
-                email: requestedEmail,
-                role: ROLES.Creator,
-            })
-        );
+		return done(createdError, createdUser);
+	};
 
-        return done(createdError, createdUser);
-    };
+	passport.use('orcid', new OrcidStrategy(strategyOptions, verifyCallback));
 
-    passport.use('orcid', new OrcidStrategy(strategyOptions, verifyCallback));
+	app.get(
+		`/auth/orcid`,
+		(req, res, next) => {
+			// Save the url of the user's current page so the app can redirect back to it after authorization
+			if (req.headers.referer) {
+				req.param.returnpage = req.headers.referer;
+			}
+			next();
+		},
+		passport.authenticate('orcid')
+	);
 
-    app.get(
-        `/auth/orcid`,
-        (req, res, next) => {
-            // Save the url of the user's current page so the app can redirect back to it after authorization
-            if (req.headers.referer) {
-                req.param.returnpage = req.headers.referer;
-            }
-            next();
-        },
-        passport.authenticate('orcid')
-    );
-
-    app.get('/auth/orcid/callback', (req, res, next) => {
-        passport.authenticate('orcid', (err, user, info) => {
-
-            if (err || !user) {
-                //loginError
-                if (err === 'loginError') return res.status(200).redirect(process.env.homeURL + '/loginerror');
-
-                // failureRedirect
-                var redirect = '/';
-                let returnPage = null;
-                if (req.param.returnpage) {
-                    returnPage = Url.parse(req.param.returnpage);
-                    redirect = returnPage.path;
-                    delete req.param.returnpage;
-                };
-
-                let redirectUrl = process.env.homeURL + redirect;
-                return res.status(200).redirect(redirectUrl);
-            };
-
-            req.login(user, async err => {
-                
-                if (err) {
-                    return next(err);
-                };
-
-                var redirect = '/';
-                let returnPage = null;
-                let queryStringParsed = null;
-                if (req.param.returnpage) {
-                    returnPage = Url.parse(req.param.returnpage);
-                    redirect = returnPage.path;
-                    queryStringParsed = queryString.parse(returnPage.query);
-                };
-
-                let [profileErr, profile] = await to(getObjectById(req.user.id));
-                if (!profile) {
-                    await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
-                    return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
-                };
-
-                if (req.param.returnpage) {
-                    delete req.param.returnpage;
-                };
-
-                let redirectUrl = process.env.homeURL + redirect;
-                if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
-                    try {
-                        console.log(req.user)
-                        redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
-                    } catch (err) {
-                        console.error(err.message);
-                        return res.status(500).send('Error authenticating the user.');
-                    }
-                };
-
-                //Build event object for user login and log it to DB
-                let eventObj = {
-                    userId: req.user.id,
-                    event: `user_login_${req.user.provider}`,
-                    timestamp: Date.now(),
-                };
-                
-                await eventLogController.logEvent(eventObj);
-
-                return res
-                    .status(200)
-                    .cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
-                        httpOnly: true,
-                        secure: process.env.api_url ? true : false,
-                    })
-                    .redirect(redirectUrl);
-            });
-        })(req, res, next);
-    });
-    return app;
+	app.get(
+		'/auth/orcid/callback',
+		(req, res, next) => {
+			passport.authenticate('orcid', (err, user, info) => {
+				req.err = err;
+				req.user = user;
+				next();
+			})(req, res, next);
+		},
+		catchLoginErrorAndRedirect,
+		loginAndSignToken
+	);
+	return app;
 };
 
 export { strategy };

--- a/src/resources/auth/strategies/orcid.js
+++ b/src/resources/auth/strategies/orcid.js
@@ -73,7 +73,7 @@ const strategy = app => {
 	app.get(
 		'/auth/orcid/callback',
 		(req, res, next) => {
-			passport.authenticate('orcid', (err, user, info) => {
+			passport.authenticate('orcid', (err, user) => {
 				req.auth = {
 					err: err,
 					user: user,

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -1,6 +1,11 @@
 /* eslint-disable no-undef */
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
+import { to } from 'await-to-js';
+import Url from 'url';
+import { isEmpty } from 'lodash';
+import queryString from 'query-string';
+
 import { ROLES } from '../user/user.roles';
 import { UserModel } from '../user/user.model';
 import { Course } from '../course/course.model';
@@ -8,7 +13,11 @@ import { Collections } from '../collections/collections.model';
 import { Data } from '../tool/data.model';
 import { TeamModel } from '../team/team.model';
 import constants from '../utilities/constants.util';
-import { isEmpty } from 'lodash';
+import { discourseLogin } from './sso/sso.discourse.service';
+import { updateRedirectURL } from './../user/user.service';
+import { getObjectById } from './../tool/data.repository';
+
+const eventLogController = require('./../eventlog/eventlog.controller');
 
 const setup = () => {
 	passport.serializeUser((user, done) => done(null, user._id));
@@ -46,18 +55,20 @@ const camundaToken = () => {
 	);
 };
 
-const checkIsInRole = (...roles) => (req, res, next) => {
-	if (!req.user) {
-		return res.redirect('/login');
-	}
+const checkIsInRole =
+	(...roles) =>
+	(req, res, next) => {
+		if (!req.user) {
+			return res.redirect('/login');
+		}
 
-	const hasRole = roles.find(role => req.user.role === role);
-	if (!hasRole) {
-		return res.redirect('/login');
-	}
+		const hasRole = roles.find(role => req.user.role === role);
+		if (!hasRole) {
+			return res.redirect('/login');
+		}
 
-	return next();
-};
+		return next();
+	};
 
 const whatIsRole = req => {
 	if (!req.user) {
@@ -116,4 +127,90 @@ const getTeams = async () => {
 	return teams;
 };
 
-export { setup, signToken, camundaToken, checkIsInRole, whatIsRole, checkIsUser, checkAllowedToAccess, getTeams };
+const catchLoginErrorAndRedirect = (req, res, next) => {
+	if (req.err || !req.user) {
+		if (req.err === 'loginError') {
+			return res.status(200).redirect(process.env.homeURL + '/loginerror');
+		}
+
+		let redirect = '/';
+		let returnPage = null;
+		if (req.param.returnpage) {
+			returnPage = Url.parse(req.param.returnpage);
+			redirect = returnPage.path;
+			delete req.param.returnpage;
+		}
+
+		let redirectUrl = process.env.homeURL + redirect;
+
+		return res.status(200).redirect(redirectUrl);
+	}
+	next();
+};
+
+const loginAndSignToken = (req, res, next) => {
+	req.login(req.user, async err => {
+		if (err) {
+			return next(err);
+		}
+
+		let redirect = '/';
+		let returnPage = null;
+		let queryStringParsed = null;
+		if (req.param.returnpage) {
+			returnPage = Url.parse(req.param.returnpage);
+			redirect = returnPage.path;
+			queryStringParsed = queryString.parse(returnPage.query);
+		}
+
+		let [, profile] = await to(getObjectById(req.user.id));
+		if (!profile) {
+			await to(updateRedirectURL({ id: req.user.id, redirectURL: redirect }));
+			return res.redirect(process.env.homeURL + '/completeRegistration/' + req.user.id);
+		}
+
+		if (req.param.returnpage) {
+			delete req.param.returnpage;
+		}
+
+		let redirectUrl = process.env.homeURL + redirect;
+		if (queryStringParsed && queryStringParsed.sso && queryStringParsed.sig) {
+			try {
+				redirectUrl = discourseLogin(queryStringParsed.sso, queryStringParsed.sig, req.user);
+			} catch (err) {
+				console.error(err.message);
+				return res.status(500).send('Error authenticating the user.');
+			}
+		}
+
+		//Build event object for user login and log it to DB
+		let eventObj = {
+			userId: req.user.id,
+			event: `user_login_${req.user.provider}`,
+			timestamp: Date.now(),
+		};
+
+		await eventLogController.logEvent(eventObj);
+
+		return res
+			.status(200)
+			.cookie('jwt', signToken({ _id: req.user._id, id: req.user.id, timeStamp: Date.now() }), {
+				httpOnly: true,
+				secure: process.env.api_url ? true : false,
+			})
+			.redirect(redirectUrl);
+	});
+};
+
+export {
+	setup,
+	signToken,
+	camundaToken,
+	checkIsInRole,
+	whatIsRole,
+	checkIsUser,
+	checkAllowedToAccess,
+	getTeams,
+	catchLoginErrorAndRedirect,
+	loginAndSignToken,
+};

--- a/src/resources/auth/utils.js
+++ b/src/resources/auth/utils.js
@@ -128,8 +128,8 @@ const getTeams = async () => {
 };
 
 const catchLoginErrorAndRedirect = (req, res, next) => {
-	if (req.err || !req.user) {
-		if (req.err === 'loginError') {
+	if (req.auth.err || !req.auth.user) {
+		if (req.auth.err === 'loginError') {
 			return res.status(200).redirect(process.env.homeURL + '/loginerror');
 		}
 
@@ -149,7 +149,7 @@ const catchLoginErrorAndRedirect = (req, res, next) => {
 };
 
 const loginAndSignToken = (req, res, next) => {
-	req.login(req.user, async err => {
+	req.login(req.auth.user, async err => {
 		if (err) {
 			return next(err);
 		}


### PR DESCRIPTION
Each of the passport strategies (Google, LinkedIn, Azure etc.) had a similar ~70 lines of code for catching user authentication errors and redirecting, or if authenticated, logging the user in and sending a JWT back to the browser in a cookie.

This PR pulls that logic out into two new utilities function middleware, catchErrorAndRedirect and loginAndSignToken (see src/resources/auth/utils.js). Unit tests are added to test these middleware.