### PR TITLE
Fixing bug: Saved DOI on the correct field

### DIFF
--- a/src/services/aridhia/aridhia.service.js
+++ b/src/services/aridhia/aridhia.service.js
@@ -28,7 +28,6 @@ export default class aridhiaService {
 				datasetid: `datasetid-fair-${res.code}`,
 				description: res.catalogue.description,
 				datasetv2: {},
-				doiName: "" || res.catalogue.identifier,
 				license: res.catalogue.license,
 				name: res.name,
 				publisher: res.catalogue.publisher,
@@ -136,7 +135,7 @@ export default class aridhiaService {
 	
 		v2.doiName = null;
 		if (res.catalogue.identifier)
-			v2.doiName = res.catalogue.identifier;
+			v2.summary.doiName = res.catalogue.identifier;
 	
 		v2.summary.contactPoint = null;
 		if (res.catalogue.creator && res.catalogue.contactPoint) {


### PR DESCRIPTION
I fixed a bug on this ticket.
Previously I stored the DOI name on dataset..doiName.
Now the DOI number stored on the correct field, which is: datasetv2.summary.doiName