### PR TITLE
CR - admin publisher to return all versions

### DIFF
--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -60,12 +60,11 @@ module.exports = {
 					const versionDetails = { _id, datasetVersion, activeflag };
 					arr[datasetIdx].listOfVersions = [...arr[datasetIdx].listOfVersions, versionDetails];
 				}
+				if (publisherID === constants.userTypes.ADMIN) {
+					arr = arr.filter(dataset => dataset.activeflag === constants.applicationStatuses.INREVIEW);
+				}
 				return arr;
 			}, []);
-
-			if (publisherID === constants.userTypes.ADMIN) {
-				listOfDatasets = listOfDatasets.filter(dataset => dataset.activeflag === 'inReview');
-			}
 
 			return res.status(200).json({
 				success: true,

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -50,7 +50,7 @@ module.exports = {
 				.lean();
 
 			//Loop through the list of datasets and attach the list of versions to them
-			let listOfDatasets = datasets.reduce((arr, dataset) => {
+			const listOfDatasets = datasets.reduce((arr, dataset) => {
 				dataset.listOfVersions = [];
 				const datasetIdx = arr.findIndex(item => item.pid === dataset.pid);
 				if (datasetIdx === -1) {

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -30,7 +30,7 @@ module.exports = {
 			if (publisherID === 'admin') {
 				// get all datasets in review for admin
 				query = {
-					activeflag: 'inReview',
+					activeflag: { $in: ['active', 'inReview', 'draft', 'rejected', 'archive'] },
 					type: 'dataset',
 				};
 			} else {
@@ -50,7 +50,7 @@ module.exports = {
 				.lean();
 
 			//Loop through the list of datasets and attach the list of versions to them
-			const listOfDatasets = datasets.reduce((arr, dataset) => {
+			let listOfDatasets = datasets.reduce((arr, dataset) => {
 				dataset.listOfVersions = [];
 				const datasetIdx = arr.findIndex(item => item.pid === dataset.pid);
 				if (datasetIdx === -1) {
@@ -62,6 +62,10 @@ module.exports = {
 				}
 				return arr;
 			}, []);
+
+			if (publisherID === 'admin') {
+				listOfDatasets = listOfDatasets.filter(dataset => dataset.activeflag === 'inReview');
+			}
 
 			return res.status(200).json({
 				success: true,

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -27,7 +27,7 @@ module.exports = {
 
 			//Build query, if the publisherId is admin then only return the inReview datasets
 			let query = {};
-			if (publisherID === 'admin') {
+			if (publisherID === constants.userTypes.ADMIN) {
 				// get all datasets in review for admin
 				query = {
 					activeflag: { $in: ['active', 'inReview', 'draft', 'rejected', 'archive'] },
@@ -63,7 +63,7 @@ module.exports = {
 				return arr;
 			}, []);
 
-			if (publisherID === 'admin') {
+			if (publisherID === constants.userTypes.ADMIN) {
 				listOfDatasets = listOfDatasets.filter(dataset => dataset.activeflag === 'inReview');
 			}
 


### PR DESCRIPTION
This small change allows the listOfVersions to appear on the admin datasets API so that the version IDs can be passed to the activity log API.

Previously the listOfVersions for the admin datasets page came back blank for all datasets.