### PR TITLE
Add sort by most viewed for active datasets

### DIFF
--- a/src/middlewares/__tests__/datasetonboarding.middleware.test.js
+++ b/src/middlewares/__tests__/datasetonboarding.middleware.test.js
@@ -140,7 +140,7 @@ describe('Testing the datasetonboarding middleware', () => {
 					maxResults: 10,
 					sortBy: sortOption,
 					sortDirection: 'asc',
-					status: 'inReview',
+					status: 'active',
 				};
 				validateSearchParameters(req, res, nextFunction);
 			});
@@ -297,6 +297,36 @@ describe('Testing the datasetonboarding middleware', () => {
 			validateSearchParameters(req, res, nextFunction);
 
 			expect(res.status).toHaveBeenCalledWith(500);
+			expect(nextFunction.mock.calls.length).toBe(0);
+		});
+
+		it('Should return a 500 error for the popularity sort option with a status which does not equal active', () => {
+			let req = mockedRequest();
+			let res = mockedResponse();
+			const nextFunction = jest.fn();
+
+			const expectedResponse = {
+				success: false,
+				message: `Sorting by popularity is only available for active datasets [status=active]`,
+			};
+
+			req.params = {
+				publisherID: 'fakeTeam',
+			};
+
+			req.query = {
+				search: '',
+				datasetIndex: 0,
+				maxResults: 10,
+				sortBy: 'popularity',
+				sortDirection: 'asc',
+				status: 'inReview',
+			};
+
+			validateSearchParameters(req, res, nextFunction);
+
+			expect(res.status).toHaveBeenCalledWith(500);
+			expect(res.json).toHaveBeenCalledWith(expectedResponse);
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});
 	});

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -23,7 +23,7 @@ const validateSearchParameters = (req, res, next) => {
 	const datasetStatuses = Object.values(constants.datatsetStatuses);
 
 	let {
-		query: { search = '', datasetIndex = 0, maxResults, sortBy = 'recentActivity', sortDirection = 'desc', status },
+		query: { search = '', datasetIndex = 0, maxResults, sortBy = 'latest', sortDirection = 'desc', status },
 	} = req;
 
 	if (req.params.publisherID === constants.teamTypes.ADMIN) {
@@ -54,6 +54,13 @@ const validateSearchParameters = (req, res, next) => {
 		return res.status(500).json({
 			success: false,
 			message: `The sort direction must be either ascending [asc] or descending [desc]`,
+		});
+	}
+
+	if (sortBy === constants.datasetSortOptions.MOSTVIEWED && status !== constants.datatsetStatuses.ACTIVE) {
+		return res.status(500).json({
+			success: false,
+			message: `Sorting by popularity is only available for active datasets [status=active]`,
 		});
 	}
 

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -43,7 +43,7 @@ module.exports = {
 
 			const datasets = await Data.find(searchQuery)
 				.select(
-					'_id pid name datasetVersion activeflag timestamps applicationStatusDesc applicationStatusAuthor percentageCompleted datasetv2.summary.publisher.name'
+					'_id pid name datasetVersion activeflag timestamps applicationStatusDesc applicationStatusAuthor percentageCompleted datasetv2.summary.publisher.name counter'
 				)
 				.sort({ 'timestamps.updated': -1 })
 				.lean();

--- a/src/resources/dataset/utils/__tests__/datasetonboarding.util.test.js
+++ b/src/resources/dataset/utils/__tests__/datasetonboarding.util.test.js
@@ -75,11 +75,13 @@ describe('Dataset onboarding utility', () => {
 						timestamps: { updated: 1234, created: 1234 },
 						name: 'abc',
 						percentageCompleted: { summary: 20 },
+						counter: 200,
 					},
 					{
 						timestamps: { updated: 5678, created: 5678 },
 						name: 'xyz',
 						percentageCompleted: { summary: 80 },
+						counter: 100,
 					},
 				];
 
@@ -109,6 +111,10 @@ describe('Dataset onboarding utility', () => {
 					let arr = sortedDatasets.map(dataset => dataset.percentageCompleted.summary);
 					expect(arr[0]).toBeLessThan(arr[1]);
 				}
+				if (sortOption === constants.datasetSortOptions.MOSTVIEWED) {
+					let arr = sortedDatasets.map(dataset => dataset.counter);
+					expect(arr[0]).toBeLessThan(arr[1]);
+				}
 			}
 		);
 
@@ -120,11 +126,13 @@ describe('Dataset onboarding utility', () => {
 						timestamps: { updated: 1234, created: 1234 },
 						name: 'abc',
 						percentageCompleted: { summary: 20 },
+						counter: 200,
 					},
 					{
 						timestamps: { updated: 5678, created: 5678 },
 						name: 'xyz',
 						percentageCompleted: { summary: 80 },
+						counter: 100,
 					},
 				];
 
@@ -152,6 +160,10 @@ describe('Dataset onboarding utility', () => {
 				}
 				if (sortOption === constants.datasetSortOptions.METADATAQUALITY) {
 					let arr = sortedDatasets.map(dataset => dataset.percentageCompleted.summary);
+					expect(arr[1]).toBeLessThan(arr[0]);
+				}
+				if (sortOption === constants.datasetSortOptions.MOSTVIEWED) {
+					let arr = sortedDatasets.map(dataset => dataset.counter);
 					expect(arr[1]).toBeLessThan(arr[0]);
 				}
 			}

--- a/src/resources/dataset/utils/datasetonboarding.util.js
+++ b/src/resources/dataset/utils/datasetonboarding.util.js
@@ -1361,6 +1361,26 @@ const datasetSortingHelper = (datasets, sortBy, sortDirection) => {
 					});
 				}
 				break;
+
+			case constants.datasetSortOptions.MOSTVIEWED:
+				if (sortDirection === constants.datasetSortDirections.ASCENDING) {
+					datasets = datasets.map(dataset => {
+						if (!dataset.counter) dataset.counter = 0;
+						return dataset;
+					});
+					return datasets.sort((a, b) => {
+						return a.counter - b.counter;
+					});
+				} else if (sortDirection === constants.datasetSortDirections.DESCENDING) {
+					datasets = datasets.map(dataset => {
+						if (!dataset.counter) dataset.counter = 0;
+						return dataset;
+					});
+					return datasets.sort((a, b) => {
+						return b.counter - a.counter;
+					});
+				}
+				break;
 		}
 	} catch (err) {
 		process.stdout.write(`${err.message}\n`);

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -297,6 +297,7 @@ const _datasetSortOptions = {
 	ALPHABETIC: 'alphabetic',
 	RECENTLYPUBLISHED: 'recentlyadded',
 	METADATAQUALITY: 'metadata',
+	MOSTVIEWED: 'popularity',
 };
 
 const _datasetSortDirections = {


### PR DESCRIPTION
Adding the option to sort by popularity (i.e., most-viewed) for active datasets.