### PR TITLE
feature/GAT-302

### DIFF
--- a/src/middlewares/__tests__/datasetonboarding.middleware.test.js
+++ b/src/middlewares/__tests__/datasetonboarding.middleware.test.js
@@ -153,7 +153,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
 
-			const statuses = Object.values(constants.datatsetStatuses);
+			const statuses = Object.values(constants.datasetStatuses);
 
 			statuses.forEach(status => {
 				req.params = {

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -20,7 +20,7 @@ const authoriseUserForPublisher = (req, res, next) => {
 
 const validateSearchParameters = (req, res, next) => {
 	const sortOptions = Object.values(constants.datasetSortOptions);
-	const datasetStatuses = Object.values(constants.datatsetStatuses);
+	const datasetStatuses = Object.values(constants.datasetStatuses);
 
 	let {
 		query: { search = '', datasetIndex = 0, maxResults, sortBy = 'latest', sortDirection = 'desc', status },
@@ -57,7 +57,7 @@ const validateSearchParameters = (req, res, next) => {
 		});
 	}
 
-	if (sortBy === constants.datasetSortOptions.MOSTVIEWED && status !== constants.datatsetStatuses.ACTIVE) {
+	if (sortBy === constants.datasetSortOptions.MOSTVIEWED && status !== constants.datasetStatuses.ACTIVE) {
 		return res.status(500).json({
 			success: false,
 			message: `Sorting by popularity is only available for active datasets [status=active]`,

--- a/src/resources/dataset/__tests__/datasetonboarding.controller.test.js
+++ b/src/resources/dataset/__tests__/datasetonboarding.controller.test.js
@@ -43,7 +43,7 @@ describe('Dataset onboarding controller', () => {
 
 				const response = await getDatasetsByPublisher(req, res);
 
-				const formattedDatasets = response.json.mock.calls[0][0].data.listOfDatasets;
+				const formattedDatasets = response.json.mock.calls[0][0].data.results.listOfDatasets;
 
 				formattedDatasets.forEach(dataset => {
 					expect(dataset.activeflag).toEqual('inReview');
@@ -69,7 +69,7 @@ describe('Dataset onboarding controller', () => {
 
 				const response = await getDatasetsByPublisher(req, res);
 
-				const formattedDatasets = response.json.mock.calls[0][0].data.listOfDatasets;
+				const formattedDatasets = response.json.mock.calls[0][0].data.results.listOfDatasets;
 
 				expect(formattedDatasets.length).toEqual(1);
 			});
@@ -96,7 +96,7 @@ describe('Dataset onboarding controller', () => {
 
 				const response = await getDatasetsByPublisher(req, res);
 
-				const formattedDatasets = response.json.mock.calls[0][0].data.listOfDatasets;
+				const formattedDatasets = response.json.mock.calls[0][0].data.results.listOfDatasets;
 
 				formattedDatasets.forEach(dataset => {
 					expect(dataset.activeflag).toEqual(status);
@@ -151,9 +151,33 @@ describe('Dataset onboarding controller', () => {
 
 				const response = await getDatasetsByPublisher(req, res);
 
-				const formattedDatasets = response.json.mock.calls[0][0].data.listOfDatasets;
+				const formattedDatasets = response.json.mock.calls[0][0].data.results.listOfDatasets;
 
 				expect([...new Set(formattedDatasets.map(dataset => dataset.activeflag))]).toEqual([...new Set(expectedResponse)]);
+			});
+
+			it('Should return the correct count matching the supplied query parameters', async () => {
+				let req = mockedRequest();
+				let res = mockedResponse();
+
+				req.params = {
+					publisherID: 'TestPublisher',
+				};
+
+				req.query = {
+					search: '',
+					datasetIndex: 0,
+					maxResults: 10,
+					sortBy: 'latest',
+					sortDirection: 'asc',
+					status: 'inReview',
+				};
+
+				const response = await getDatasetsByPublisher(req, res);
+
+				const counts = response.json.mock.calls[0][0].data.results.total;
+
+				expect(counts).toBeGreaterThan(0);
 			});
 		});
 	});

--- a/src/resources/dataset/__tests__/datasetonboarding.controller.test.js
+++ b/src/resources/dataset/__tests__/datasetonboarding.controller.test.js
@@ -75,7 +75,7 @@ describe('Dataset onboarding controller', () => {
 			});
 		});
 		describe('As a publisher team user', () => {
-			const statuses = Object.values(constants.datatsetStatuses);
+			const statuses = Object.values(constants.datasetStatuses);
 
 			test.each(statuses)('Each status should only return datasets with the supplied status', async status => {
 				let res = mockedResponse();

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -50,7 +50,6 @@ module.exports = {
 				...(publisherID !== constants.teamTypes.ADMIN && { 'datasetv2.summary.publisher.identifier': publisherID }),
 			};
 
-			//Get all datasets with no search term to produce a counts object
 			const allPublishersDatasetVersions = await Data.find(searchQuery)
 				.select(
 					'_id pid name datasetVersion activeflag timestamps applicationStatusDesc applicationStatusAuthor percentageCompleted datasetv2.summary.publisher.name counter'
@@ -81,7 +80,6 @@ module.exports = {
 
 			let versionedDatasets = [];
 
-			//If search term, return only datasets matching search term
 			if (search.length > 0) {
 				searchQuery['$or'] = [
 					{ name: { $regex: search, $options: 'i' } },

--- a/src/resources/dataset/datasetonboarding.controller.js
+++ b/src/resources/dataset/datasetonboarding.controller.js
@@ -40,7 +40,7 @@ module.exports = {
 				query: { search, datasetIndex, maxResults, sortBy, sortDirection, status },
 			} = req;
 
-			const activeflagOptions = Object.values(constants.datatsetStatuses);
+			const activeflagOptions = Object.values(constants.datasetStatuses);
 
 			let searchQuery = {
 				activeflag: {
@@ -367,12 +367,12 @@ module.exports = {
 
 			let datasetv2Object = await datasetonboardingUtil.buildv2Object(dataset);
 
-			//update dataset to inreview - constants.datatsetStatuses.INREVIEW
+			//update dataset to inreview - constants.datasetStatuses.INREVIEW
 			let updatedDataset = await Data.findOneAndUpdate(
 				{ _id: id },
 				{
 					datasetv2: datasetv2Object,
-					activeflag: constants.datatsetStatuses.INREVIEW,
+					activeflag: constants.datasetStatuses.INREVIEW,
 					'timestamps.updated': Date.now(),
 					'timestamps.submitted': Date.now(),
 				}
@@ -604,7 +604,7 @@ module.exports = {
 				let updatedDataset = await Data.findOneAndUpdate(
 					{ _id: id },
 					{
-						activeflag: constants.datatsetStatuses.REJECTED,
+						activeflag: constants.datasetStatuses.REJECTED,
 						applicationStatusDesc: applicationStatusDesc,
 						applicationStatusAuthor: `${firstname} ${lastname}`,
 						'timestamps.rejected': Date.now(),
@@ -662,7 +662,7 @@ module.exports = {
 				}
 				let updatedDataset = await Data.findOneAndUpdate(
 					{ _id: id },
-					{ activeflag: constants.datatsetStatuses.ARCHIVE, 'timestamps.updated': Date.now(), 'timestamps.archived': Date.now() }
+					{ activeflag: constants.datasetStatuses.ARCHIVE, 'timestamps.updated': Date.now(), 'timestamps.archived': Date.now() }
 				);
 
 				await activityLogService.logActivity(constants.activityLogEvents.dataset.DATASET_VERSION_ARCHIVED, {

--- a/src/resources/dataset/utils/datasetonboarding.util.js
+++ b/src/resources/dataset/utils/datasetonboarding.util.js
@@ -332,7 +332,7 @@ const updateDataset = async (dataset, updateObj) => {
 	// 1. Extract properties
 	let { activeflag, _id } = dataset;
 	// 2. If application is in progress, update initial question answers
-	if (activeflag === constants.datatsetStatuses.DRAFT || activeflag === constants.applicationStatuses.INREVIEW) {
+	if (activeflag === constants.datasetStatuses.DRAFT || activeflag === constants.applicationStatuses.INREVIEW) {
 		await Data.findByIdAndUpdate(_id, updateObj, { new: true }).catch(err => {
 			console.error(err);
 			throw err;
@@ -740,7 +740,7 @@ const buildMetadataQuality = async (dataset, v2Object, pid) => {
 				} else completeness.push({ value: 'observation.measuredProperty', weight });
 			}
 		} else {
-			let datasetValue = getDatatsetValue(cleanV2Object, key);
+			let datasetValue = getDatasetValue(cleanV2Object, key);
 
 			if (!isEmpty(datasetValue)) {
 				totalCount++;
@@ -767,7 +767,7 @@ const buildMetadataQuality = async (dataset, v2Object, pid) => {
 		errorWeight = 0;
 
 	Object.entries(weights).forEach(([key, weight]) => {
-		let datasetValue = getDatatsetValue(cleanV2Object, key);
+		let datasetValue = getDatasetValue(cleanV2Object, key);
 		let updatedKey = '/' + key.replace(/\./g, '/');
 
 		let errorIndex = Object.keys(validate.errors).find(key => validate.errors[key].instancePath === updatedKey);
@@ -822,7 +822,7 @@ const cleanUpV2Object = v2Object => {
  *
  * @return  {String}           [return field value that is found in the dataset]
  */
-const getDatatsetValue = (dataset, field) => {
+const getDatasetValue = (dataset, field) => {
 	return field.split('.').reduce(function (o, k) {
 		return o && o[k];
 	}, dataset);

--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -222,7 +222,7 @@ const _roleTypes = {
 
 // <Dataset onboarding related enums>
 
-const _datatsetStatuses = {
+const _datasetStatuses = {
 	DRAFT: 'draft',
 	INREVIEW: 'inReview',
 	ACTIVE: 'active',
@@ -327,7 +327,7 @@ export default {
 	submissionEmailRecipientTypes: _submissionEmailRecipientTypes,
 	hdrukEmail: _hdrukEmail,
 	mailchimpSubscriptionStatuses: _mailchimpSubscriptionStatuses,
-	datatsetStatuses: _datatsetStatuses,
+	datasetStatuses: _datasetStatuses,
 	logTypes: _logTypes,
 	activityLogEvents: _activityLogEvents,
 	activityLogTypes: _activityLogTypes,


### PR DESCRIPTION
changed by request from FE devs > counts for statuses to not be affected by search term, show all datasets count at all times in response.

The total counts matching the search parameters has not moved into the 'results' key. 