### PR TITLE
Remove pagination from search/sort datasets API

### DIFF
--- a/docs/resources/dataset.docs.js
+++ b/docs/resources/dataset.docs.js
@@ -108,30 +108,9 @@ module.exports = {
 				},
 				{
 					in: 'query',
-					name: 'datasetIndex',
-					required: false,
-					description: 'The index at which to start the results from for pagination purposed. Defaults to 0 if parameter is not given.',
-					schema: {
-						type: 'integer',
-						example: 0,
-					},
-				},
-				{
-					in: 'query',
-					name: 'maxResults',
-					required: false,
-					description:
-						'The maximum number of results (i.e., datasets) to return in the response. Defaults to 10 if the parameter is not given in the initial request.',
-					schema: {
-						type: 'integer',
-						example: 10,
-					},
-				},
-				{
-					in: 'query',
 					name: 'sortBy',
 					required: false,
-					description: `The parameter to sort the dataset results by. Links to the 'sortDirection' which controls whether the sort is ascending or descending. Note that sorting by popularity is only applicable when 'status=active.'. Defaults to 'latest' if no 'sortBy' parameter is given in the request.`,
+					description: `The parameter to sort the dataset results by. Links to the 'sortDirection' which controls whether the sort is ascending or descending. Note that sorting by popularity is only applicable when 'status=active'. Defaults to 'latest' if no 'sortBy' parameter is given in the request.`,
 					schema: {
 						type: 'string',
 						example: 'latest',

--- a/src/controllers/__tests__/datasetonboarding.controller.test.js
+++ b/src/controllers/__tests__/datasetonboarding.controller.test.js
@@ -29,7 +29,7 @@ describe('datasetOnboardingController', () => {
 	describe('getDatasetsByPublisher', () => {
 		it('should return a correctly formatted JSON response', async () => {
 			let serviceStub1 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisherCounts').returns({ inReview: 100 });
-			let serviceStub2 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisher').returns([[], 100, 10]);
+			let serviceStub2 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisher').returns([[], 100]);
 
 			let req = mockedRequest();
 			let res = mockedResponse();
@@ -46,7 +46,6 @@ describe('datasetOnboardingController', () => {
 					results: {
 						status: 'inReview',
 						total: 100,
-						pageCount: 10,
 						listOfDatasets: [],
 					},
 				},
@@ -62,7 +61,7 @@ describe('datasetOnboardingController', () => {
 
 		it('should return status=all if no status param given in initial request', async () => {
 			let serviceStub1 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisherCounts').returns({ inReview: 100 });
-			let serviceStub2 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisher').returns([[], 100, 10]);
+			let serviceStub2 = sinon.stub(datasetonboardingService, 'getDatasetsByPublisher').returns([[], 100]);
 
 			let req = mockedRequest();
 			let res = mockedResponse();
@@ -78,7 +77,6 @@ describe('datasetOnboardingController', () => {
 					results: {
 						status: 'all',
 						total: 100,
-						pageCount: 10,
 						listOfDatasets: [],
 					},
 				},

--- a/src/controllers/datasetonboarding.controller.js
+++ b/src/controllers/datasetonboarding.controller.js
@@ -24,16 +24,14 @@ export default class DatasetOnboardingController {
 		try {
 			let {
 				params: { publisherID },
-				query: { search, datasetIndex, maxResults, sortBy, sortDirection, status },
+				query: { search, sortBy, sortDirection, status },
 			} = req;
 
 			const totalCounts = await this.datasetonboardingService.getDatasetsByPublisherCounts(publisherID);
 
-			const [versionedDatasets, count, pageCount] = await this.datasetonboardingService.getDatasetsByPublisher(
+			const [versionedDatasets, count] = await this.datasetonboardingService.getDatasetsByPublisher(
 				status,
 				publisherID,
-				datasetIndex,
-				maxResults,
 				sortBy,
 				sortDirection,
 				search
@@ -45,7 +43,7 @@ export default class DatasetOnboardingController {
 				success: true,
 				data: {
 					publisherTotals: totalCounts,
-					results: { status: status, total: count, pageCount: pageCount, listOfDatasets: versionedDatasets },
+					results: { status: status, total: count, listOfDatasets: versionedDatasets },
 				},
 			});
 		} catch (err) {

--- a/src/middlewares/__tests__/datasetonboarding.middleware.test.js
+++ b/src/middlewares/__tests__/datasetonboarding.middleware.test.js
@@ -110,8 +110,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: '',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'latest',
 				sortDirection: 'asc',
 				status: 'inReview',
@@ -136,8 +134,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 				req.query = {
 					search: '',
-					datasetIndex: 0,
-					maxResults: 10,
 					sortBy: sortOption,
 					sortDirection: 'asc',
 					status: 'active',
@@ -162,8 +158,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 				req.query = {
 					search: '',
-					datasetIndex: 0,
-					maxResults: 10,
 					sortBy: 'latest',
 					sortDirection: 'asc',
 					status: status,
@@ -190,8 +184,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: '',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'latest',
 				sortDirection: 'asc',
 				status: 'active',
@@ -215,8 +207,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: '',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'unallowedSortOption',
 				sortDirection: 'asc',
 				status: 'inReview',
@@ -239,8 +229,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: '',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'latest',
 				sortDirection: 'asc',
 				status: 'notARealStatus',
@@ -263,8 +251,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: 'unallowed-/?@"{}()characters',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'latest',
 				sortDirection: 'asc',
 				status: 'inReview',
@@ -287,8 +273,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: 'unallowed-/?@"{}()characters',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'latest',
 				sortDirection: 'unallowedSortDirection',
 				status: 'inReview',
@@ -316,8 +300,6 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			req.query = {
 				search: '',
-				datasetIndex: 0,
-				maxResults: 10,
 				sortBy: 'popularity',
 				sortDirection: 'asc',
 				status: 'inReview',

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -23,14 +23,7 @@ const validateSearchParameters = (req, res, next) => {
 	const datasetStatuses = Object.values(constants.datasetStatuses);
 
 	let {
-		query: {
-			search = '',
-			datasetIndex = 0,
-			maxResults = process.env.API_DEFAULT_RESULTS_LIMIT,
-			sortBy = process.env.API_DEFAULT_SORT_OPTION,
-			sortDirection = process.env.API_DEFAULT_SORT_DIRECTION,
-			status,
-		},
+		query: { search = '', sortBy = process.env.API_DEFAULT_SORT_OPTION, sortDirection = process.env.API_DEFAULT_SORT_DIRECTION, status },
 	} = req;
 
 	if (req.params.publisherID === constants.teamTypes.ADMIN) {
@@ -73,8 +66,6 @@ const validateSearchParameters = (req, res, next) => {
 
 	req.query = {
 		search: search.replace(/[-"@.*+/?^${}()|[\]\\]/g, ''),
-		datasetIndex: parseInt(datasetIndex),
-		maxResults: parseInt(maxResults),
 		sortBy: sortBy,
 		sortDirection: sortDirection,
 		status: status,

--- a/src/services/__tests__/datasetonboarding.service.test.js
+++ b/src/services/__tests__/datasetonboarding.service.test.js
@@ -40,30 +40,18 @@ describe('datasetOnboardingService', () => {
 		const statuses = Object.values(constants.datasetStatuses);
 
 		test.each(statuses)('should only return datasets matching the given status', async activeflag => {
-			const datasetIndex = 0;
-			const maxResults = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
 			const status = activeflag;
 			const publisherID = 'TestPublisher';
 			const search = '';
 
-			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				datasetIndex,
-				maxResults,
-				sortBy,
-				sortDirection,
-				search
-			);
+			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(status, publisherID, sortBy, sortDirection, search);
 
 			expect([...new Set(versionedDatasets.map(dataset => dataset.activeflag))].length).toEqual(1);
 		});
 
 		it('should return all status types if no status is given', async () => {
-			const datasetIndex = 0;
-			const maxResults = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
 			const status = null;
@@ -74,84 +62,33 @@ describe('datasetOnboardingService', () => {
 				.filter(dataset => dataset.datasetv2.summary.publisher.identifier === 'TestPublisher')
 				.map(dataset => dataset.activeflag);
 
-			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				datasetIndex,
-				maxResults,
-				sortBy,
-				sortDirection,
-				search
-			);
+			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(status, publisherID, sortBy, sortDirection, search);
 
 			expect([...new Set(versionedDatasets.map(dataset => dataset.activeflag))]).toEqual([...new Set(expectedResponse)]);
 		});
 
 		it('should return the correct count of filered results', async () => {
-			const datasetIndex = 0;
-			const maxResults = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
 			const status = 'inReview';
 			const publisherID = 'admin';
 			const search = '';
 
-			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				datasetIndex,
-				maxResults,
-				sortBy,
-				sortDirection,
-				search
-			);
+			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(status, publisherID, sortBy, sortDirection, search);
 
 			expect(count).toEqual(2);
 		});
 
 		it('should return results matching an appropriate search term', async () => {
-			const datasetIndex = 0;
-			const maxResults = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
 			const status = 'inReview';
 			const publisherID = 'admin';
 			const search = 'abstract3';
 
-			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				datasetIndex,
-				maxResults,
-				sortBy,
-				sortDirection,
-				search
-			);
+			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(status, publisherID, sortBy, sortDirection, search);
 
 			expect(count).toEqual(1);
-		});
-
-		it('should allow for pagintation', async () => {
-			const datasetIndex = 0;
-			const maxResults = 1;
-			const sortBy = 'latest';
-			const sortDirection = 'desc';
-			const status = 'inReview';
-			const publisherID = 'admin';
-			const search = '';
-
-			const [_, count, pageCount] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				datasetIndex,
-				maxResults,
-				sortBy,
-				sortDirection,
-				search
-			);
-
-			expect(count).toEqual(2);
-			expect(pageCount).toEqual(1);
 		});
 	});
 

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -54,7 +54,7 @@ export default class DatasetOnboardingService {
 		return totalCounts;
 	};
 
-	getDatasetsByPublisher = async (status, publisherID, datasetIndex, maxResults, sortBy, sortDirection, search) => {
+	getDatasetsByPublisher = async (status, publisherID, sortBy, sortDirection, search) => {
 		const activeflagOptions = Object.values(constants.datasetStatuses);
 
 		let searchQuery = {
@@ -87,11 +87,7 @@ export default class DatasetOnboardingService {
 
 		versionedDatasets = await datasetonboardingUtil.datasetSortingHelper(versionedDatasets, sortBy, sortDirection);
 
-		versionedDatasets = versionedDatasets.slice(datasetIndex, datasetIndex + maxResults);
-
-		const pageCount = versionedDatasets.length;
-
-		return [versionedDatasets, count, pageCount];
+		return [versionedDatasets, count];
 	};
 
 	getDatasetVersion = async id => {


### PR DESCRIPTION
Removing pagination ability from search/sort story (this functionality will be added to separate story).