### PR TITLE
release-fix/GAT-646

### DIFF
--- a/src/controllers/__tests__/datasetonboarding.controller.test.js
+++ b/src/controllers/__tests__/datasetonboarding.controller.test.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 
 import datasetOnboardingController from '../datasetonboarding.controller';
 import datasetOnboardingService from '../../services/datasetonboarding.service';
+import constants from '../../resources/utilities/constants.util';
 
 afterEach(function () {
 	sinon.restore();
@@ -46,7 +47,7 @@ describe('datasetOnboardingController', () => {
 						inReview: 100,
 					},
 					results: {
-						status: 'inReview',
+						'activeflag(s)': 'inReview',
 						total: 100,
 						currentPage: 1,
 						totalPages: 10,
@@ -81,7 +82,7 @@ describe('datasetOnboardingController', () => {
 						inReview: 100,
 					},
 					results: {
-						status: 'all',
+						'activeflag(s)': Object.values(constants.datasetStatuses).join(', '),
 						total: 100,
 						currentPage: 1,
 						totalPages: 10,

--- a/src/controllers/datasetonboarding.controller.js
+++ b/src/controllers/datasetonboarding.controller.js
@@ -54,7 +54,7 @@ export default class DatasetOnboardingController {
 				data: {
 					publisherTotals: totalCounts,
 					results: {
-						'activeflag(s)': statusArray.join(', '),
+						'activeflag(s)': [...new Set(statusArray)].join(', '),
 						total: count,
 						currentPage: page,
 						totalPages: pageCount,

--- a/src/controllers/datasetonboarding.controller.js
+++ b/src/controllers/datasetonboarding.controller.js
@@ -21,16 +21,24 @@ export default class DatasetOnboardingController {
 	}
 
 	getDatasetsByPublisher = async (req, res) => {
+		const activeflagOptions = Object.values(constants.datasetStatuses);
+
 		try {
 			let {
 				params: { publisherID },
 				query: { search, page, limit, sortBy, sortDirection, status },
 			} = req;
 
+			let statusArray = activeflagOptions;
+
+			if (status) {
+				statusArray = status.split(',');
+			}
+
 			const totalCounts = await this.datasetonboardingService.getDatasetsByPublisherCounts(publisherID);
 
 			const [versionedDatasets, count] = await this.datasetonboardingService.getDatasetsByPublisher(
-				status,
+				statusArray,
 				publisherID,
 				page,
 				limit,
@@ -39,15 +47,19 @@ export default class DatasetOnboardingController {
 				search
 			);
 
-			if (!status) status = 'all';
-
 			const pageCount = Math.ceil(count / limit);
 
 			return res.status(200).json({
 				success: true,
 				data: {
 					publisherTotals: totalCounts,
-					results: { status: status, total: count, currentPage: page, totalPages: pageCount, listOfDatasets: versionedDatasets },
+					results: {
+						'activeflag(s)': statusArray.join(', '),
+						total: count,
+						currentPage: page,
+						totalPages: pageCount,
+						listOfDatasets: versionedDatasets,
+					},
 				},
 			});
 		} catch (err) {

--- a/src/middlewares/__tests__/datasetonboarding.middleware.test.js
+++ b/src/middlewares/__tests__/datasetonboarding.middleware.test.js
@@ -108,7 +108,7 @@ describe('Testing the datasetonboarding middleware', () => {
 		];
 
 		test.each(pageAndLimitOptions)(
-			'Each invalid page-limit combination should return a 500 error and the appropriate response',
+			'Each invalid page-limit combination should return a 400 error and the appropriate response',
 			pageLimitOption => {
 				let req = mockedRequest();
 				let res = mockedResponse();
@@ -134,7 +134,7 @@ describe('Testing the datasetonboarding middleware', () => {
 
 				validateSearchParameters(req, res, nextFunction);
 
-				expect(res.status).toHaveBeenCalledWith(500);
+				expect(res.status).toHaveBeenCalledWith(400);
 				expect(res.json).toHaveBeenCalledWith(expectedResponse);
 				expect(nextFunction.mock.calls.length).toBe(0);
 			}
@@ -189,7 +189,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			expect(nextFunction.mock.calls.length).toBe(sortOptions.length);
 		});
 
-		it('Should invoke next() for each correct status option', () => {
+		it('Should invoke next() for each correct single status option', () => {
 			let req = mockedRequest();
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
@@ -213,6 +213,28 @@ describe('Testing the datasetonboarding middleware', () => {
 			});
 
 			expect(nextFunction.mock.calls.length).toBe(statuses.length);
+		});
+
+		it('Should invoke next() for multiple correct status options', () => {
+			let req = mockedRequest();
+			let res = mockedResponse();
+			const nextFunction = jest.fn();
+
+			req.params = {
+				publisherID: 'fakeTeam',
+			};
+
+			req.query = {
+				search: '',
+				page: 1,
+				limit: 10,
+				sortBy: 'latest',
+				sortDirection: 'asc',
+				status: 'active,draft,rejected',
+			};
+			validateSearchParameters(req, res, nextFunction);
+
+			expect(nextFunction.mock.calls.length).toBe(1);
 		});
 
 		it('Should return a 401 if and admin team member provides a status which is not "inReview"', () => {
@@ -245,7 +267,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});
 
-		it('Should return a 500 error for an unallowed sort option', () => {
+		it('Should return a 400 error for an unallowed sort option', () => {
 			let req = mockedRequest();
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
@@ -265,11 +287,11 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			validateSearchParameters(req, res, nextFunction);
 
-			expect(res.status).toHaveBeenCalledWith(500);
+			expect(res.status).toHaveBeenCalledWith(400);
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});
 
-		it('Should return a 500 error for an unallowed status parameter', () => {
+		it('Should return a 400 error for an unallowed single status parameter', () => {
 			let req = mockedRequest();
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
@@ -289,7 +311,31 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			validateSearchParameters(req, res, nextFunction);
 
-			expect(res.status).toHaveBeenCalledWith(500);
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(nextFunction.mock.calls.length).toBe(0);
+		});
+
+		it('Should return a 400 error for an unallowed status parameter if multiple are supplied', () => {
+			let req = mockedRequest();
+			let res = mockedResponse();
+			const nextFunction = jest.fn();
+
+			req.params = {
+				publisherID: 'fakeTeam',
+			};
+
+			req.query = {
+				search: '',
+				page: 1,
+				limit: 10,
+				sortBy: 'latest',
+				sortDirection: 'asc',
+				status: 'active,notARealStatus,rejected',
+			};
+
+			validateSearchParameters(req, res, nextFunction);
+
+			expect(res.status).toHaveBeenCalledWith(400);
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});
 
@@ -317,7 +363,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			expect(nextFunction.mock.calls.length).toBe(1);
 		});
 
-		it('Should return a 500 error for an unallowed sortDirection option', () => {
+		it('Should return a 400 error for an unallowed sortDirection option', () => {
 			let req = mockedRequest();
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
@@ -337,11 +383,11 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			validateSearchParameters(req, res, nextFunction);
 
-			expect(res.status).toHaveBeenCalledWith(500);
+			expect(res.status).toHaveBeenCalledWith(400);
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});
 
-		it('Should return a 500 error for the popularity sort option with a status which does not equal active', () => {
+		it('Should return a 400 error for the popularity sort option with a status which does not equal active', () => {
 			let req = mockedRequest();
 			let res = mockedResponse();
 			const nextFunction = jest.fn();
@@ -366,7 +412,7 @@ describe('Testing the datasetonboarding middleware', () => {
 
 			validateSearchParameters(req, res, nextFunction);
 
-			expect(res.status).toHaveBeenCalledWith(500);
+			expect(res.status).toHaveBeenCalledWith(400);
 			expect(res.json).toHaveBeenCalledWith(expectedResponse);
 			expect(nextFunction.mock.calls.length).toBe(0);
 		});

--- a/src/middlewares/__tests__/datasetonboarding.middleware.test.js
+++ b/src/middlewares/__tests__/datasetonboarding.middleware.test.js
@@ -349,7 +349,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			};
 
 			req.query = {
-				search: 'unallowed-/?@"{}()characters',
+				search: 'unallowed/?@"{}()characters',
 				page: 1,
 				limit: 10,
 				sortBy: 'latest',
@@ -373,7 +373,7 @@ describe('Testing the datasetonboarding middleware', () => {
 			};
 
 			req.query = {
-				search: 'unallowed-/?@"{}()characters',
+				search: 'unallowed/?@"{}()characters',
 				page: 1,
 				limit: 10,
 				sortBy: 'latest',

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -81,7 +81,7 @@ const validateSearchParameters = (req, res, next) => {
 	}
 
 	req.query = {
-		search: search.replace(/[-"@.*+/?^${}()|[\]\\]/g, ''),
+		search: search.replace(/["@.*+/?^${}()|[\]\\]/g, ''),
 		page: parseInt(page),
 		limit: parseInt(limit),
 		sortBy: sortBy,

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -49,26 +49,13 @@ const validateSearchParameters = (req, res, next) => {
 			});
 		}
 	} else {
-		if (status) {
-			if (status.split(',').length > 1) {
-				status.split(',').forEach(status => {
-					if (!datasetStatuses.includes(status)) {
-						return res.status(400).json({
-							success: false,
-							message: `The status parameter must be one of or a combination of [${datasetStatuses.join(
-								', '
-							)}]. Multiple statuses must be delimited by a ',' (comma - with no space)`,
-						});
-					}
-				});
-			} else if (!datasetStatuses.includes(status)) {
-				return res.status(400).json({
-					success: false,
-					message: `The status parameter must be one of or a combination of [${datasetStatuses.join(
-						', '
-					)}]. Multiple statuses must be delimited by a ',' (comma - with no space)`,
-				});
-			}
+		if (status && !status.split(',').every(option => datasetStatuses.includes(option))) {
+			return res.status(400).json({
+				success: false,
+				message: `The status parameter must be one of or a combination of [${datasetStatuses.join(
+					', '
+				)}]. Multiple statuses must be delimited by a ',' (comma - with no space)`,
+			});
 		}
 	}
 

--- a/src/middlewares/datasetonboarding.middleware.js
+++ b/src/middlewares/datasetonboarding.middleware.js
@@ -34,7 +34,7 @@ const validateSearchParameters = (req, res, next) => {
 	} = req;
 
 	if (page < 1 || limit < 1 || !parseInt(page) || !parseInt(limit)) {
-		return res.status(500).json({
+		return res.status(400).json({
 			success: false,
 			message: 'The page and / or limit parameter(s) must be integers > 0',
 		});
@@ -49,30 +49,45 @@ const validateSearchParameters = (req, res, next) => {
 			});
 		}
 	} else {
-		if (status && !datasetStatuses.includes(status)) {
-			return res.status(500).json({
-				success: false,
-				message: `The status parameter must be one of [${datasetStatuses.join(', ')}]`,
-			});
+		if (status) {
+			if (status.split(',').length > 1) {
+				status.split(',').forEach(status => {
+					if (!datasetStatuses.includes(status)) {
+						return res.status(400).json({
+							success: false,
+							message: `The status parameter must be one of or a combination of [${datasetStatuses.join(
+								', '
+							)}]. Multiple statuses must be delimited by a ',' (comma - with no space)`,
+						});
+					}
+				});
+			} else if (!datasetStatuses.includes(status)) {
+				return res.status(400).json({
+					success: false,
+					message: `The status parameter must be one of or a combination of [${datasetStatuses.join(
+						', '
+					)}]. Multiple statuses must be delimited by a ',' (comma - with no space)`,
+				});
+			}
 		}
 	}
 
 	if (!sortOptions.includes(sortBy)) {
-		return res.status(500).json({
+		return res.status(400).json({
 			success: false,
 			message: `The sortBy parameter must be one of [${sortOptions.join(', ')}]`,
 		});
 	}
 
 	if (!['asc', 'desc'].includes(sortDirection)) {
-		return res.status(500).json({
+		return res.status(400).json({
 			success: false,
 			message: `The sort direction must be either ascending [asc] or descending [desc]`,
 		});
 	}
 
 	if (sortBy === 'popularity' && status !== constants.datasetStatuses.ACTIVE) {
-		return res.status(500).json({
+		return res.status(400).json({
 			success: false,
 			message: `Sorting by popularity is only available for active datasets [status=active]`,
 		});

--- a/src/services/__tests__/datasetonboarding.service.test.js
+++ b/src/services/__tests__/datasetonboarding.service.test.js
@@ -44,12 +44,12 @@ describe('datasetOnboardingService', () => {
 			const limit = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
-			const status = activeflag;
+			const statusArray = [activeflag];
 			const publisherID = 'TestPublisher';
 			const search = '';
 
 			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
+				statusArray,
 				publisherID,
 				page,
 				limit,
@@ -61,43 +61,17 @@ describe('datasetOnboardingService', () => {
 			expect([...new Set(versionedDatasets.map(dataset => dataset.activeflag))].length).toEqual(1);
 		});
 
-		it('should return all status types if no status is given', async () => {
-			const page = 1;
-			const limit = 10;
-			const sortBy = 'latest';
-			const sortDirection = 'desc';
-			const status = null;
-			const publisherID = 'TestPublisher';
-			const search = '';
-
-			const expectedResponse = datasetSearchStub
-				.filter(dataset => dataset.datasetv2.summary.publisher.identifier === 'TestPublisher')
-				.map(dataset => dataset.activeflag);
-
-			const [versionedDatasets] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
-				publisherID,
-				page,
-				limit,
-				sortBy,
-				sortDirection,
-				search
-			);
-
-			expect([...new Set(versionedDatasets.map(dataset => dataset.activeflag))].sort()).toEqual([...new Set(expectedResponse)].sort());
-		});
-
 		it('should return the correct count of filered results', async () => {
 			const page = 1;
 			const limit = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
-			const status = 'inReview';
+			const statusArray = ['inReview'];
 			const publisherID = 'admin';
 			const search = '';
 
 			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
+				statusArray,
 				publisherID,
 				page,
 				limit,
@@ -114,12 +88,12 @@ describe('datasetOnboardingService', () => {
 			const limit = 10;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
-			const status = 'inReview';
+			const statusArray = ['inReview'];
 			const publisherID = 'admin';
 			const search = 'abstract3';
 
 			const [_, count] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
+				statusArray,
 				publisherID,
 				page,
 				limit,
@@ -136,12 +110,12 @@ describe('datasetOnboardingService', () => {
 			const limit = 1;
 			const sortBy = 'latest';
 			const sortDirection = 'desc';
-			const status = 'inReview';
+			const statusArray = ['inReview'];
 			const publisherID = 'admin';
 			const search = '';
 
 			const [versionedDatasets, count] = await datasetonboardingService.getDatasetsByPublisher(
-				status,
+				statusArray,
 				publisherID,
 				page,
 				limit,
@@ -161,12 +135,12 @@ describe('datasetOnboardingService', () => {
 				const limit = 10;
 				const sortBy = sortOption;
 				const sortDirection = 'asc';
-				const status = '';
+				const statusArray = Object.values(constants.datasetStatuses);
 				const publisherID = 'admin';
 				const search = 'test';
 
 				const [versionedDatasets, _] = await datasetonboardingService.getDatasetsByPublisher(
-					status,
+					statusArray,
 					publisherID,
 					page,
 					limit,
@@ -215,12 +189,12 @@ describe('datasetOnboardingService', () => {
 				const limit = 10;
 				const sortBy = sortOption;
 				const sortDirection = 'desc';
-				const status = '';
+				const statusArray = Object.values(constants.datasetStatuses);
 				const publisherID = 'admin';
 				const search = 'test';
 
 				const [versionedDatasets, _] = await datasetonboardingService.getDatasetsByPublisher(
-					status,
+					statusArray,
 					publisherID,
 					page,
 					limit,

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -54,9 +54,7 @@ export default class DatasetOnboardingService {
 		return totalCounts;
 	};
 
-	getDatasetsByPublisher = async (status, publisherID, page, limit, sortBy, sortDirection, search) => {
-		const activeflagOptions = Object.values(constants.datasetStatuses);
-
+	getDatasetsByPublisher = async (statusArray, publisherID, page, limit, sortBy, sortDirection, search) => {
 		let datasets = await Data.aggregate([
 			{
 				$match: {
@@ -122,11 +120,9 @@ export default class DatasetOnboardingService {
 			},
 			{
 				$match: {
-					activeflag: status
-						? status
-						: {
-								$in: activeflagOptions,
-						  },
+					activeflag: {
+						$in: statusArray,
+					},
 					...(search.length > 0 && {
 						$or: [
 							{ name: { $regex: search, $options: 'i' } },


### PR DESCRIPTION
Fixes a defect where the draft datasets were not shown alongside the live datasets on the custodian/HDR admin dashboard.

Changes to endpoint so that the dataset-onboarding GET can accept a comma-delimited list of statuses instead of one, e.g., status=active,draft, minimising the number of requests that are required from the FE.

Changed to middleware functions to return a 400 in the case of an invalid param (instead of 500).

Fixes to relevant tests.