### PR TITLE
release-fix/GAT-655

### DIFF
--- a/src/services/__mocks__/datasetSearchStub.js
+++ b/src/services/__mocks__/datasetSearchStub.js
@@ -130,6 +130,8 @@ export const datasetSearchStub = [
 			submitted: 456,
 		},
 		pid: 'pid7',
+		datasetid: 'exampleID',
+		questionAnswers: '{ "properties/summary/title": "test6 v1" }',
 		datasetVersion: '1.0.0',
 		name: 'test2 v1',
 		datasetv2: { summary: { publisher: { identifier: 'AnotherTestPublisher' }, abstract: 'test' } },

--- a/src/services/__tests__/datasetonboarding.service.test.js
+++ b/src/services/__tests__/datasetonboarding.service.test.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 
 import dbHandler from '../../config/in-memory-db';
+import { Data } from '../../resources/tool/data.model';
 import { publisherStub } from '../__mocks__/publisherStub';
 import constants from '../../resources/utilities/constants.util';
 import { datasetSearchStub } from '../__mocks__/datasetSearchStub';
@@ -286,6 +287,26 @@ describe('datasetOnboardingService', () => {
 			await datasetonboardingService.createNewDatasetVersion(publisherID, pid, currentVersionId);
 
 			expect(newVersionForExistingDatasetStub.calledOnce).toBe(true);
+		});
+	});
+
+	describe('duplicateDataset', () => {
+		it('should not create duplicates of the pid and datasetid fields', async () => {
+			const dataset = datasetSearchStub[7];
+
+			await datasetonboardingService.duplicateDataset(dataset._id);
+
+			const allDatasets = await Data.find({}).sort({ createdAt: -1 });
+
+			const duplicatedDataset = allDatasets[0];
+
+			expect(duplicatedDataset._id).not.toEqual(dataset._id);
+			expect(duplicatedDataset.datasetid).not.toEqual(dataset.datasetid);
+			expect(duplicatedDataset.pid).not.toEqual(dataset.pid);
+			expect(duplicatedDataset.questionAnswers).not.toEqual(dataset.questionAnswers);
+			expect(duplicatedDataset.name).toEqual(dataset.name + '-duplicate');
+			expect(duplicatedDataset.activeflag).toEqual('draft');
+			expect(duplicatedDataset.datasetVersion).toEqual('1.0.0');
 		});
 	});
 });

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -314,6 +314,9 @@ export default class DatasetOnboardingService {
 		delete datasetCopy._id;
 		datasetCopy.pid = uuidv4();
 
+		delete datasetCopy.datasetid;
+		datasetCopy.datasetid = 'New duplicated dataset';
+
 		let parsedQuestionAnswers = JSON.parse(datasetCopy.questionAnswers);
 		parsedQuestionAnswers['properties/summary/title'] += duplicateText;
 


### PR DESCRIPTION
Fixes an issue where a duplicated dataset had matching 'datasetid' fields to their root, causing propagated errors.

Fixed by adding temp string for datasetid, which is replaced when the dataset is approved.

Added test.