### PR TITLE
release-fix/GAT-725

### DIFF
--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -313,9 +313,18 @@ const _datasetSortOptions = {
 	latest: 'timestamps.updated',
 	alphabetic: 'name',
 	metadata: 'percentageCompleted.summary',
-	recentlyadded: 'timestamps.created',
+	recentlyadded: 'timestamps.published',
 	popularity: 'counter',
 	relevance: 'weights',
+};
+
+const _datasetSortOptionsKeys = {
+	LATEST: 'latest',
+	ALPHABETIC: 'alphabetic',
+	METADATA: 'metadata',
+	RECENTLYADDED: 'recentlyadded',
+	POPULARITY: 'popularity',
+	RELEVANCE: 'relevance',
 };
 
 const _datasetSortDirections = {
@@ -353,6 +362,7 @@ export default {
 	activityLogNotifications: _activityLogNotifications,
 	DARMessageTypes: _DARMessageTypes,
 	datasetSortOptions: _datasetSortOptions,
+	datasetSortOptionsKeys: _datasetSortOptionsKeys,
 	datasetSortDirections: _datasetSortDirections,
 	dataUseRegisterStatus: _dataUseRegisterStatus,
 	dataUseRegisterNotifications: _dataUseRegisterNotifications,

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -183,7 +183,12 @@ export default class DatasetOnboardingService {
 					},
 				},
 			},
-			{ $sort: { [constants.datasetSortOptions[sortBy]]: constants.datasetSortDirections[sortDirection] } },
+			{
+				$sort: {
+					[constants.datasetSortOptions[sortBy]]: constants.datasetSortDirections[sortDirection],
+					'timestamps.updated': constants.datasetSortDirections[sortDirection],
+				},
+			},
 			{ $unset: 'weights' },
 			{
 				$facet: {

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -185,6 +185,7 @@ export default class DatasetOnboardingService {
 			},
 			{
 				$sort: {
+					...(sortBy === constants.datasetSortOptionsKeys.RECENTLYADDED && { activeflag: 1 }),
 					[constants.datasetSortOptions[sortBy]]: constants.datasetSortDirections[sortDirection],
 					'timestamps.updated': constants.datasetSortDirections[sortDirection],
 				},


### PR DESCRIPTION
Metadata sorting caused datasets with the same metadata score to be randomly sorted. This fix add the timestamps.updated as the secondary sort such that the datasets will first be sorted on the chosen sort option, and then secondary by the updated time.