### PR TITLE
release-fix/GAT-733

### DIFF
--- a/src/resources/utilities/constants.util.js
+++ b/src/resources/utilities/constants.util.js
@@ -312,7 +312,7 @@ const _systemGeneratedUser = {
 const _datasetSortOptions = {
 	latest: 'timestamps.updated',
 	alphabetic: 'name',
-	metadata: 'percentageCompleted.summary',
+	metadata: 'metadataQualityScore',
 	recentlyadded: 'timestamps.published',
 	popularity: 'counter',
 	relevance: 'weights',

--- a/src/services/__mocks__/datasetSearchStub.js
+++ b/src/services/__mocks__/datasetSearchStub.js
@@ -13,8 +13,10 @@ export const datasetSearchStub = [
 		name: 'test1 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract1', keywords: ['test'] } },
 		activeflag: 'rejected',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 	},
@@ -30,8 +32,10 @@ export const datasetSearchStub = [
 		name: 'A test1 v2',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract2' } },
 		activeflag: 'inReview',
-		percentageCompleted: {
-			summary: 60,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 60,
+			},
 		},
 		type: 'dataset',
 		counter: 5,
@@ -48,8 +52,10 @@ export const datasetSearchStub = [
 		name: 'B test2 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract3' } },
 		activeflag: 'inReview',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 		counter: 10,
@@ -66,8 +72,10 @@ export const datasetSearchStub = [
 		name: 'test3 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract4' } },
 		activeflag: 'draft',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 	},
@@ -83,8 +91,10 @@ export const datasetSearchStub = [
 		name: 'test4 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract5' } },
 		activeflag: 'active',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 	},
@@ -100,8 +110,10 @@ export const datasetSearchStub = [
 		name: 'test5 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract6' } },
 		activeflag: 'rejected',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 	},
@@ -117,8 +129,10 @@ export const datasetSearchStub = [
 		name: 'test6 v1',
 		datasetv2: { summary: { publisher: { identifier: 'TestPublisher' }, abstract: 'abstract7' } },
 		activeflag: 'archive',
-		percentageCompleted: {
-			summary: 80,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 80,
+			},
 		},
 		type: 'dataset',
 	},
@@ -136,8 +150,10 @@ export const datasetSearchStub = [
 		name: 'test2 v1',
 		datasetv2: { summary: { publisher: { identifier: 'AnotherTestPublisher' }, abstract: 'test' } },
 		activeflag: 'inReview',
-		percentageCompleted: {
-			summary: 70,
+		datasetfields: {
+			metadataquality: {
+				weighted_quality_score: 70,
+			},
 		},
 		type: 'dataset',
 		counter: 1,

--- a/src/services/__tests__/datasetonboarding.service.test.js
+++ b/src/services/__tests__/datasetonboarding.service.test.js
@@ -162,7 +162,7 @@ describe('datasetOnboardingService', () => {
 				}
 
 				if (sortOption === 'metadata') {
-					let arr = versionedDatasets.map(dataset => dataset.percentageCompleted.summary);
+					let arr = versionedDatasets.map(dataset => dataset.metadataQualityScore);
 					expect(arr[0]).toBeLessThan(arr[1]);
 				}
 
@@ -216,7 +216,7 @@ describe('datasetOnboardingService', () => {
 				}
 
 				if (sortOption === 'metadata') {
-					let arr = versionedDatasets.map(dataset => dataset.percentageCompleted.summary);
+					let arr = versionedDatasets.map(dataset => dataset.metadataQualityScore);
 					expect(arr[1]).toBeLessThan(arr[0]);
 				}
 

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -95,7 +95,14 @@ export default class DatasetOnboardingService {
 					'datasetv2.summary.publisher.identifier': { $arrayElemAt: ['$versions.datasetv2.summary.publisher.identifier', 0] },
 					counter: { $arrayElemAt: ['$versions.counter', 0] },
 					percentageCompleted: { $arrayElemAt: ['$versions.percentageCompleted', 0] },
-					metadataQualityScore: { $arrayElemAt: ['$versions.datasetfields.metadataquality.weighted_quality_score', 0] },
+					metadataQualityScore: {
+						$convert: {
+							input: { $arrayElemAt: ['$versions.datasetfields.metadataquality.weighted_quality_score', 0] },
+							to: 'double',
+							onError: 0,
+							onNull: 0,
+						},
+					},
 					listOfVersions: {
 						$map: {
 							input: '$versions',

--- a/src/services/datasetonboarding.service.js
+++ b/src/services/datasetonboarding.service.js
@@ -95,6 +95,7 @@ export default class DatasetOnboardingService {
 					'datasetv2.summary.publisher.identifier': { $arrayElemAt: ['$versions.datasetv2.summary.publisher.identifier', 0] },
 					counter: { $arrayElemAt: ['$versions.counter', 0] },
 					percentageCompleted: { $arrayElemAt: ['$versions.percentageCompleted', 0] },
+					metadataQualityScore: { $arrayElemAt: ['$versions.datasetfields.metadataquality.weighted_quality_score', 0] },
 					listOfVersions: {
 						$map: {
 							input: '$versions',


### PR DESCRIPTION
Sorting by metadata was sorting on the wrong field.

This updates sorts on the metadata quality score. Because this field is sometimes a string, use the Mongo conversion feature. Datasets with no score are sorted as if they had a score of 0.

Datasets with the same score are secondary sorted on their updated time.