### PR TITLE
feature/GAT-994

### DIFF
--- a/src/resources/publisher/publisher.model.js
+++ b/src/resources/publisher/publisher.model.js
@@ -44,6 +44,12 @@ const PublisherSchema = new Schema(
 		allowAccessRequestManagement: { type: Boolean, default: false },
 		uses5Safes: { type: Boolean, default: false },
 		wordTemplate: String,
+		federation: {
+			active: { type: Boolean },
+			auth: { type: Object, select: false },
+			endpoints: { type: Boolean, select: false },
+			notificationEmail: { type: Array, select: false },
+		},
 	},
 	{
 		toJSON: { virtuals: true },


### PR DESCRIPTION
Add the federation field to the publisher model specification and set the sensitive fields to "select: false" so that they are not returned in the API response to the FE. Only active: true/false under federation should be shown.