### PR TITLE
Fix metadata ordering of search results

### DIFF
--- a/src/resources/questionbank/__tests__/questionbank.service.test.js
+++ b/src/resources/questionbank/__tests__/questionbank.service.test.js
@@ -13,7 +13,7 @@ import * as noSchemaExists from '../__mocks__/noSchemaExists';
 describe('Question Bank Service', function () {
 	const dataRequestRepository = new DataRequestRepository();
 	const globalService = new GlobalService();
-	sinon.stub(globalService, 'getGlobal').returns(questionBank.globalDocument);
+	sinon.stub(globalService, 'getMasterSchema').returns(questionBank.globalDocument);
 	const publisherRepository = new PublisherRepository();
 	sinon.stub(publisherRepository, 'getPublisher').returns(questionBank.publisherDocument);
 	const publisherService = new PublisherService(publisherRepository);

--- a/src/resources/search/search.repository.js
+++ b/src/resources/search/search.repository.js
@@ -320,7 +320,16 @@ export async function getObjectResult(type, searchAll, searchQuery, startIndex, 
 
 					activeflag: 1,
 					counter: 1,
-					'datasetfields.metadataquality.weighted_quality_score': 1,
+
+					'datasetfields.metadataquality.weighted_quality_score': {
+						$convert: {
+							input: '$datasetfields.metadataquality.weighted_quality_score',
+							to: 'double',
+							onError: 0,
+							onNull: 0,
+						},
+					},
+
 					'datasetfields.metadataquality.weighted_quality_rating': 1,
 					'datasetfields.metadataquality.weighted_error_percent': 1,
 					'datasetfields.metadataquality.weighted_completeness_percent': 1,


### PR DESCRIPTION
Fixes bug where metadata ordering was not working properly because the metadata quality score was in string format for some datasets. Also fixes a broken unit test.