### PR TITLE
updates hubspot calls to use new auth method for private apps

### DIFF
--- a/src/services/hubspot/hubspot.js
+++ b/src/services/hubspot/hubspot.js
@@ -10,7 +10,7 @@ import { logger } from '../../resources/utilities/logger';
 const apiKey = process.env.HUBSPOT_API_KEY;
 const logCategory = 'Hubspot Integration';
 let hubspotClient;
-if (apiKey) hubspotClient = new Client({ apiKey, numberOfApiCallRetries: NumberOfRetries.Three });
+if (apiKey) hubspotClient = new Client({ accessToken: apiKey, numberOfApiCallRetries: NumberOfRetries.Three });
 
 /**
  * Sync A Single Gateway User With Hubspot


### PR DESCRIPTION
Prior to deployment, you’ll need the following to test:

```
HUBSPOT_API_KEY=<new private app phrase key>
HUBSPOT_SYNC_KEY=<a shared sync key>
```

The private app phrase key will come from @camilner-hdr. The shared sync key, just needs to match what is currently live in the environment and what is sent inside the POST to the service under

```
{
    "key": "<a shared sync key>"
}
```