### PR TITLE
Fix index tests filtered by user_id

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -14,7 +14,8 @@ return [
             'firstname' => 'John',
             'lastname' => 'Doe',
             'email' => 'john.doe.1234567890@example.com',
-            'password' => 'passw@rdJ0hnD0e'
+            'password' => 'passw@rdJ0hnD0e',
+            'is_admin' => 1
         ],
     ],
     'per_page' => 25,

--- a/tests/Traits/Authorization.php
+++ b/tests/Traits/Authorization.php
@@ -11,6 +11,7 @@ trait Authorization
     const CFG_TEST_NAME = 'constants.test.user.name';
     const CFG_TEST_EMAIL = 'constants.test.user.email';
     const CFG_TEST_PASSWORD = 'constants.test.user.password';
+    const CFG_TEST_ADMIN = 'constants.test.user.is_admin';
     const CFG_PROVIDER_SERVICE = 'constants.provider.service';
 
     public function authorisationUser(): bool
@@ -22,6 +23,7 @@ trait Authorization
             'email' => Config::get(self::CFG_TEST_EMAIL),
             'provider' => Config::get(self::CFG_PROVIDER_SERVICE),
             'password' => Hash::make(Config::get(self::CFG_TEST_PASSWORD)),
+            'is_admin' => Config::get(self::CFG_TEST_ADMIN),
         ];
 
         $userId = $this->checkUserIfExist();


### PR DESCRIPTION
The `index` tests for ActivityLogs, Applications and Users were failing because the test user did not have permissions so the response was empty.  This PR makes the test user an admin so that they have permission.