### PR TITLE
Revert "Add JWT environment variables to .env.example."

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,11 +66,6 @@ VITE_PUSHER_PORT="${PUSHER_PORT}"
 VITE_PUSHER_SCHEME="${PUSHER_SCHEME}"
 VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
-# generate using php artisan jwt:secret
-JWT_SECRET=
-# JWT expiration time in seconds
-JWT_EXPIRATION=86400
-
 GATEWAY_URL="http://localhost:3000"
 CORS_ACCESS_CONTROL_ALLOW_ORIGIN="http://localhost:3000"
 


### PR DESCRIPTION
Reverts HDRUK/gateway-api-2#62 as this broke the CI tests - not sure why? Probably just because the PR was so old.