### PR TITLE
update request payload federation

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -458,7 +458,6 @@ class DatasetController extends Controller
                     $duplicateDataModel = Mauro::duplicateDataModel($currentDatasetId);
                     $newDatasetId = (string) $duplicateDataModel['id'];
                     MMC::updateDataModel($user, $team, $input, $newDatasetId);
-                    $versioning = Mauro::finaliseDataModel($newDatasetId, 'minor');
 
                     $dataset = MMC::createDataset([
                         'datasetid' => $newDatasetId,

--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -252,7 +252,7 @@ class FederationController extends Controller
                 'team_id' => $teamId,
             ]);
 
-            foreach($input['notification'] as $email) {
+            foreach($input['notifications'] as $email) {
                 $notification = Notification::create([
                     'notification_type' => 'federation',
                     'message' => '',
@@ -375,7 +375,7 @@ class FederationController extends Controller
                 FederationHasNotification::where('notification_id', $federationNotification)->delete();
             }
 
-            foreach ($input['notification'] as $email) {
+            foreach ($input['notifications'] as $email) {
                 $notification = Notification::create([
                     'notification_type' => 'federation',
                     'message' => '',
@@ -498,7 +498,7 @@ class FederationController extends Controller
 
             Federation::where('id', $federationId)->update($array);
 
-            if (array_key_exists('notification', $input)) {
+            if (array_key_exists('notifications', $input)) {
                 $federationNotifications = FederationHasNotification::where([
                     'federation_id' => $federationId,
                 ])->pluck('notification_id');
@@ -508,7 +508,7 @@ class FederationController extends Controller
                     FederationHasNotification::where('notification_id', $federationNotification)->delete();
                 }
 
-                foreach ($input['notification'] as $email) {
+                foreach ($input['notifications'] as $email) {
                     $notification = Notification::create([
                         'notification_type' => 'federation',
                         'message' => '',

--- a/app/Http/Requests/Federation/CreateFederation.php
+++ b/app/Http/Requests/Federation/CreateFederation.php
@@ -53,10 +53,10 @@ class CreateFederation extends BaseFormRequest
                 'required',
                 'boolean',
             ],
-            'notification' => [
+            'notifications' => [
                 'array',
             ],
-            'notification.*' => [
+            'notifications.*' => [
                 'email',
             ],
             'tested' => [

--- a/app/Http/Requests/Federation/EditFederation.php
+++ b/app/Http/Requests/Federation/EditFederation.php
@@ -61,10 +61,10 @@ class EditFederation extends BaseFormRequest
             'enabled' => [
                 'boolean',
             ],
-            'notification' => [
+            'notifications' => [
                 'array',
             ],
-            'notification.*' => [
+            'notifications.*' => [
                 'email',
             ],
             'tested' => [

--- a/app/Http/Requests/Federation/UpdateFederation.php
+++ b/app/Http/Requests/Federation/UpdateFederation.php
@@ -69,10 +69,10 @@ class UpdateFederation extends BaseFormRequest
                 'required',
                 'boolean',
             ],
-            'notification' => [
+            'notifications' => [
                 'array',
             ],
-            'notification.*' => [
+            'notifications.*' => [
                 'email',
             ],
             'tested' => [

--- a/app/Models/Federation.php
+++ b/app/Models/Federation.php
@@ -57,7 +57,6 @@ class Federation extends Model
         'endpoint_datasets',
         'endpoint_dataset',
         'run_time_hour',
-        'notification',
         'enabled',
         'tested',
     ];

--- a/rest.http
+++ b/rest.http
@@ -762,7 +762,7 @@ Authorization: Bearer {{accessToken}}
     "endpoint_dataset": "/api/v1/noauth/datasets/{id}",
     "run_time_hour": 11,
     "enabled": true,
-    "notification": [
+    "notifications": [
         "t1@test.com",
         "t2@test.com",
         "t3@test.com"
@@ -785,7 +785,7 @@ Authorization: Bearer {{accessToken}}
     "endpoint_dataset": "/api/v1/noauth/datasets/{id}",
     "run_time_hour": 11,
     "enabled": true,
-    "notification": [
+    "notifications": [
         "t1@test.com",
         "y2@test.com",
         "y3@test.com"
@@ -807,7 +807,7 @@ Authorization: Bearer {{accessToken}}
     "endpoint_dataset": "/api/v1/noauth/datasets/{id}",
     "run_time_hour": 11,
     "enabled": true,
-    "notification": [
+    "notifications": [
         "t1@test.com"
     ]
 }

--- a/tests/Feature/FederationTest.php
+++ b/tests/Feature/FederationTest.php
@@ -104,7 +104,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -240,7 +240,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -363,7 +363,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -505,7 +505,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -579,7 +579,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     'y1@test.com',
                     'y2@test.com',
                     'y3@test.com',
@@ -695,7 +695,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -769,7 +769,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     'y1@test.com',
                     'y2@test.com',
                     'y3@test.com',
@@ -817,7 +817,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     'y1@test.com',
                     'y2@test.com',
                 ]
@@ -936,7 +936,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     't1@test.com',
                     't2@test.com',
                     't3@test.com'
@@ -1010,7 +1010,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     'y1@test.com',
                     'y2@test.com',
                     'y3@test.com',
@@ -1058,7 +1058,7 @@ class FederationTest extends TestCase
                 'endpoint_dataset' => '/api/v1/noauth/datasets/{id}',
                 'run_time_hour' => 11,
                 'enabled' => true,
-                'notification' => [
+                'notifications' => [
                     'y1@test.com',
                     'y2@test.com',
                 ]


### PR DESCRIPTION
```
root@187bdc4c3a76:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter FederationTest
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

......                                                              6 / 6 (100%)

Time: 00:22.807, Memory: 54.50 MB

Federation (Tests\Feature\Federation)
 ✔ Get all federation by team id with success
 ✔ Get federation by id and by team id with success
 ✔ Create federation by team id with success
 ✔ Update federation by federation id and team id with success
 ✔ Edit federation by federation id and team id with success
 ✔ Delete federation by federation id and team id with success

There was 1 PHPUnit test runner warning:

1) No tests found in class "Tests\Feature\LogoutTest".

WARNINGS!
Tests: 6, Assertions: 217, Warnings: 1.
root@187bdc4c3a76:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter DatasetTest
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

....                                                                4 / 4 (100%)

Time: 00:18.402, Memory: 56.50 MB

Dataset (Tests\Feature\Dataset)
 ✔ Get all datasets with success
 ✔ Get one dataset by id with success
 ✔ Create delete dataset with success
 ✔ Create dataset fails with invalid origin

There was 1 PHPUnit test runner warning:

1) No tests found in class "Tests\Feature\LogoutTest".

WARNINGS!
Tests: 4, Assertions: 52, Warnings: 1.
root@187bdc4c3a76:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 248/248 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        
```