### PR TITLE
Hot Fix: api/v1/users 

### DIFF
--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -53,11 +53,10 @@ class UserController extends Controller
     {
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-       
         $response = [];
-        if (count($jwtUser)) {
+        if (count($jwtUser)) { //should really always be a jwtUser
             $userIsAdmin = (bool) $jwtUser['is_admin'];
-            if($userIsAdmin){
+            if($userIsAdmin){ // if it's the superadmin return a bunch of information
                 $users = User::with(
                     'roles',
                     'roles.permissions',
@@ -66,13 +65,12 @@ class UserController extends Controller
                 )->get()->toArray();
                 $response = $this->getUsers($users);
             }
-            else{
+            else{ // otherwise, for now, just return the id and name
                 $response = User::select(
                     'id','name'
                 )->get()->toArray();
             }
         }
-
         return response()->json([
             'data' => $response,
         ]);


### PR DESCRIPTION
Currently for non-super-users only information about the current user (via jwt) is returned

For non-super-users, instead just return the id,name for all users. Will return data like so:
```
{
    "data": [
        {
            "id": 1,
            "name": "HDRUK Super-User"
        },
        {
            "id": 2,
            "name": "HDRUK Service-User"
        },
        {
            "id": 3,
            "name": "HDR Team-Admin"
        },
```



