### PR TITLE
GAT-3135 :: application has notifications

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -56,4 +56,12 @@ class Application extends Model
     {
         return $this->belongsTo(User::class);
     }
+    
+    /**
+     * The notifications that belong to the team.
+     */
+    public function notifications(): BelongsToMany
+    {
+        return $this->belongsToMany(Notification::class, 'application_has_notifications');
+    }
 }

--- a/app/Models/ApplicationHasNotification.php
+++ b/app/Models/ApplicationHasNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ApplicationHasNotification extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     * 
+     * @var string
+     */
+    protected $table = 'application_has_notifications';
+
+    /**
+     * Indicates if the model should be timestamped
+     * 
+     * @var bool
+     */
+    public $timestamps = false;
+
+    protected $fillable = [
+        'application_id',
+        'notification_id',
+    ];
+}

--- a/database/migrations/2023_11_16_145315_create_application_has_notifications_table.php
+++ b/database/migrations/2023_11_16_145315_create_application_has_notifications_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('application_has_notifications', function (Blueprint $table) {
+            $table->bigInteger('application_id')->unsigned();
+            $table->bigInteger('notification_id')->unsigned();
+
+            $table->foreign('application_id')->references('id')->on('applications');
+            $table->foreign('notification_id')->references('id')->on('notifications');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('application_has_notifications');
+    }
+};

--- a/database/seeders/ApplicationSeeder.php
+++ b/database/seeders/ApplicationSeeder.php
@@ -3,8 +3,10 @@
 namespace Database\Seeders;
 
 use App\Models\Application;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Notification;
 use Illuminate\Database\Seeder;
+use App\Models\ApplicationHasNotification;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class ApplicationSeeder extends Seeder
 {
@@ -14,5 +16,28 @@ class ApplicationSeeder extends Seeder
     public function run(): void
     {
         Application::factory(50)->create();
+
+        $applications = Application::all();
+        
+        foreach ($applications as $application) {
+
+            $applicationId = $application->id;
+            $noNotifications = rand(1, 3);
+
+            for ($i = 1; $i <= $noNotifications; $i++) {
+                $notification = Notification::create([
+                    'notification_type' => 'application',
+                    'message' => null,
+                    'opt_in' => true,
+                    'enabled' => true,
+                    'email' => fake()->unique()->safeEmail(),
+                ]);
+
+                ApplicationHasNotification::create([
+                    'application_id' => $applicationId,
+                    'notification_id' => $notification->id,
+                ]);
+            }
+        }
     }
 }

--- a/rest.http
+++ b/rest.http
@@ -336,7 +336,12 @@ Authorization: Bearer {{accessToken}}
     "description": "Praesentium ut et quae suscipit ut quo adipisci. Enim ut tenetur ad omnis ut consequatur. Aliquid officiis expedita rerum.",
     "team_id": 5,
     "user_id": 2,
-    "enabled": true
+    "enabled": true,
+    "notifications": [
+        "t1@test.com",
+        "t2@test.com",
+        "t3@test.com"
+    ]
 }
 
 #### update application
@@ -353,7 +358,12 @@ Authorization: Bearer {{accessToken}}
     "user_id": 3,
     "enabled": true,
     "tags": [1,2],
-    "permissions": [3,2]
+    "permissions": [3,2],
+    "notifications": [
+        "t1@test.com",
+        "t2@test.com",
+        "t3@test.com"
+    ]
 }
 
 #### edit application

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -68,6 +68,7 @@ class ApplicationTest extends TestCase
                     'permissions',
                     'team',
                     'user',
+                    'notifications',
                 ],
             ],
             'current_page',
@@ -102,6 +103,11 @@ class ApplicationTest extends TestCase
                 'permissions' => [
                     1,
                     2,
+                ],
+                "notifications" => [
+                    "t1@test.com",
+                    "t2@test.com",
+                    "t3@test.com"
                 ],
             ],
             $this->header,
@@ -147,6 +153,7 @@ class ApplicationTest extends TestCase
                 'permissions',
                 'team',
                 'user',
+                'notifications',
             ],
         ]);
         $responseGet->assertStatus(200);
@@ -167,6 +174,11 @@ class ApplicationTest extends TestCase
                 'permissions' => [
                     1,
                     2,
+                ],
+                "notifications" => [
+                    "t1@test.com",
+                    "t2@test.com",
+                    "t3@test.com"
                 ],
             ],
             $this->header,
@@ -201,6 +213,11 @@ class ApplicationTest extends TestCase
                 'permissions' => [
                     1,
                     2,
+                ],
+                "notifications" => [
+                    "t1@test.com",
+                    "t2@test.com",
+                    "t3@test.com"
                 ],
             ],
             $this->header,
@@ -266,6 +283,11 @@ class ApplicationTest extends TestCase
                     1,
                     2,
                 ],
+                "notifications" => [
+                    "t1@test.com",
+                    "t2@test.com",
+                    "t3@test.com"
+                ],
             ],
             $this->header,
         );
@@ -297,6 +319,9 @@ class ApplicationTest extends TestCase
                 'enabled' => false,
                 'permissions' => [
                     2,
+                ],
+                "notifications" => [
+                    "t1@test.com"
                 ],
             ],
             $this->header,
@@ -351,6 +376,11 @@ class ApplicationTest extends TestCase
                     1,
                     2,
                 ],
+                "notifications" => [
+                    "t1@test.com",
+                    "t2@test.com",
+                    "t3@test.com"
+                ],
             ],
             $this->header,
         );
@@ -382,6 +412,9 @@ class ApplicationTest extends TestCase
                 'enabled' => false,
                 'permissions' => [
                     2,
+                ],
+                "notifications" => [
+                    "t1@test.com",
                 ],
             ],
             $this->header,


### PR DESCRIPTION
```
root@d6c15bcc4a8a:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 257/257 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        
root@d6c15bcc4a8a:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter ApplicationTest
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

......                                                              6 / 6 (100%)

Time: 00:07.187, Memory: 50.50 MB

Application (Tests\Feature\Application)
 ✔ Get all applications with success
 ✔ Get application by id with success
 ✔ Create application with success
 ✔ Update application with success
 ✔ Edit application with success
 ✔ Delete application with success

There was 1 PHPUnit test runner warning:

1) No tests found in class "Tests\Feature\LogoutTest".

WARNINGS!
Tests: 6, Assertions: 107, Warnings: 1.
root@d6c15bcc4a8a:/var/www# 
```