### PR TITLE
removes dataset from returned payload, which is for internal use only

### DIFF
--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -53,6 +53,14 @@ class Dataset extends Model
     ];
 
     /**
+     * Indicates if elements of the model should be hidden
+     * from returned payloads
+     */
+    protected $hidden = [
+        'dataset',
+    ];
+
+    /**
      * The named_entities that belong to the dataset.
      */
     public function namedEntities(): BelongsToMany

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -431,22 +431,7 @@ class DatasetTest extends TestCase
         );
         $response->assertStatus(200);
         $response->assertJsonStructure([
-            'data' => [
-                '*' => [
-                    'dataset' => [
-                        "metadata" => [
-                            "required",
-                            "summary",
-                            "coverage",
-                            "provenance",
-                            "accessibility",
-                            "linkage",
-                            "observations",
-                            "structuralMetadata"
-                        ]
-                    ]
-                ]
-            ]
+            'data'
         ]);
 
         for ($i = 1; $i <= 3; $i++) {


### PR DESCRIPTION
  Tests:    186 passed (2231 assertions)
  Duration: 101.36s
