### PR TITLE
fix to CohortRequestControl log

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -248,6 +248,12 @@ class CohortRequestController extends Controller
                     ])
                 ->first()->toArray();
 
+            if (isset($cohortRequests['logs'])) {
+                foreach ($cohortRequests['logs'] as &$log) {
+                    $log['details'] = html_entity_decode($log['details']);
+                }
+            }
+
             return response()->json([
                 'message' => 'success',
                 'data' => $cohortRequests,


### PR DESCRIPTION
Without, log activity messages get displayed as:
```
&amp;&amp;&amp; &#039;&#039;&#039;&#039; &#039;&#039;&#039;&#039; it&#039;s it&#039;s haven&#039;t
```

With:
```

&&& '''' '''' it's it's haven't
```