### PR TITLE
cohort request test fix

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -499,7 +499,7 @@ class CohortRequestController extends Controller
             }
 
             $this->sendEmail($id);
-            
+ 
             return response()->json([
                 'message' => Config::get('statuscodes.STATUS_OK.message'),
                 'data' => CohortRequest::where('id', $id)->first()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,7 +66,6 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
-        'preferred_email' => UserPreferredEmail::class,
         'terms' => 'boolean',
     ];
 

--- a/tests/Feature/CohortRequestTest.php
+++ b/tests/Feature/CohortRequestTest.php
@@ -8,9 +8,10 @@ use App\Models\CohortRequest;
 use Tests\Traits\Authorization;
 use Database\Seeders\UserSeeder;
 use Database\Seeders\SectorSeeder;
-use Database\Seeders\EmailTemplateSeeder;
+use Tests\Traits\MockExternalApis;
 use Database\Seeders\CohortRequestSeed;
 use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\EmailTemplatesSeeder;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -18,6 +19,9 @@ class CohortRequestTest extends TestCase
 {
     use RefreshDatabase;
     use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
 
     const TEST_URL = '/api/v1/cohort_requests';
 
@@ -36,7 +40,7 @@ class CohortRequestTest extends TestCase
             MinimalUserSeeder::class,
             SectorSeeder::class,
             CohortRequestSeed::class,
-            EmailTemplateSeeder::class,
+            EmailTemplatesSeeder::class,
         ]);
         $this->authorisationUser();
         $jwt = $this->getAuthorisationJwt();


### PR DESCRIPTION
```
root@24caa4887733:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter CohortRequestTest                      
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

......                                                              6 / 6 (100%)

Time: 00:20.664, Memory: 56.50 MB

Cohort Request (Tests\Feature\CohortRequest)
 ✔ Get all cohort requests with success
 ✔ Get cohort request by id with success
 ✔ Create cohort request with success
 ✔ Update cohort request with success
 ✔ Download cohort request dashboard with success
 ✔ Delete cohort request with success

There was 1 PHPUnit test runner warning:

1) No tests found in class "Tests\Feature\LogoutTest".

WARNINGS!
Tests: 6, Assertions: 60, Warnings: 1.
root@24caa4887733:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 263/263 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        
root@24caa4887733:/var/www# 
```