### PR TITLE
Bugfix Cohort Request Job and test

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -336,6 +336,7 @@ class CohortRequestController extends Controller
                     'user_id' => $jwtUser['id'],
                     'request_status' => 'PENDING',
                     'cohort_status' => false,
+                    'created_at' => Carbon::now(),
                 ]);
             }
 

--- a/tests/Unit/CohortUserExpiryTest.php
+++ b/tests/Unit/CohortUserExpiryTest.php
@@ -6,17 +6,21 @@ use Tests\TestCase;
 
 use App\Models\Permission;
 use App\Models\CohortRequest;
-use App\Models\CohortRequestHasPermission;
-
-use Database\Seeders\PermissionSeeder;
-use Database\Seeders\MinimalUserSeeder;
-
 use Illuminate\Support\Carbon;
+use Database\Seeders\EmailTemplatesSeeder;
+use Tests\Traits\MockExternalApis;
+use Database\Seeders\PermissionSeeder;
+
+use Database\Seeders\MinimalUserSeeder;
+use App\Models\CohortRequestHasPermission;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class CohortUserExpiryTest extends TestCase
 {
     use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
 
     public function setUp(): void
     {
@@ -25,6 +29,7 @@ class CohortUserExpiryTest extends TestCase
         $this->seed([
             MinimalUserSeeder::class,
             PermissionSeeder::class,
+            EmailTemplatesSeeder::class,
         ]);
     }
 
@@ -42,6 +47,10 @@ class CohortUserExpiryTest extends TestCase
             'request_expire_at' => null,
             'created_at' => Carbon::now()->subDays(181),
         ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(181);
+        $cr->save();
 
         $perms = Permission::where([
             'application' => 'cohort',
@@ -82,6 +91,9 @@ class CohortUserExpiryTest extends TestCase
             'request_expire_at' => null,
             'created_at' => Carbon::now()->subDays(100),
         ]);
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100);
+        $cr->save();
 
         $perms = Permission::where([
             'application' => 'cohort',


### PR DESCRIPTION
```
root@24caa4887733:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter CohortUserExpiryTest       
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 00:09.010, Memory: 52.50 MB

Cohort User Expiry (Tests\Unit\CohortUserExpiry)
 ✔ It can run
 ✔ It can expire requests
 ✔ It doesnt expire valid requests

There was 1 PHPUnit test runner warning:

1) No tests found in class "Tests\Feature\LogoutTest".

WARNINGS!
Tests: 3, Assertions: 8, Warnings: 1.
root@24caa4887733:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 263/263 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                     
 [OK] No errors                                                                                                         

root@24caa4887733:/var/www# 
```