### PR TITLE
Hotfix/gat 3398

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -179,7 +179,7 @@ class DatasetController extends Controller
 
         // perform query for the matching datasets with ordering and pagination. 
         // Include soft-deleted versions.
-        $datasets = Dataset::with(['versions' => fn($version) => $version->withTrashed()])
+        $datasets = Dataset::with(['versions' => fn($version) => $version->withTrashed()->latest()->first()])
             ->whereIn('id', $matches)
             ->when($request->has('withTrashed') || $filterStatus === 'ARCHIVED', 
                 function ($query) {


### PR DESCRIPTION
Return only the latest DatasetVersion associated to each Dataset when calling the `Dataset::index()` method, regardless of whether the Dataset is archived.

Fixes gat-3398 which reported that archived Datasets displayed no associated DatasetVersion, while modifying the behaviour in the unarchived case to restrict the return to a single DatasetVersion rather than all.