### PR TITLE
added key users in create/edit/update team

### DIFF
--- a/app/Http/Requests/Team/CreateTeam.php
+++ b/app/Http/Requests/Team/CreateTeam.php
@@ -74,6 +74,14 @@ class CreateTeam extends BaseFormRequest
             'is_question_bank' => [
                 'boolean',
             ],
+            'users' => [
+                'array',
+            ],
+            'users.*'  => [
+                'integer',
+                'distinct',
+                'exists:users,id',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Team/EditTeam.php
+++ b/app/Http/Requests/Team/EditTeam.php
@@ -77,6 +77,14 @@ class EditTeam extends BaseFormRequest
             'is_question_bank' => [
                 'boolean',
             ],
+            'users' => [
+                'array',
+            ],
+            'users.*'  => [
+                'integer',
+                'distinct',
+                'exists:users,id',
+            ],
         ];
     }
 

--- a/app/Http/Requests/Team/UpdateTeam.php
+++ b/app/Http/Requests/Team/UpdateTeam.php
@@ -79,6 +79,14 @@ class UpdateTeam extends BaseFormRequest
             'is_question_bank' => [
                 'boolean',
             ],
+            'users' => [
+                'array',
+            ],
+            'users.*'  => [
+                'integer',
+                'distinct',
+                'exists:users,id',
+            ],
         ];
     }
 

--- a/rest.http
+++ b/rest.http
@@ -179,7 +179,8 @@ Authorization: Bearer {{accessToken}}
     "contact_point": "dinos345@mail.com",
     "application_form_updated_by": "Someone Somewhere",
     "application_form_updated_on": "2023-04-06 15:44:41",
-    "notifications": []
+    "notifications": [],
+    "users": [],
 }
 
 ### Review

--- a/tests/Feature/DatasetIntegrationTest.php
+++ b/tests/Feature/DatasetIntegrationTest.php
@@ -139,6 +139,7 @@ class DatasetIntegrationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -294,6 +295,7 @@ class DatasetIntegrationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -112,6 +112,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -148,6 +149,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -456,6 +458,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -612,6 +615,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -790,6 +794,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -940,6 +945,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -1068,6 +1074,7 @@ class DatasetTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );

--- a/tests/Feature/DatasetVersionTest.php
+++ b/tests/Feature/DatasetVersionTest.php
@@ -73,6 +73,7 @@ class DatasetVersionTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -198,6 +199,7 @@ class DatasetVersionTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );

--- a/tests/Feature/FederationTest.php
+++ b/tests/Feature/FederationTest.php
@@ -67,6 +67,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -207,6 +208,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -334,6 +336,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -480,6 +483,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -674,6 +678,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );
@@ -919,6 +924,7 @@ class FederationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );

--- a/tests/Feature/TeamNotificationTest.php
+++ b/tests/Feature/TeamNotificationTest.php
@@ -43,6 +43,7 @@ class TeamNotificationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [],
+                'users' => [],
             ],
             $this->header,
         );
@@ -120,6 +121,7 @@ class TeamNotificationTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [],
+                'users' => [],
             ],
             $this->header,
         );

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -120,6 +120,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 1,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -211,6 +212,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 0,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -290,6 +292,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 0,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -325,6 +328,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:45:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 1,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -406,6 +410,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 1,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -445,6 +450,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:45:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 0,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,
@@ -573,6 +579,7 @@ class TeamTest extends TestCase
                 'application_form_updated_on' => '2023-04-06 15:44:41',
                 'notifications' => [$notificationID],
                 'is_question_bank' => 0,
+                'users' => [],
             ],
             [
                 'Authorization' => 'bearer ' . $this->accessToken,

--- a/tests/Feature/TeamUserTest.php
+++ b/tests/Feature/TeamUserTest.php
@@ -411,6 +411,7 @@ class TeamUserTest extends TestCase
                 'application_form_updated_by' => 'Someone Somewhere',
                 'application_form_updated_on' => now(),
                 'notifications' => [$notificationID],
+                'users' => [],
             ],
             $this->header,
         );


### PR DESCRIPTION
```
root@2f533b5b5ed6:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter TeamTest
PHPUnit 10.4.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.3
Configuration: /var/www/phpunit.xml

.......                                                             7 / 7 (100%)

Time: 00:04.909, Memory: 52.50 MB

Team (Tests\Feature\Team)
 ✔ The application can list teams
 ✔ The application can show one team
 ✔ The application can create a team
 ✔ The application can update a team
 ✔ The application can edit a team
 ✔ The application can delete a team

Team (Tests\Unit\Team)
 ✔ New team is instance of team

There was 1 PHPUnit test runner warning:
```

```
root@2f533b5b5ed6:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 280/280 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                
 [OK] No errors                                                                                                         
                                                                                                                       
```