### PR TITLE
bug fixes for datasets

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -185,7 +185,7 @@ class DatasetController extends Controller
 
         // perform query for the matching datasets with ordering and pagination. 
         // Include soft-deleted versions.
-        $datasets = Dataset::with(['versions' => fn($version) => $version->withTrashed()->latest()->first()])
+        $datasets = Dataset::with(['versions' => fn($version) => $version->withTrashed()->latest()])
             ->whereIn('id', $matches)
             ->when($request->has('withTrashed') || $filterStatus === 'ARCHIVED', 
                 function ($query) {

--- a/app/Jobs/TermExtraction.php
+++ b/app/Jobs/TermExtraction.php
@@ -66,7 +66,7 @@ class TermExtraction implements ShouldQueue
                 'application/json'
             )->post(env('TED_SERVICE_URL'));
 
-            if (array_key_exists('extracted_terms', $response->json())) {
+            if ($response->json() && array_key_exists('extracted_terms', $response->json())) {
                 foreach ($response->json()['extracted_terms'] as $n) {
                     $named_entities = NamedEntities::create([
                         'name' => $n,


### PR DESCRIPTION
`->first()` was making the the version only be returned for the first dataset rather than the first version of a dataset