### PR TITLE
Expose content-disposition header

### DIFF
--- a/app/Http/Middleware/Cors.php
+++ b/app/Http/Middleware/Cors.php
@@ -15,6 +15,7 @@ class Cors
         $headers = [
             'Access-Control-Allow-Methods' => 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
             'Access-Control-Allow-Headers' => 'Content-Type, Origin, Authorization',
+            'Access-Control-Expose-Headers' => 'Content-Disposition',
         ];
 
         if ($request->getMethod() === 'OPTIONS') {


### PR DESCRIPTION
This allows the filename to be returned in the header from the backend, for when we're downloading content.