### PR TITLE
Update publications table

### DIFF
--- a/app/Http/Requests/Publication/CreatePublication.php
+++ b/app/Http/Requests/Publication/CreatePublication.php
@@ -43,7 +43,7 @@ class CreatePublication extends BaseFormRequest
                 'max:255',
             ],
             'abstract' => [
-                'required',
+                'nullable',
                 'string',
             ],
         ];

--- a/app/Http/Requests/Publication/UpdatePublication.php
+++ b/app/Http/Requests/Publication/UpdatePublication.php
@@ -48,7 +48,7 @@ class UpdatePublication extends BaseFormRequest
                 'max:255',
             ],
             'abstract' => [
-                'required',
+                'nullable',
                 'string',
             ],            
         ];

--- a/database/migrations/2024_03_07_172014_update_publication_table.php
+++ b/database/migrations/2024_03_07_172014_update_publication_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('publications', function (Blueprint $table) {
+            $table->text('abstract')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('publications', function (Blueprint $table) {
+            $table->text('abstract');
+        });
+    }
+};

--- a/tests/Traits/MockExternalApis.php
+++ b/tests/Traits/MockExternalApis.php
@@ -544,7 +544,7 @@ trait MockExternalApis
 
         // Mock the search service - filters
         Http::fake([
-            '*/search/filters*' => Http::response(
+            '*search*/filters*' => Http::response(
                 [
                     'filters' => [
                         0 => [


### PR DESCRIPTION
Making publications abstract field nullable.  This is often missing for preprints when querying EuropePMC. It affects about 150 of the papers we have on the gateway.