### PR TITLE
adds an example behat scenario and feature test

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,14 +1,46 @@
 <?php
 
+use Tests\TestCase;
+
+use App\Models\User;
+use App\Models\Team;
+use App\Models\Application;
+use App\Models\TeamHasUser;
+use App\Models\Permission;
+use App\Models\ApplicationHasPermission;
+
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 
+use Illuminate\Support\Str;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+
+use Tests\Traits\MockExternalApis;
+
+/**
+ * When you have created your Feature (*.feature) file, complete with scenario(s), you can run
+ * `vendor/bin/behat` within the root of your gateway-api-2 directory and behat will determine
+ * unresolved/undefined steps. It will then ask how you wish to run them. Should you choose
+ * "FeatureContext" - behat will output the missing step signatures for you to copy paste here.
+ */
+
 /**
  * Defines application features from the specific context.
  */
-class FeatureContext implements Context
+class FeatureContext extends TestCase implements Context
 {
+    use DatabaseMigrations, MockExternalApis;
+
+    protected $user = null;
+    protected $team = null;
+    protected $app = null;
+
+    const TEST_URL = '/api/v1/integrations/datasets';
+
     /**
      * Initializes context.
      *
@@ -18,5 +50,81 @@ class FeatureContext implements Context
      */
     public function __construct()
     {
+        putenv('DB_CONNECTION=sqlite');
+        putenv('DB_DATABASE=:memory:');
+        parent::setUp();
+    }
+
+    /** @BeforeScenario */
+    public function before(BeforeScenarioScope $scope)
+    {
+        $this->artisan('migrate:fresh');
+    }
+
+    /**
+     * @Given I am a registered user on the gateway
+     */
+    public function iAmARegisteredUserOnTheGateway()
+    {
+        $this->user = User::factory(1)->create();
+        $this->assertNotNull($this->user);
+    }
+
+    /**
+     * @Given I am a member of a team
+     */
+    public function iAmAMemberOfATeam()
+    {
+        $this->team = Team::factory(1)->create([
+            'name' => 'Test Team 123',
+        ]);
+        $this->assertNotNull($this->team);
+
+        $teamHasUser = TeamHasUser::create([
+            'team_id' => $this->team[0]->id,
+            'user_id' => $this->user[0]->id,
+        ]);
+
+        $this->assertNotNull($teamHasUser);
+
+        $this->assertDatabaseHas('team_has_users', [
+            'team_id' => $this->team[0]->id,
+            'user_id' => $this->user[0]->id,
+        ]);
+    }    
+
+    /**
+     * @Then I can create an application to use automation services
+     */
+    public function iCanCreateAnApplicationToUseAutomationServices()
+    {
+        $this->app = Application::factory(1)->create([
+            'user_id' => $this->user[0]->id,
+            'name' => 'My Application v1',
+        ]);
+
+        $this->assertNotNull($this->app[0]->app_id);
+        $this->assertNotNull($this->app[0]->client_id);
+
+        $perms = Permission::whereIn('name', [
+            'datasets.create',
+            'datasets.read',
+            'datasets.update',
+            'datasets.delete',
+        ])->get();
+
+        foreach ($perms as $perm) {
+            ApplicationHasPermission::firstOrCreate([
+                'application_id' => $this->app[0]->id,
+                'permission_id' => $perm->id,
+            ]);
+        }
+
+        foreach ($perms as $perm) {
+            $this->assertDatabaseHas('application_has_permissions', [
+                'application_id' => $this->app[0]->id,
+                'permission_id' => $perm->id,
+            ]);
+        }
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -9,6 +9,8 @@ use App\Models\TeamHasUser;
 use App\Models\Permission;
 use App\Models\ApplicationHasPermission;
 
+use Database\Seeders\SectorSeeder;
+
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
@@ -53,6 +55,10 @@ class FeatureContext extends TestCase implements Context
         putenv('DB_CONNECTION=sqlite');
         putenv('DB_DATABASE=:memory:');
         parent::setUp();
+
+        $this->seed([
+            SectorSeeder::class,
+        ]);
     }
 
     /** @BeforeScenario */

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -16,6 +16,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 
 use Illuminate\Support\Str;
+
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
@@ -55,16 +56,16 @@ class FeatureContext extends TestCase implements Context
         putenv('DB_CONNECTION=sqlite');
         putenv('DB_DATABASE=:memory:');
         parent::setUp();
-
-        $this->seed([
-            SectorSeeder::class,
-        ]);
     }
 
     /** @BeforeScenario */
     public function before(BeforeScenarioScope $scope)
     {
         $this->artisan('migrate:fresh');
+
+        $this->seed([
+            SectorSeeder::class,
+        ]);
     }
 
     /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -37,7 +37,7 @@ use Tests\Traits\MockExternalApis;
 class FeatureContext extends TestCase implements Context
 {
     use DatabaseMigrations;
-    use MockExternalApis { setUp as commonSetUp; }
+    use MockExternalApis;
 
     protected $user = null;
     protected $team = null;
@@ -54,11 +54,9 @@ class FeatureContext extends TestCase implements Context
      */
     public function __construct()
     {
-        // putenv('DB_CONNECTION=sqlite');
-        // putenv('DB_DATABASE=:memory:');
+        putenv('DB_CONNECTION=sqlite');
+        putenv('DB_DATABASE=:memory:');
         parent::setUp();
-
-        $this->commonSetUp();
     }
 
     /** @BeforeScenario */
@@ -76,7 +74,21 @@ class FeatureContext extends TestCase implements Context
      */
     public function iAmARegisteredUserOnTheGateway()
     {
-        $this->user = User::factory(1)->create();
+        $this->user = User::create([
+            'name' => 'Test User',
+            'email' => 'test.user@test.com',
+            'password' => 'Passw@rd1!',
+            'sector_id' => 1,
+            'contact_feedback' => 1,
+            'contact_news' => 1,
+            'organisation' => 'Test Organisation',
+            'bio' => 'Test Biography',
+            'domain' => 'https://testdomain.com',
+            'link' => 'https://testlink.com/link',
+            'orcid' => "https://orcid.org/12345678",
+            'mongo_id' => 1234567,
+            'mongo_object_id' => "12345abcde",              
+        ]);
         $this->assertNotNull($this->user);
     }
 
@@ -92,14 +104,14 @@ class FeatureContext extends TestCase implements Context
 
         $teamHasUser = TeamHasUser::create([
             'team_id' => $this->team[0]->id,
-            'user_id' => $this->user[0]->id,
+            'user_id' => $this->user->id,
         ]);
 
         $this->assertNotNull($teamHasUser);
 
         $this->assertDatabaseHas('team_has_users', [
             'team_id' => $this->team[0]->id,
-            'user_id' => $this->user[0]->id,
+            'user_id' => $this->user->id,
         ]);
     }    
 
@@ -109,7 +121,7 @@ class FeatureContext extends TestCase implements Context
     public function iCanCreateAnApplicationToUseAutomationServices()
     {
         $this->app = Application::factory(1)->create([
-            'user_id' => $this->user[0]->id,
+            'user_id' => $this->user->id,
             'name' => 'My Application v1',
         ]);
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -36,7 +36,8 @@ use Tests\Traits\MockExternalApis;
  */
 class FeatureContext extends TestCase implements Context
 {
-    use DatabaseMigrations, MockExternalApis;
+    use DatabaseMigrations;
+    use MockExternalApis { setUp as commonSetUp; }
 
     protected $user = null;
     protected $team = null;
@@ -53,9 +54,11 @@ class FeatureContext extends TestCase implements Context
      */
     public function __construct()
     {
-        putenv('DB_CONNECTION=sqlite');
-        putenv('DB_DATABASE=:memory:');
+        // putenv('DB_CONNECTION=sqlite');
+        // putenv('DB_DATABASE=:memory:');
         parent::setUp();
+
+        $this->commonSetUp();
     }
 
     /** @BeforeScenario */

--- a/features/datasets.feature
+++ b/features/datasets.feature
@@ -1,0 +1,9 @@
+Feature: Automated Metadata onboarding
+    In order to view my metadata via automation
+    As a developer user
+    I need to be able to upload metadata by API integration
+
+Scenario: Automated metadata onboarding
+    Given I am a registered user on the gateway
+    When I am a member of a team
+    Then I can create an application to use automation services


### PR DESCRIPTION
lokisinclair@Lokis-Office gateway-api-2 % vendor/bin/behat
Feature: Automated Metadata onboarding
    In order to view my metadata via automation
    As a developer user
    I need to be able to upload metadata by API integration

  Scenario: Automated metadata onboarding                       # features/datasets.feature:6
    Given I am a registered user on the gateway                 # FeatureContext::iAmARegisteredUserOnTheGateway()
    When I am a member of a team                                # FeatureContext::iAmAMemberOfATeam()
    Then I can create an application to use automation services # FeatureContext::iCanCreateAnApplicationToUseAutomationServices()

1 scenario (1 passed)
3 steps (3 passed)
0m0.59s (42.61Mb)