### PR TITLE
Include tool->dataset linkage in tool controller

### DIFF
--- a/app/Http/Requests/Tag/CreateTag.php
+++ b/app/Http/Requests/Tag/CreateTag.php
@@ -18,13 +18,12 @@ class CreateTag extends BaseFormRequest
             'type' => [
                 'required',
                 'string',
-                'unique:tags,type',
             ],
             'description' => [
                 'required',
                 'string',
                 Rule::unique('tags')->where(function ($query) {
-                    $query->where('description', trim($this->type));
+                    $query->where('description', trim($this->description));
                 }),
             ],
             'enabled' => [

--- a/app/Http/Requests/Tag/EditTag.php
+++ b/app/Http/Requests/Tag/EditTag.php
@@ -23,7 +23,6 @@ class EditTag extends BaseFormRequest
             ],
             'type' => [
                 'string',
-                'exists:tags,type',
             ],
             'description' => [
                 'string',

--- a/app/Http/Requests/Tag/UpdateTag.php
+++ b/app/Http/Requests/Tag/UpdateTag.php
@@ -23,7 +23,6 @@ class UpdateTag extends BaseFormRequest
             'type' => [
                 'required',
                 'string',
-                'unique:tags,type',
             ],
             'description' => [
                 'required',

--- a/tests/Feature/TagTest.php
+++ b/tests/Feature/TagTest.php
@@ -158,7 +158,7 @@ class TagTest extends TestCase
             [
                 'type' =>  'Tag-123456789',
                 'enabled' => 1,
-                'description' => 'type for test 2'
+                'description' => 'type for test'
             ],
             $this->header,
         );


### PR DESCRIPTION
Also changes tags to be unique on `description` rather than `type`.  This made sense to me as tags in the mongo db are either `topics` or `features` with descriptions (e.g. `software`, `covid` etc.) under those two categories.

```
  Tests:    243 passed (3257 assertions)
  Duration: 39.60s
``` 