### PR TITLE
GAT-3871 :: add url to publications

### DIFF
--- a/app/Http/Controllers/Api/V1/PublicationController.php
+++ b/app/Http/Controllers/Api/V1/PublicationController.php
@@ -175,8 +175,9 @@ class PublicationController extends Controller
      *             @OA\Property(property="year_of_publication", type="string", example="2024"),
      *             @OA\Property(property="paper_doi", type="string", example="10.12345"),
      *             @OA\Property(property="publication_type", type="string", example="Journal article, Book"),
-     *             @OA\Property(property="journal_name", type="integer", example="A Journal"),
-     *             @OA\Property(property="abstract", type="integer", example="A long description of the paper"),
+     *             @OA\Property(property="journal_name", type="string", example="A Journal"),
+     *             @OA\Property(property="abstract", type="string", example="A long description of the paper"),
+     *             @OA\Property(property="url", type="string", example="http://example"),
      *             @OA\Property(property="datasets", type="array", 
      *                @OA\Items(type="object",
      *                   @OA\Property(property="id", type="integer"),
@@ -224,6 +225,7 @@ class PublicationController extends Controller
                 'publication_type' => $input['publication_type'],
                 'journal_name' => $input['journal_name'],
                 'abstract' => $input['abstract'],
+                'url' => $input['url'],
             ]);
 
             $datasetInput = array_key_exists('datasets', $input) ? $input['datasets']: [];
@@ -287,8 +289,9 @@ class PublicationController extends Controller
      *             @OA\Property(property="year_of_publication", type="string", example="2024"),
      *             @OA\Property(property="paper_doi", type="string", example="10.12345"),
      *             @OA\Property(property="publication_type", type="string", example="Journal article, Book"),
-     *             @OA\Property(property="journal_name", type="integer", example="A Journal"),
-     *             @OA\Property(property="abstract", type="integer", example="A long description of the paper"),
+     *             @OA\Property(property="journal_name", type="string", example="A Journal"),
+     *             @OA\Property(property="abstract", type="string", example="A long description of the paper"),
+     *             @OA\Property(property="url", type="string", example="http://example"),
      *             @OA\Property(property="datasets", type="array", 
      *                @OA\Items(type="object",
      *                   @OA\Property(property="id", type="integer"),
@@ -352,6 +355,7 @@ class PublicationController extends Controller
                 'publication_type' => $input['publication_type'],
                 'journal_name' => $input['journal_name'],
                 'abstract' => $input['abstract'],
+                'url' => $input['url'],
             ]);
 
             $datasetInput = array_key_exists('datasets', $input) ? $input['datasets']: [];
@@ -412,8 +416,9 @@ class PublicationController extends Controller
      *             @OA\Property(property="year_of_publication", type="string", example="2024"),
      *             @OA\Property(property="paper_doi", type="string", example="10.12345"),
      *             @OA\Property(property="publication_type", type="string", example="Journal article, Book"),
-     *             @OA\Property(property="journal_name", type="integer", example="A Journal"),
-     *             @OA\Property(property="abstract", type="integer", example="A long description of the paper"),
+     *             @OA\Property(property="journal_name", type="string", example="A Journal"),
+     *             @OA\Property(property="abstract", type="string", example="A long description of the paper"),
+     *             @OA\Property(property="url", type="string", example="http://example"),
      *             @OA\Property(property="datasets", type="array", 
      *                @OA\Items(type="object",
      *                   @OA\Property(property="id", type="integer"),
@@ -469,15 +474,18 @@ class PublicationController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $publication = Publication::where('id', $id)->update([
-                'paper_title' => $input['paper_title'],
-                'authors' => $input['authors'],
-                'year_of_publication' => $input['year_of_publication'],
-                'paper_doi' => $input['paper_doi'],
-                'publication_type' => $input['publication_type'],
-                'journal_name' => $input['journal_name'],
-                'abstract' => $input['abstract'],
-            ]);
+            $arrayKeys = [
+                'paper_title',
+                'authors',
+                'year_of_publication',
+                'paper_doi',
+                'publication_type',
+                'journal_name',
+                'abstract',
+                'url',
+            ];
+            $array = $this->checkEditArray($input, $arrayKeys);
+            $publication = Publication::where('id', $id)->update($array);
 
             $datasetInput = array_key_exists('datasets', $input) ? $input['datasets']: [];
             PublicationHasDataset::where('publication_id', $id)->delete();

--- a/app/Http/Requests/Publication/CreatePublication.php
+++ b/app/Http/Requests/Publication/CreatePublication.php
@@ -46,6 +46,10 @@ class CreatePublication extends BaseFormRequest
                 'nullable',
                 'string',
             ],
+            'url' => [
+                'nullable',
+                'string',
+            ],
             'datasets' => [
                 'nullable', 
                 'array', 

--- a/app/Http/Requests/Publication/EditPublication.php
+++ b/app/Http/Requests/Publication/EditPublication.php
@@ -44,6 +44,9 @@ class EditPublication extends BaseFormRequest
             'abstract' => [
                 'string',
             ],
+            'url' => [
+                'string',
+            ],
             'datasets' => [
                 'nullable', 
                 'array', 

--- a/app/Http/Requests/Publication/UpdatePublication.php
+++ b/app/Http/Requests/Publication/UpdatePublication.php
@@ -51,6 +51,10 @@ class UpdatePublication extends BaseFormRequest
                 'nullable',
                 'string',
             ],
+            'url' => [
+                'nullable',
+                'string',
+            ],
             'datasets' => [
                 'nullable', 
                 'array', 

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -31,6 +31,7 @@ class Publication extends Model
         'publication_type',
         'journal_name',
         'abstract',
+        'url',
     ];
 
     /**

--- a/database/factories/PublicationFactory.php
+++ b/database/factories/PublicationFactory.php
@@ -26,6 +26,7 @@ class PublicationFactory extends Factory
             'publication_type' => fake()->words(4, true),
             'journal_name' => fake()->sentence(),
             'abstract' => fake()->paragraph(),
+            'url' => fake()->url(),
         ];
     }
 }

--- a/database/migrations/2024_04_15_102516_add_url_to_publications_table.php
+++ b/database/migrations/2024_04_15_102516_add_url_to_publications_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('publications', function (Blueprint $table) {
+            $table->string('url', 2048)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('publications', function (Blueprint $table) {
+            $table->dropColumn('url');
+        });
+    }
+};

--- a/tests/Feature/PublicationTest.php
+++ b/tests/Feature/PublicationTest.php
@@ -68,6 +68,7 @@ class PublicationTest extends TestCase
                     'publication_type',
                     'journal_name',
                     'abstract',
+                    'url',
                 ],
             ],
             'first_page_url',
@@ -106,6 +107,7 @@ class PublicationTest extends TestCase
                     'publication_type',
                     'journal_name',
                     'abstract',
+                    'url',
                 ]
             ]
         ]);
@@ -132,6 +134,7 @@ class PublicationTest extends TestCase
                 'publication_type' => 'Paper and such',
                 'journal_name' => 'Something Journal-y here',
                 'abstract' => 'Some blurb about this made up paper written by people who should never meet.',
+                'url' => 'http://smith.com/cumque-sint-molestiae-minima-corporis-quaerat.html',
                 'datasets' => [
                     0 => [
                         'id' => 1,
@@ -174,7 +177,8 @@ class PublicationTest extends TestCase
                 'paper_doi' => 'https://doi.org/10.1000/182',
                 'publication_type' => 'Paper and such',
                 'journal_name' => 'Something Journal-y here',
-                'abstract' => 'Some blurb about this made up paper written by people who should never meet.',  
+                'abstract' => 'Some blurb about this made up paper written by people who should never meet.', 
+                'url' => 'http://smith.com/cumque-sint-molestiae-minima-corporis-quaerat.html', 
                 'datasets' => [
                     0 => [
                         'id' => 1,
@@ -212,6 +216,7 @@ class PublicationTest extends TestCase
                 'publication_type' => 'Paper and such',
                 'journal_name' => 'Something Journal-y here',
                 'abstract' => 'Some blurb about this made up paper written by people who should never meet.',
+                'url' => 'http://smith.com/cumque-sint-molestiae-minima-corporis-quaerat.html',
                 'datasets' => [
                     0 => [
                         'id' => 1,
@@ -245,6 +250,7 @@ class PublicationTest extends TestCase
                 'publication_type' => 'Paper and such',
                 'journal_name' => 'Something Journal-y here',
                 'abstract' => 'Some blurb about this made up paper written by people who should never meet.',
+                'url' => 'http://smith.com/cumque-sint-molestiae-minima-corporis-quaerat.html',
                 'datasets' => [
                     0 => [
                         'id' => 1,


### PR DESCRIPTION
```
root@10b2cd34b8f3:/var/www# php -d memory_limit=4G vendor/bin/phpstan analyse
Note: Using configuration file /var/www/phpstan.neon.
 322/322 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 [OK] No errors
```
```
root@10b2cd34b8f3:/var/www# php -d memory_limit=2048M ./vendor/bin/phpunit --testdox --filter PublicationTest
PHPUnit 10.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.3
Configuration: /var/www/phpunit.xml

......                                                              6 / 6 (100%)

Time: 00:05.223, Memory: 56.50 MB

Publication (Tests\Feature\Publication)
 ✔ Get all publications with success
 ✔ Get publication by id with success
 ✔ Create publication with success
 ✔ Create publication without success
 ✔ Update publication with success
 ✔ Soft delete tag with success
```