### PR TITLE
small workaround to remove header tags from abstract

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -871,7 +871,9 @@ class SearchController extends Controller
                         if ((int) $p['_id'] === $model['id']) {
                             $pubArray[$i]['_source']['created_at'] = $model['created_at'];
                             $pubArray[$i]['paper_title'] = $model['paper_title'];
-                            $pubArray[$i]['abstract'] = $model['abstract'];
+                            // This is an in-transit workaround to remove header elements of the abstract text in the request.
+                            // This requires more thought, and only a temporary fix. LS.
+                            $pubArray[$i]['abstract'] = preg_replace('/<h4>(.*?)<\/h4>/', '', $model['abstract']);
                             $pubArray[$i]['authors'] = $model['authors'];
                             $pubArray[$i]['journal_name'] = $model['journal_name'];
                             $pubArray[$i]['year_of_publication'] = $model['year_of_publication'];
@@ -890,7 +892,9 @@ class SearchController extends Controller
                     $pubArray[$i]['_source']['publicationDate'] = $paper['pubYear'];
                     $pubArray[$i]['_source']['title'] = $paper['title'];
                     $pubArray[$i]['paper_title'] = $paper['title'];
-                    $pubArray[$i]['abstract'] = $paper['abstractText'];
+                    // This is an in-transit workaround to remove header elements of the abstract text in the request.
+                    // This requires more thought, and only a temporary fix. LS.
+                    $pubArray[$i]['abstract'] = preg_replace('/<h4>(.*?)<\/h4>/', '', $paper['abstractText']);
                     $pubArray[$i]['authors'] = $paper['authorString'];
                     $pubArray[$i]['journal_name'] = isset($paper['journalInfo']) ? $paper['journalInfo']['journal']['title'] : '';
                     $pubArray[$i]['year_of_publication'] = $paper['pubYear'];


### PR DESCRIPTION
## Screenshots (if relevant)
N/A

## Describe your changes
Temporary fix to remove <h4></h4> tags from the abstract in returned payload. Requires more thought for a lasting solution though.

## Issue ticket link
N/A

## Environment / Configuration changes (if applicable)
N/A

## Requires migrations being run?
N/A

## If not using the pre-push hook. Confirm tests pass:
Pre-push is run.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
