### PR TITLE
Remove search results when no db match found

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -164,10 +164,7 @@ class SearchController extends Controller
 
             $datasetsModels = Dataset::with('versions')->whereIn('id', $matchedIds)->get()->toArray();
             foreach ($datasetsArray as $i => $dataset) {
-                if (!in_array($dataset['_id'], $matchedIds)) {
-                    unset($datasetsArray[$i]);
-                    continue;
-                }
+                $foundFlag = false;
                 foreach ($datasetsModels as $model) {
                     if ((int) $dataset['_id'] === $model['id']) {
                         $datasetsArray[$i]['_source']['created_at'] = $model['versions'][0]['created_at'];
@@ -178,7 +175,12 @@ class SearchController extends Controller
                         }
                         $datasetsArray[$i]['isCohortDiscovery'] = $model['is_cohort_discovery'];
                         $datasetsArray[$i]['dataProvider'] = $this->getDataProvider($model);
+                        $foundFlag = true;
                     }
+                }
+                if (!$foundFlag) {
+                    unset($datasetsArray[$i]);
+                    continue;
                 }
             }
 
@@ -419,10 +421,7 @@ class SearchController extends Controller
             $toolModels = Tool::whereIn('id', $matchedIds)->get();
 
             foreach ($toolsArray as $i => $tool) {
-                if (!in_array($tool['_id'], $matchedIds)) {
-                    unset($toolsArray[$i]);
-                    continue;
-                }
+                $foundFlag = false;
                 foreach ($toolModels as $model){
                     if ((int) $tool['_id'] === $model['id']) {
                         // uploader
@@ -461,8 +460,13 @@ class SearchController extends Controller
                         }
                         $toolsArray[$i]['_source']['category'] = $category;
                         $toolsArray[$i]['_source']['created_at'] = $model['created_at'];
+                        $foundFlag = true;
                         break;
                     }
+                }
+                if (!$foundFlag) {
+                    unset($toolsArray[$i]);
+                    continue;
                 }
             }
      
@@ -605,17 +609,19 @@ class SearchController extends Controller
             $collectionModels = Collection::whereIn('id', $matchedIds)->get();
 
             foreach ($collectionArray as $i => $collection) {
-                if (!in_array($collection['_id'], $matchedIds)) {
-                    unset($collectionArray[$i]);
-                    continue;
-                }
+                $foundFlag = false;
                 foreach ($collectionModels as $model){
                     if ((int) $collection['_id'] === $model['id']) {
                         $collectionArray[$i]['_source']['created_at'] = $model['created_at'];
                         $collectionArray[$i]['name'] = $model['name'];
                         $collectionArray[$i]['dataProvider'] = $this->getDataProvider($model->toArray());
+                        $foundFlag = true;
                         break;
                     }
+                }
+                if (!$foundFlag) {
+                    unset($collectionArray[$i]);
+                    continue;
                 }
             }
 
@@ -751,10 +757,7 @@ class SearchController extends Controller
             $durModels = Dur::whereIn('id', $matchedIds)->with('datasets')->get();
 
             foreach ($durArray as $i => $dur) {
-                if (!in_array($dur['_id'], $matchedIds)) {
-                    unset($durArray[$i]);
-                    continue;
-                }
+                $foundFlag = false;
                 foreach ($durModels as $model){
                     if ((int) $dur['_id'] === $model['id']) {
                         $durArray[$i]['_source']['created_at'] = $model['created_at'];
@@ -764,8 +767,13 @@ class SearchController extends Controller
                         $durArray[$i]['mongoObjectId'] = $model['mongo_object_id']; // remove
                         $durArray[$i]['datasetTitles'] = $this->durDatasetTitles($model);
                         $durArray[$i]['dataProvider'] = $this->getDataProvider($model->toArray());
+                        $foundFlag = true;
                         break;
                     }
+                }
+                if (!$foundFlag) {
+                    unset($durArray[$i]);
+                    continue;
                 }
             }
 
@@ -944,10 +952,7 @@ class SearchController extends Controller
                 $pubModels = Publication::whereIn('id', $matchedIds)->get();
 
                 foreach ($pubArray as $i => $p) {
-                    if (!in_array($p['_id'], $matchedIds)) {
-                        unset($pubArray[$i]);
-                        continue;
-                    }
+                    $foundFlag = false;
                     foreach ($pubModels as $model){
                         if ((int) $p['_id'] === $model['id']) {
                             $pubArray[$i]['_source']['created_at'] = $model['created_at'];
@@ -960,8 +965,13 @@ class SearchController extends Controller
                             $pubArray[$i]['year_of_publication'] = $model['year_of_publication'];
                             $pubArray[$i]['full_text_url'] = 'https://doi.org/' . $model['paper_doi'];
                             $pubArray[$i]['url'] = $model['url'];
+                            $foundFlag = true;
                             break;
                         }
+                    }
+                    if (!$foundFlag) {
+                        unset($pubArray[$i]);
+                        continue;
                     }
                 }
             } else {
@@ -1123,18 +1133,20 @@ class SearchController extends Controller
             $dataProviderModels = DataProvider::whereIn('id', $matchedIds)->with('teams')->get();
 
             foreach ($dataProviderArray as $i => $dp) {
-                if (!in_array($dp['_id'], $matchedIds)) {
-                    unset($dataProviderArray[$i]);
-                    continue;
-                }
+                $foundFlag = false;
                 foreach ($dataProviderModels as $model){
                     if ((int) $dp['_id'] === $model['id']) {
                         $dataProviderArray[$i]['_source']['updated_at'] = $model['updated_at'];
                         $dataProviderArray[$i]['name'] = $model['name'];
                         $dataProviderArray[$i]['datasetTitles'] = $this->dataProviderDatasetTitles($model);
                         $dataProviderArray[$i]['geographicLocations'] = $this->dataProviderLocations($model);
+                        $foundFlag = true;
                         break;
                     }
+                }
+                if (!$foundFlag) {
+                    unset($dataProviderArray[$i]);
+                    continue;
                 }
             }
 

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -150,6 +150,14 @@ class SearchTest extends TestCase
             'total',                
         ]);
         $this->assertTrue($response['data'][0]['_source']['shortTitle'] === 'Third asthma dataset');
+        
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
 
         // Test sorting by dataset name (shortTitle)        
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/datasets" . '?sort=title:asc', ["query" => "asthma"], ['Accept' => 'application/json']); 
@@ -299,6 +307,14 @@ class SearchTest extends TestCase
             'total',                
         ]);
 
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
+
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/tools" . '?sort=score:asc', ["query" => "nlp"], ['Accept' => 'application/json']);   
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -447,6 +463,14 @@ class SearchTest extends TestCase
             'to',
             'total',                
         ]);
+
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
 
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/collections" . '?sort=score:asc', ["query" => "term"], ['Accept' => 'application/json']);   
         $response->assertStatus(200);
@@ -650,6 +674,14 @@ class SearchTest extends TestCase
         // dd($response['data'][0]['datasetTitles'][$endTitle]); // HDR UK Papers & Preprints
         $this->assertTrue($response['data'][0]['datasetTitles'][$endTitle] === 'Updated HDR UK Papers & Preprints');
 
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
+
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/dur" . '?sort=score:asc', ["query" => "term"], ['Accept' => 'application/json']);   
         $response->assertStatus(200);
         $response->assertJsonStructure([
@@ -781,6 +813,14 @@ class SearchTest extends TestCase
             'to',
             'total',                
         ]);
+
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
         
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/publications" . '?sort=score:asc', ["query" => "term"], ['Accept' => 'application/json']);   
         $response->assertStatus(200);
@@ -943,6 +983,14 @@ class SearchTest extends TestCase
             'to',
             'total',                
         ]);
+
+        // Test search result with id not in db is not returned
+        $content = $response->decodeResponseJson();
+        $elasticIds = array();
+        foreach ($content['data'] as $res) {
+            $elasticIds[] = $res['_id'];
+        }
+        $this->assertTrue(!in_array('1111', $elasticIds));
 
         $response = $this->json('POST', self::TEST_URL_SEARCH . "/data_providers" . '?sort=score:asc', ["query" => "term"], ['Accept' => 'application/json']);   
         $response->assertStatus(200);

--- a/tests/Traits/MockExternalApis.php
+++ b/tests/Traits/MockExternalApis.php
@@ -187,6 +187,29 @@ trait MockExternalApis
                                     'abstract' => [],
                                     'description' => []
                                 ]
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'datasets',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 15.0,
+                                '_shard' => '[datasets][0]',
+                                '_source' => [
+                                    'abstract' => '',
+                                    'description' => '',
+                                    'keywords' => '',
+                                    'named_entities' => [],
+                                    'publisherName' => '',
+                                    'shortTitle' => 'Fourth asthma dataset',
+                                    'title' => 'Fourth asthma dataset',
+                                    'dataUseTitles' => [],
+                                    'populationSize'=> 1000,
+                                ],
+                                'highlight' => [
+                                    'abstract' => [],
+                                    'description' => []
+                                ]
                             ]
                         ]
                     ],
@@ -379,6 +402,27 @@ trait MockExternalApis
                                     'abstract' => [],
                                     'description' => []
                                 ]
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'tools',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 16.0,
+                                '_shard' => '[tools][0]',
+                                '_source' => [
+                                    'category' => 'NLP System',
+                                    'description' => 'Yet another NLP tool',
+                                    'name' => 'D tool',
+                                    'tags' => [
+                                        'nlp',
+                                        'machine learning'
+                                    ]
+                                ],
+                                'highlight' => [
+                                    'abstract' => [],
+                                    'description' => []
+                                ]
                             ]
                         ]
                     ],
@@ -447,6 +491,24 @@ trait MockExternalApis
                                 '_source' => [
                                     'description' => 'a gateway collection',
                                     'name' => 'Third Collection',
+                                    'keywords' => 'some, useful, keywords',
+                                    'datasetTitles' => ['some', 'dataset', 'titles']
+                                ],
+                                'highlight' => [
+                                    'abstract' => [],
+                                    'description' => []
+                                ]
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'collections',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 16.0,
+                                '_shard' => '[collections][0]',
+                                '_source' => [
+                                    'description' => 'a gateway collection',
+                                    'name' => 'Fourth Collection',
                                     'keywords' => 'some, useful, keywords',
                                     'datasetTitles' => ['some', 'dataset', 'titles']
                                 ],
@@ -544,6 +606,29 @@ trait MockExternalApis
                                 'highlight' => [
                                     'laySummary' => []
                                 ]
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'data_uses',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 16.0,
+                                '_shard' => '[data_uses][0]',
+                                '_source' => [
+                                    'projectTitle' => 'Fourth Data Use',
+                                    'laySummary' => 'a gateway data use',
+                                    'publicBenefitStatement' => '',
+                                    'technicalSummary' => '',
+                                    'fundersAndSponsors' => '',
+                                    'datasetTitles' => ['some', 'dataset', 'title'],
+                                    'keywords' => ['some', 'useful', 'keywords'],
+                                    'sector' => 'Academia',
+                                    'publisherName' => 'A Publisher',
+                                    'organisationName' => 'An Organisation'
+                                ],
+                                'highlight' => [
+                                    'laySummary' => []
+                                ]
                             ]
                         ]
                     ],
@@ -616,6 +701,26 @@ trait MockExternalApis
                                 '_shard' => '[data_uses][0]',
                                 '_source' => [
                                     'title' => 'Third Publication',
+                                    'journalName' => 'A Journal',
+                                    'abstract' => '',
+                                    'authors' => '',
+                                    'publicationDate' => '',
+                                    'datasetTitles' => ['some', 'dataset', 'title'],
+                                    'publicationType' => ['article', 'comment', 'letter'],
+                                ],
+                                'highlight' => [
+                                    'laySummary' => []
+                                ]
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'data_uses',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 16.0,
+                                '_shard' => '[data_uses][0]',
+                                '_source' => [
+                                    'title' => 'Fourth Publication',
                                     'journalName' => 'A Journal',
                                     'abstract' => '',
                                     'authors' => '',
@@ -773,6 +878,20 @@ trait MockExternalApis
                                 '_shard' => '[dataprovider][0]',
                                 '_source' => [
                                     'name' => 'Third Provider',
+                                    'datasetTitles' => ['some', 'dataset', 'titles'],
+                                    'geographicLocations' => ['Scotland', 'Wales']
+                                ],
+                                'highlight' => null,
+                            ],
+                            3 => [
+                                '_explanation' => [],
+                                '_id' => '1111',
+                                '_index' => 'dataprovider',
+                                '_node' => 'abcd-123-efgh',
+                                '_score' => 16.0,
+                                '_shard' => '[dataprovider][0]',
+                                '_source' => [
+                                    'name' => 'Fourth Provider',
                                     'datasetTitles' => ['some', 'dataset', 'titles'],
                                     'geographicLocations' => ['Scotland', 'Wales']
                                 ],


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Removes hits from the elastic search response when no match is found in the mysql db.  Fixes the undefined publication cards in the ticket.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-3960

## Environment / Configuration changes (if applicable)

None

## Requires migrations being run?

No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
