### PR TITLE
Remove auth from dur export route.

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -2617,9 +2617,7 @@ return [
         'path' => '/dur/export',
         'methodController' => 'DurController@export',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [
-            'jwt.verify',
-        ],
+        'middleware' => [],
         'constraint' => [],
     ],
     [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Removes auth from the dur export route, enanbling it to be called without signing in.

Required for https://github.com/HDRUK/gateway-web-2/pull/302 to function correctly.

## Issue ticket link
None

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
