### PR TITLE
Bugfix for fresh migration of filters

### DIFF
--- a/app/Http/Requests/Filter/CreateFilter.php
+++ b/app/Http/Requests/Filter/CreateFilter.php
@@ -19,7 +19,7 @@ class CreateFilter extends BaseFormRequest
                 'required',
                 'string',
                 function ($attribute, $value, $fail) {
-                    $type = ['dataset', 'collection', 'tool', 'course', 'project', 'paper', 'dataUseRegister'];
+                    $type = \Config::get('filters.types');
 
                     if (!in_array($value, $type)) {
                         $fail('The selected value is invalid.');

--- a/app/Http/Requests/Filter/EditFilter.php
+++ b/app/Http/Requests/Filter/EditFilter.php
@@ -23,7 +23,7 @@ class EditFilter extends BaseFormRequest
             'type' => [
                 'string',
                 function ($attribute, $value, $fail) {
-                    $type = ['dataset', 'collection', 'tool', 'course', 'project', 'paper', 'dataUseRegister'];
+                    $type = \Config::get('filters.types');
 
                     if (!in_array($value, $type)) {
                         $fail('The selected value is invalid.');

--- a/app/Http/Requests/Filter/UpdateFilter.php
+++ b/app/Http/Requests/Filter/UpdateFilter.php
@@ -24,7 +24,7 @@ class UpdateFilter extends BaseFormRequest
                 'required',
                 'string',
                 function ($attribute, $value, $fail) {
-                    $type = ['dataset', 'collection', 'tool', 'course', 'project', 'paper', 'dataUseRegister'];
+                    $type = \Config::get('filters.types');
 
                     if (!in_array($value, $type)) {
                         $fail('The selected value is invalid.');

--- a/database/migrations/2024_05_08_133911_update_filter_table_add_provider.php
+++ b/database/migrations/2024_05_08_133911_update_filter_table_add_provider.php
@@ -13,6 +13,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('filters', function (Blueprint $table) {
+            $table->dropUnique(['type', 'keys']);
             $table->renameColumn('type', 'type_old');
         });
 
@@ -24,6 +25,7 @@ return new class extends Migration
 
         Schema::table('filters', function (Blueprint $table) {
             $table->dropColumn('type_old');
+            $table->unique(['type', 'keys']);
         });        
     }
 
@@ -33,6 +35,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('filters', function (Blueprint $table) {
+            $table->dropUnique(['type', 'keys']);
             $table->enum('type_old', [
                 'dataset',
                 'collection',
@@ -52,6 +55,7 @@ return new class extends Migration
 
         Schema::table('filters', function (Blueprint $table) {
             $table->renameColumn('type_old', 'type');
+            $table->unique(['type', 'keys']);
         }); 
     }
 };


### PR DESCRIPTION
## Screenshots (if relevant)

Recent filters migration was causing a `migrate:fresh` to fail with:

![Screenshot 2024-05-10 at 12 27 09](https://github.com/HDRUK/gateway-api-2/assets/15649757/6d00ff83-9e81-45a3-a846-e380f6d8f7ca)

For some reason the filter type-keys uniqueness condition was not migrating properly with MySQL (though it was working in SQLite, hence the tests passing on the previous PR).  This PR updates the migration to reapply the uniqueness condition.

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

Yes

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
