### PR TITLE
Return license label in tools search.

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -31,6 +31,7 @@ use App\Models\ProgrammingPackage;
 use App\Models\PublicationHasTool;
 use App\Exports\DatasetTableExport;
 use App\Models\ProgrammingLanguage;
+use App\Models\License;
 use App\Models\ToolHasTypeCategory;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Http;
@@ -437,7 +438,8 @@ class SearchController extends Controller
                         $toolsArray[$i]['type_category'] = $toolHasTypeCategoryIds ? TypeCategory::whereIn('id', $toolHasTypeCategoryIds)->pluck('name')->all() : [];
 
                         // license
-                        $toolsArray[$i]['license'] = $model['license'];
+                        $license = License::where('id', $model['license'])->first();
+                        $toolsArray[$i]['license'] = $license ? $license->label : '';
 
                         // programming_language
                         $toolHasProgrammingLangIds = ToolHasProgrammingLanguage::where('tool_id', $model['id'])->pluck('programming_language_id')->all();


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="707" alt="image" src="https://github.com/HDRUK/gateway-api-2/assets/11610738/9f26e2d8-ba00-4c90-b7a5-cef777ccf4d0">

```
  Tests:    283 passed (3899 assertions)
  Duration: 215.12s
```
## Describe your changes
Tools search now returns the license label rather than license ID.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4192
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
