### PR TITLE
Add fetch all (lite) options to controllers for migration suite to use

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -127,6 +127,7 @@ class DatasetController extends Controller
             $filterStatus = $request->query('status', null);
             $datasetId = $request->query('dataset_id', null);
             $mongoPId = $request->query('mongo_pid', null);
+            $withMetadata = $request->boolean('with_metadata', true);
     
             $sort = $request->query('sort',"created:desc");   
             
@@ -203,8 +204,8 @@ class DatasetController extends Controller
     
             // perform query for the matching datasets with ordering and pagination. 
             // Include soft-deleted versions.
-            $datasets = Dataset::with('latestMetadata') 
-                ->whereIn('id', $matches)
+            $datasets = Dataset::whereIn('id', $matches)
+                ->when($withMetadata, fn($query) => $query->with('latestMetadata'))
                 ->when($request->has('withTrashed') || $filterStatus === 'ARCHIVED', 
                     function ($query) {
                         return $query->withTrashed();

--- a/app/Http/Controllers/Api/V1/DurController.php
+++ b/app/Http/Controllers/Api/V1/DurController.php
@@ -159,6 +159,7 @@ class DurController extends Controller
             $teamId = $request->query('team_id',null);
             $filterStatus = $request->query('status', null);
             $perPage = request('perPage', Config::get('constants.per_page'));
+            $withRelated = $request->boolean('with_related', true);
             $durs = Dur::when($mongoId, function ($query) use ($mongoId) {
                     return $query->where('mongo_id', '=', $mongoId);
                 })->when($projectTitle, function ($query) use ($projectTitle) {
@@ -171,27 +172,29 @@ class DurController extends Controller
                 })->when($filterStatus, 
                     function ($query) use ($filterStatus) {
                         return $query->where('status', '=', $filterStatus);
-                })->with([
-                    'datasets',
-                    'publications', 
-                    'tools',
-                    'keywords',
-                    'userDatasets' => function ($query) {
-                        $query->distinct('id');
-                    },
-                    'userPublications' => function ($query) {
-                        $query->distinct('id');
-                    },
-                    'applicationDatasets' => function ($query) {
-                        $query->distinct('id');
-                    },
-                    'applicationPublications' => function ($query) {
-                        $query->distinct('id');
-                    },
-                    'user',
-                    'team',
-                    'application',
-                ]);
+                })->when($withRelated, fn($query) => $query
+                    ->with([
+                        'datasets',
+                        'publications', 
+                        'tools',
+                        'keywords',
+                        'userDatasets' => function ($query) {
+                            $query->distinct('id');
+                        },
+                        'userPublications' => function ($query) {
+                            $query->distinct('id');
+                        },
+                        'applicationDatasets' => function ($query) {
+                            $query->distinct('id');
+                        },
+                        'applicationPublications' => function ($query) {
+                            $query->distinct('id');
+                        },
+                        'user',
+                        'team',
+                        'application',
+                    ])
+                );
 
             foreach ($sort as $key => $value) {
                 $durs->orderBy('dur.' . $key, strtoupper($value));

--- a/app/Http/Controllers/Api/V1/PublicationController.php
+++ b/app/Http/Controllers/Api/V1/PublicationController.php
@@ -66,6 +66,8 @@ class PublicationController extends Controller
             $input = $request->all();
             $mongoId = $request->query('mongo_id', null);
             $paperTitle = $request->query('paper_title', null);
+            $perPage = request('per_page', Config::get('constants.per_page'));
+            $withRelated = $request->boolean('with_related', true);
 
             $publications = Publication::when($paperTitle, function ($query) use ($paperTitle) {
                 return $query->where('paper_title', 'LIKE', '%' . $paperTitle . '%');
@@ -73,11 +75,8 @@ class PublicationController extends Controller
             ->when($mongoId, function ($query) use ($mongoId) {
                 return $query->where('mongo_id', '=', $mongoId);
             })
-            ->with([
-                'datasets',
-                'tools',
-            ])
-            ->paginate(Config::get('constants.per_page'), ['*'], 'page');
+            ->when($withRelated, fn($query) => $query->with(['datasets', 'tools']))
+            ->paginate($perPage, ['*'], 'page');
 
             Auditor::log([
                 'action_type' => 'GET',

--- a/app/Http/Controllers/Api/V1/ToolController.php
+++ b/app/Http/Controllers/Api/V1/ToolController.php
@@ -134,6 +134,7 @@ class ToolController extends Controller
             $mongoId = $request->query('mongo_id', null);
             $teamId = $request->query('team_id', null);
             $filterTitle = $request->query('title', null);
+            $perPage = request('per_page', Config::get('constants.per_page'));
 
             $sort = $request->query('sort', 'name:desc');
             $tmp = explode(":", $sort);
@@ -171,7 +172,7 @@ class ToolController extends Controller
             })
             ->where('enabled', 1)
             ->orderBy($sortField, $sortDirection)
-            ->paginate(Config::get('constants.per_page'), ['*'], 'page');
+            ->paginate($perPage, ['*'], 'page');
 
             Auditor::log([
                 'action_type' => 'GET',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adding options to `index` methods that the mongo-migration suite can use. The options allow for grabbing all the instances of an entity by trimming down the response (e.g. grabbing datasets without metadata, publications without related entities etc).

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-4386

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
