### PR TITLE
Hotfix to DataProviderCollController

### DIFF
--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -681,7 +681,7 @@ class DataProviderCollController extends Controller
         $datasetType = MMC::getValueByPossibleKeys($metadataSummary, ['datasetType'], '');
 
         if (empty($title) || $title === '') {
-            Log::error('Dataset title is empty or unknown', ['datasetId' => $dataset->id]);
+            Log::error('DataProviderCollController: Dataset title is empty or unknown', ['datasetId' => $dataset->id]);
         }
 
         $this->datasets[] = [


### PR DESCRIPTION
## Screenshots (if relevant)
exception: Exception {#885
      #message: "Undefined array key "original_metadata""
      #code: 0
      #file: "./app/Http/Controllers/Api/V1/DataProviderCollController.php"
      #line: 228
## Describe your changes

Change to public function checkingDataset() to only use current metadata, I.e. do not get title from original metadata. added logging if dataset title is empty and implemented fetching via MMC::getValueByPossibleKeys() 

## Issue ticket link
https://hdruk.atlassian.net/servicedesk/customer/portal/7/FBL-524
## Environment / Configuration changes (if applicable)
Dev
## Requires migrations being run?
No
## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x ] I have performed a self-review of my code
- [x ] I have added appropriate unit tests
- [x ] I have created mocks for unit tests (where appropriate)
- [x ] I have added appropriate Behat tests to confirm AC (if applicable)
- [x ] I have added Swagger annotations for new endpoints (if applicable)
- [x ] I have added audit logs for new operation logic (if applicable)
- [x ] I have added new environment variables to the .env.example file (if applicable)
