### PR TITLE
GAT-4674 :: update licenses doesnt work on preprod

### DIFF
--- a/app/Console/Commands/UpdateLicenses.php
+++ b/app/Console/Commands/UpdateLicenses.php
@@ -35,6 +35,7 @@ class UpdateLicenses extends Command
             $getVocabulariesLicense = $this->getVocabulariesLicense();
             $vocabulariesLicence = $getVocabulariesLicense['result']['results'];
 
+            // echo 'Team ' . $teamName . ' not found. skipping ...' . PHP_EOL;
             // EU
             foreach ($vocabulariesLicence as $license) {
                 if (!array_key_exists('en', $license['pref_label'])) {
@@ -43,10 +44,12 @@ class UpdateLicenses extends Command
                 $label = $license['pref_label']['en'];
 
                 $licenseId = (string) $license['id'];
+                echo 'Licence Id :: ' . $licenseId . ' start ' . PHP_EOL;
 
                 $data = $this->getLicenseDetails($licenseId); // parse resource
 
                 if (!$data) {
+                    echo 'Licence Id :: ' . $licenseId . ' data not found. skipping ...' . PHP_EOL;
                     continue;
                 }
 
@@ -62,15 +65,20 @@ class UpdateLicenses extends Command
                     ],
                     $data
                 );
+                echo 'Licence Id :: ' . $licenseId . ' update or create in db ...' . PHP_EOL;
+                sleep(2);
             }
         } catch (Exception $exception) {
             throw new Exception($exception->getMessage());
         }
+
+        echo 'Completed ...' . PHP_EOL;
     }
 
     public function getVocabulariesLicense()
     {
         try {
+            echo 'Call url :: ' . $this->urlVocabularies . PHP_EOL;
             return Http::timeout(5)->get($this->urlVocabularies);
         } catch (Exception $exception) {
             throw new Exception($exception->getMessage());
@@ -81,6 +89,7 @@ class UpdateLicenses extends Command
     {
         $url = $this->urlLicense . trim($code);
         try {
+            echo 'Get license details :: ' . $url . PHP_EOL;
             $getLicense = Http::retry(3, 100)->timeout(5)->get($url);
 
             if ($getLicense->ok()) {


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2024-07-16 at 12 58 24](https://github.com/user-attachments/assets/3991b21b-d22c-426a-b3f7-ef27155176d2)


## Describe your changes
update licenses doesnt work on preprod
- update with info & delay between requests

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4674

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
no

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
