### PR TITLE
Change to LinkedDataset accession to conform with other accessors

### DIFF
--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -30,6 +30,7 @@ class DataProviderCollController extends Controller
     private $tools = [];
     private $publications = [];
     private $collections = [];
+    private $linked_datasets = [];
 
     /**
      * @OA\Get(
@@ -185,6 +186,7 @@ class DataProviderCollController extends Controller
      *                  @OA\Property(property="tools", type="array", example="{}", @OA\Items()),
      *                  @OA\Property(property="publications", type="array", example="{}", @OA\Items()),
      *                  @OA\Property(property="collections", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="linked_datasets", type="array", example="{}", @OA\Items()),
      *              )
      *          ),
      *      ),
@@ -232,6 +234,7 @@ class DataProviderCollController extends Controller
                     'tools' => Tool::select('id', 'name', 'enabled', 'created_at', 'updated_at')->with(['user'])->whereIn('id', $this->tools)->get()->toArray(),
                     'publications' => Publication::select('id', 'paper_title', 'authors', 'publication_type', 'publication_type_mk1', 'created_at', 'updated_at')->whereIn('id', $this->publications)->get()->toArray(),
                     'collections' => Collection::select('id', 'name', 'image_link', 'created_at', 'updated_at')->whereIn('id', $this->collections)->get()->toArray(),
+                    'linked_datasets' => Dataset::select('id','created_at', 'updated_at')->whereIn('id', $this->linked_datasets)->get()->toArray(),
                 ],
             ]);
         } catch (Exception $e) {
@@ -677,14 +680,9 @@ class DataProviderCollController extends Controller
         $collectionIds = array_column($dataset->allCollections, 'id') ?? [];
         $publicationIds = array_column($dataset->allPublications, 'id') ?? [];
         $toolIds = array_column($dataset->allTools, 'id') ?? [];
-
-        $version = $dataset->latestVersion();
-        $withLinks = DatasetVersion::where('id', $version['id'])
-            ->with(['linkedDatasetVersions'])
-            ->first();
-
-        $dataset->setAttribute('versions', [$withLinks]);
-
+        $linkedDatasetIds = array_column($dataset->allLinkedDatasets, 'id') ?? [];
+        
+        $dataset->setAttribute('versions', $dataset->latestVersion());
         $metadataSummary = $dataset['versions'][0]['metadata']['metadata']['summary'] ?? [];
 
         $title = MMC::getValueByPossibleKeys($metadataSummary, ['title'], '');
@@ -707,5 +705,6 @@ class DataProviderCollController extends Controller
         $this->publications = array_unique(array_merge($this->publications, $publicationIds));
         $this->tools = array_unique(array_merge($this->tools, $toolIds));
         $this->collections = array_unique(array_merge($this->collections, $collectionIds));
+        $this->linked_datasets = array_unique(array_merge($this->linked_datasets, $linkedDatasetIds));
     }
 }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -409,7 +409,7 @@ class DatasetController extends Controller
 
             // Return the latest metadata for this dataset
             if (!($outputSchemaModel && $outputSchemaModelVersion)) {
-                $dataset->setAttribute('versions', $latestVersion ?? []);
+                $dataset->setAttribute('versions', $latestVersion);
             }
 
             if ($outputSchemaModel && $outputSchemaModelVersion) {

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -332,10 +332,16 @@ class DatasetController extends Controller
      *       description="Alternative output schema model.",
      *       @OA\Schema(type="string", example="structuralMetadata")
      *    ),
-      *    @OA\Parameter(
+     *    @OA\Parameter(
      *       name="schema_model",
      *       in="query",
      *       description="Alternative output schema model.",
+     *       @OA\Schema(type="string")
+     *    ),
+     *    @OA\Parameter(
+     *       name="linked_dataset",
+     *       in="query",
+     *       description="Return linked datasets.",
      *       @OA\Schema(type="string")
      *    ),
      *    @OA\Parameter(
@@ -390,7 +396,7 @@ class DatasetController extends Controller
             }
             // Retrieve the latest version 
             $latestVersion = $dataset->latestVersion();
-
+            
             // Inject attributes via the dataset version table
             $dataset->setAttribute('durs_count', $latestVersion->durHasDatasetVersions()->count());
             $dataset->setAttribute('publications_count', $latestVersion->publicationHasDatasetVersions()->count());
@@ -399,18 +405,19 @@ class DatasetController extends Controller
             $dataset->setAttribute('publications', $dataset->allPublications  ?? []);
             $dataset->setAttribute('named_entities', $dataset->allNamedEntities  ?? []);
             $dataset->setAttribute('collections', $dataset->allCollections  ?? []);
-            $dataset->setAttribute('linked_datasets', $dataset->allLinkedDatasets  ?? []);
 
+            $outputLinkedDatasets = $request->query('linked_datasets');
             $outputSchemaModel = $request->query('schema_model');
             $outputSchemaModelVersion = $request->query('schema_version');
 
-            // Retrieve the latest version 
-            $latestVersion = $dataset->latestVersion();
+            if ($outputLinkedDatasets){
+                    $dataset->setAttribute('linked_datasets', $dataset->allLinkedDatasets ?? []);
+            }
 
             // Return the latest metadata for this dataset
             if (!($outputSchemaModel && $outputSchemaModelVersion)) {
-                $dataset->setAttribute('versions', $latestVersion);
-            }
+                    $dataset->setAttribute('versions', [$latestVersion]);
+                }
 
             if ($outputSchemaModel && $outputSchemaModelVersion) {
                 $translated = MMC::translateDataModelType(

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -240,4 +240,46 @@ class Dataset extends Model
         // Return the collection of entities with injected dataset version IDs
         return $entities->toArray();
     }
+    public function getAllLinkedDatasetsAttribute()
+    {
+        // Collection to store linked datasets
+        $linkedDatasets = collect();
+
+        foreach ($this->versions as $version) {
+            // Get linked versions where this version is the source
+            $linkedVersionsAsSource = $version->linkedDatasetVersionsAsSource()->with('dataset')->get();
+            foreach ($linkedVersionsAsSource as $linkedVersion) {
+                if ($linkedVersion->dataset && $linkedVersion->dataset->id !== $this->id) {
+                    // Setting attributes on the linked dataset model
+                    $linkedDataset = $linkedVersion->dataset;
+                    $linkedDataset->setAttribute('linkage_type', $linkedVersion->pivot->linkage_type);
+                    $linkedDataset->setAttribute('direct_linkage', $linkedVersion->pivot->direct_linkage);
+                    $linkedDataset->setAttribute('description', $linkedVersion->pivot->description);
+                    $linkedDataset->setAttribute('dataset_version_source_id', $linkedVersion->pivot->dataset_version_source_id);
+                    $linkedDataset->setAttribute('dataset_version_target_id', $linkedVersion->pivot->dataset_version_target_id);
+
+                    $linkedDatasets->push($linkedDataset);
+                }
+            }
+
+            // Get linked versions where this version is the target
+            $linkedVersionsAsTarget = $version->linkedDatasetVersionsAsTarget()->with('dataset')->get();
+            foreach ($linkedVersionsAsTarget as $linkedVersion) {
+                if ($linkedVersion->dataset && $linkedVersion->dataset->id !== $this->id) {
+                    // Setting attributes on the linked dataset model
+                    $linkedDataset = $linkedVersion->dataset;
+                    $linkedDataset->setAttribute('linkage_type', $linkedVersion->pivot->linkage_type);
+                    $linkedDataset->setAttribute('direct_linkage', $linkedVersion->pivot->direct_linkage);
+                    $linkedDataset->setAttribute('description', $linkedVersion->pivot->description);
+                    $linkedDataset->setAttribute('dataset_version_source_id', $linkedVersion->pivot->dataset_version_source_id);
+                    $linkedDataset->setAttribute('dataset_version_target_id', $linkedVersion->pivot->dataset_version_target_id);
+
+                    $linkedDatasets->push($linkedDataset);
+                }
+            }
+        }
+
+        return $linkedDatasets->toArray();
+    }
+
 }

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -240,46 +240,55 @@ class Dataset extends Model
         // Return the collection of entities with injected dataset version IDs
         return $entities->toArray();
     }
+    
     public function getAllLinkedDatasetsAttribute()
     {
-        // Collection to store linked datasets
         $linkedDatasets = collect();
 
         foreach ($this->versions as $version) {
-            // Get linked versions where this version is the source
-            $linkedVersionsAsSource = $version->linkedDatasetVersionsAsSource()->with('dataset')->get();
-            foreach ($linkedVersionsAsSource as $linkedVersion) {
-                if ($linkedVersion->dataset && $linkedVersion->dataset->id !== $this->id) {
-                    // Setting attributes on the linked dataset model
-                    $linkedDataset = $linkedVersion->dataset;
-                    $linkedDataset->setAttribute('linkage_type', $linkedVersion->pivot->linkage_type);
-                    $linkedDataset->setAttribute('direct_linkage', $linkedVersion->pivot->direct_linkage);
-                    $linkedDataset->setAttribute('description', $linkedVersion->pivot->description);
-                    $linkedDataset->setAttribute('dataset_version_source_id', $linkedVersion->pivot->dataset_version_source_id);
-                    $linkedDataset->setAttribute('dataset_version_target_id', $linkedVersion->pivot->dataset_version_target_id);
+            // Source linked versions
+            $linkedVersionsAsSource = $version->linkedDatasetVersionsAsSource()
+                ->with('dataset') // Ensure that dataset relationship is loaded
+                ->get();
 
-                    $linkedDatasets->push($linkedDataset);
+            foreach ($linkedVersionsAsSource as $item) {
+                $linkedDatasetVersion = DatasetVersion::find($item->pivot_attributes->dataset_version_target_id);
+                if ($linkedDatasetVersion) {
+                    $linkedDataset = $linkedDatasetVersion->dataset;
+                    if ($linkedDataset && $linkedDataset->id !== $this->id) {
+                        $linkedDataset->setAttribute('linkage_type', $item->pivot_attributes->linkage_type);
+                        $linkedDataset->setAttribute('direct_linkage', $item->pivot_attributes->direct_linkage);
+                        $linkedDataset->setAttribute('description', $item->pivot_attributes->description);
+                        $linkedDataset->setAttribute('dataset_version_source_id', $item->pivot_attributes->dataset_version_source_id);
+                        $linkedDataset->setAttribute('dataset_version_target_id', $item->pivot_attributes->dataset_version_target_id);
+
+                        $linkedDatasets->push($linkedDataset);
+                    }
                 }
             }
 
-            // Get linked versions where this version is the target
-            $linkedVersionsAsTarget = $version->linkedDatasetVersionsAsTarget()->with('dataset')->get();
-            foreach ($linkedVersionsAsTarget as $linkedVersion) {
-                if ($linkedVersion->dataset && $linkedVersion->dataset->id !== $this->id) {
-                    // Setting attributes on the linked dataset model
-                    $linkedDataset = $linkedVersion->dataset;
-                    $linkedDataset->setAttribute('linkage_type', $linkedVersion->pivot->linkage_type);
-                    $linkedDataset->setAttribute('direct_linkage', $linkedVersion->pivot->direct_linkage);
-                    $linkedDataset->setAttribute('description', $linkedVersion->pivot->description);
-                    $linkedDataset->setAttribute('dataset_version_source_id', $linkedVersion->pivot->dataset_version_source_id);
-                    $linkedDataset->setAttribute('dataset_version_target_id', $linkedVersion->pivot->dataset_version_target_id);
+            // Target linked versions
+            $linkedVersionsAsTarget = $version->linkedDatasetVersionsAsTarget()
+                ->with('dataset') // Ensure that dataset relationship is loaded
+                ->get();
 
-                    $linkedDatasets->push($linkedDataset);
+            foreach ($linkedVersionsAsTarget as $item) {
+                $linkedDatasetVersion = DatasetVersion::find($item->pivot_attributes->dataset_version_source_id);
+                if ($linkedDatasetVersion) {
+                    $linkedDataset = $linkedDatasetVersion->dataset;
+                    if ($linkedDataset && $linkedDataset->id !== $this->id) {
+                        $linkedDataset->setAttribute('linkage_type', $item->pivot_attributes->linkage_type);
+                        $linkedDataset->setAttribute('direct_linkage', $item->pivot_attributes->direct_linkage);
+                        $linkedDataset->setAttribute('description', $item->pivot_attributes->description);
+                        $linkedDataset->setAttribute('dataset_version_source_id', $item->pivot_attributes->dataset_version_source_id);
+                        $linkedDataset->setAttribute('dataset_version_target_id', $item->pivot_attributes->dataset_version_target_id);
+
+                        $linkedDatasets->push($linkedDataset);
+                    }
                 }
             }
         }
 
         return $linkedDatasets->toArray();
     }
-
 }

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -132,6 +132,25 @@ class DatasetVersion extends Model
         return $this->hasMany(CollectionHasDatasetVersion::class);
     }
 
+    /**
+     * The dataset versions that belong to the dataset version.
+     */
+    public function linkedDatasetVersions(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            DatasetVersion::class, 
+            'dataset_version_has_dataset_version',
+            'dataset_version_source_id',
+            'dataset_version_target_id'
+        )->withPivot(
+            'dataset_version_source_id', 
+            'dataset_version_target_id', 
+            'linkage_type', 
+            'direct_linkage', 
+            'description'
+        );
+    }
+
     // Dataset versions where this version is the source
     public function linkedDatasetVersionsAsSource()
     {

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -131,10 +131,8 @@ class DatasetVersion extends Model
         return $this->hasMany(CollectionHasDatasetVersion::class);
     }
 
-    /**
-     * The dataset versions that belong to the dataset version.
-     */
-    public function linkedDatasetVersions(): BelongsToMany
+    // Dataset versions where this version is the source
+    public function linkedDatasetVersionsAsSource(): BelongsToMany
     {
         return $this->belongsToMany(
             DatasetVersion::class, 
@@ -149,5 +147,28 @@ class DatasetVersion extends Model
             'description'
         );
     }
+
+    // Dataset versions where this version is the target
+    public function linkedDatasetVersionsAsTarget(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            DatasetVersion::class, 
+            'dataset_version_has_dataset_version',
+            'dataset_version_target_id',
+            'dataset_version_source_id'
+        )->withPivot(
+            'dataset_version_source_id', 
+            'dataset_version_target_id', 
+            'linkage_type', 
+            'direct_linkage', 
+            'description'
+        );
+    }
+
+     // Define the relationship back to the Dataset
+     public function dataset()
+     {
+         return $this->belongsTo(Dataset::class, 'dataset_id');
+     }
 
 }

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -4,6 +4,7 @@ namespace App\Models;
 use App\Models\Tool;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\Builder;
@@ -132,7 +133,7 @@ class DatasetVersion extends Model
     }
 
     // Dataset versions where this version is the source
-    public function linkedDatasetVersionsAsSource(): BelongsToMany
+    public function linkedDatasetVersionsAsSource()
     {
         return $this->belongsToMany(
             DatasetVersion::class, 
@@ -145,11 +146,11 @@ class DatasetVersion extends Model
             'linkage_type', 
             'direct_linkage', 
             'description'
-        );
+        )->as('pivot_attributes');
     }
 
     // Dataset versions where this version is the target
-    public function linkedDatasetVersionsAsTarget(): BelongsToMany
+    public function linkedDatasetVersionsAsTarget()
     {
         return $this->belongsToMany(
             DatasetVersion::class, 
@@ -162,11 +163,11 @@ class DatasetVersion extends Model
             'linkage_type', 
             'direct_linkage', 
             'description'
-        );
+        )->as('pivot_attributes');
     }
 
      // Define the relationship back to the Dataset
-     public function dataset()
+     public function dataset(): BelongsTo
      {
          return $this->belongsTo(Dataset::class, 'dataset_id');
      }

--- a/tests/Feature/DataProviderCollTest.php
+++ b/tests/Feature/DataProviderCollTest.php
@@ -155,6 +155,7 @@ class DataProviderCollTest extends TestCase
                 'tools',
                 'publications',
                 'collections',
+                'linked_datasets'
             ]
         ]);
     }

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -565,9 +565,7 @@ class DatasetTest extends TestCase
         if(env('TED_ENABLED')){
             $this->assertNotEmpty($respArrayActive['data']['named_entities']);
         };
-        $this->assertArrayHasKey(
-            'linked_dataset_versions', $respArrayActive['data']['versions'][0]
-        );
+        $this->assertArrayHasKey('linked_datasets', $respArrayActive['data']);
 
         // delete active dataset
         $responseDeleteActiveDataset = $this->json(

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\Models\Dataset;
 use App\Models\NamedEntities;
 use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
 use Illuminate\Support\Carbon;
 use Tests\Traits\Authorization;
 use App\Http\Enums\TeamMemberOf;
@@ -523,7 +524,7 @@ class DatasetTest extends TestCase
         $activeDatasetId = $contentCreateActiveDataset['data'];
 
         // get one active dataset
-        $responseGetOneActive = $this->json('GET', self::TEST_URL_DATASET . '/' . $activeDatasetId, [], $this->header);
+        $responseGetOneActive = $this->json('GET', self::TEST_URL_DATASET . '/' . $activeDatasetId . '?linked_datasets=true', [], $this->header);
 
         $responseGetOneActive->assertJsonStructure([
             'message',
@@ -534,6 +535,7 @@ class DatasetTest extends TestCase
                 'versions',
                 'durs_count',
                 'publications_count',
+                'linked_datasets'
             ]
         ]);
         $responseGetOneActive->assertStatus(200);
@@ -558,6 +560,32 @@ class DatasetTest extends TestCase
     
             // Compare each field in the response array with the corresponding field in the database
             $this->assertEquals($namedEntity->name, $entity['name'], 'The name in the response does not match the name in the database.');
+        }
+        dump($respArrayActive['data']['linked_datasets']);
+
+        // Assert linked datasets contain required fields
+        foreach ($respArrayActive['data']['linked_datasets'] as $linkedDataset) {
+            // Assert that the array contains the key 'linkage_type'
+            $this->assertArrayHasKey('linkage_type', $linkedDataset);
+            $this->assertNotNull($linkedDataset['linkage_type'], 'The "linkage_type" key should not have a null value.');
+
+            // Assert that the array contains the key 'direct_linkage'
+            $this->assertArrayHasKey('direct_linkage', $linkedDataset);
+            $this->assertNotNull($linkedDataset['direct_linkage'], 'The "direct_linkage" key should not have a null value.');
+
+            // Assert that the array contains the key 'dataset_version_source_id'
+            $this->assertArrayHasKey('dataset_version_source_id', $linkedDataset);
+            $this->assertNotNull($linkedDataset['dataset_version_source_id'], 'The "dataset_version_source_id" key should not have a null value.');
+
+            // Assert that the array contains the key 'dataset_version_target_id'
+            $this->assertArrayHasKey('dataset_version_target_id', $linkedDataset);
+            $this->assertNotNull($linkedDataset['dataset_version_target_id'], 'The "dataset_version_target_id" key should not have a null value.');
+
+            // Optionally, if you want to validate the linkage_type and other attributes more deeply
+            $this->assertIsString($linkedDataset['linkage_type'], 'The "linkage_type" key should be a string.');
+            $this->assertIsBool($linkedDataset['direct_linkage'], 'The "direct_linkage" key should be a boolean.');
+            $this->assertIsInt($linkedDataset['dataset_version_source_id'], 'The "dataset_version_source_id" key should be an integer.');
+            $this->assertIsInt($linkedDataset['dataset_version_target_id'], 'The "dataset_version_target_id" key should be an integer.');
         }
         
 

--- a/tests/Feature/UploadTest.php
+++ b/tests/Feature/UploadTest.php
@@ -367,7 +367,8 @@ class UploadTest extends TestCase
 
         // Get the latest version and check that the structural metadata matches test data
         $latestVersion = $response->decodeResponseJson()['data']['versions'][0]['metadata'];
-
+        $structualMetadata = $latestVersion['metadata']['structuralMetadata'];
+        dump($structualMetadata);
         $this->assertIsArray($latestVersion['metadata']['structuralMetadata']);
         $this->assertEquals(
             $latestVersion['metadata']['structuralMetadata'][0]['name'], 'Test Table'


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

added accessor to the dataset model to get linked_datasets

BE can now access these using: 

  `
  $dataset->allLinkedDatasets
= [
    [
      "id" => 6,
      "mongo_object_id" => null,
      "mongo_id" => null,
      "mongo_pid" => null,
      "datasetid" => null,
      "pid" => null,
      "source" => null,
      "discourse_topic_id" => 0,
      "is_cohort_discovery" => false,
      "commercial_use" => 0,
      "state_id" => 0,
      "uploader_id" => 0,
      "metadataquality_id" => 0,
      "user_id" => 7,
      "team_id" => 8,
      "views_count" => 0,
      "views_prev_count" => 0,
      "has_technical_details" => 1,
      "created" => null,
      "updated" => null,
      "submitted" => null,
      "published" => null,
      "created_at" => "2024-07-24T11:46:39.000000Z",
      "updated_at" => "2024-07-24T11:46:39.000000Z",
      "deleted_at" => null,
      "create_origin" => "FMA",
      "status" => "ACTIVE",
      "linkage_type" => "linkedDatasets",
      "direct_linkage" => 1,
      "description" => "Necessitatibus iure dolore a nam officia. Amet inventore nobis dolore quos eaque saepe est. Rem omnis blanditiis sed.",
      "dataset_version_source_id" => 1,
      "dataset_version_target_id" => 12,
    ],
]
`
  
This can be used to directly set the attribute in the eloquent model as follows. 

    `$dataset->setAttribute('linked_datasets', $dataset->allLinkedDatasets  ?? []);`

Ive also change to controllers so that FE can get linked_datasets directly from:

    1. Get in Dataset controller (/api/v1/datasets/{id})
    2. ShowSummary in dataProviderColl controller (/api/v1/data_provider_colls/{id}/summary)

I've also update the tests to reflect these changes. 


## Issue ticket link
N/A

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
N/A

## If not using the pre-push hook. Confirm tests pass:
 PASS  Tests\Feature\DataProviderCollTest
  ✓ get all data provider colls with success                                                                                                      1.71s  
  ✓ get data provider coll by id with success                                                                                                     1.57s  
  ✓ get data provider coll by id summary with success                                                                                             1.54s  
  ✓ create data provider coll with success                                                                                                        1.58s  
  ✓ update data provider with success                                                                                                             1.55s  
  ✓ delete data provider coll with success                                                                                                        1.56s  
  ✓ can update team associations with success                                                                                                     1.62s  

  Tests:    7 passed (79 assertions)
  Duration: 11.18s

 PASS  Tests\Feature\DatasetTest
  ✓ get all datasets with success                                                                                                                 1.16s  
  ✓ get all team datasets with success                                                                                                            1.12s  
  ✓ get one dataset by id with success                                                                                                            1.03s  
  ✓ create archive delete dataset with success                                                                                                    1.00s  
  ✓ create update delete dataset with success                                                                                                     1.12s  
  ✓ create dataset fails with invalid origin                                                                                                      0.97s  
  ✓ download dataset table with success                                                                                                           1.03s  
  ✓ can download mock dataset structural metadata file                                                                                            0.95s  
  ✓ can download mock dataset metadata file                                                                                                       1.03s  
  ✓ download mock file with file not found                                                                                                        0.97s  

  Tests:    10 passed (168 assertions)
  Duration: 10.43s

## Checklist before requesting a review

- [x ] I have performed a self-review of my code
- [x ] I have added appropriate unit tests
- [x ] I have created mocks for unit tests (where appropriate)
- [N/A ] I have added appropriate Behat tests to confirm AC (if applicable)
- [x ] I have added Swagger annotations for new endpoints (if applicable)
- [N/A ] I have added audit logs for new operation logic (if applicable)
- [N/A ] I have added new environment variables to the .env.example file (if applicable)
