### PR TITLE
HOTFIX gat 4782 write be laravel command to retrigger the term extraction process for datasets

### DIFF
--- a/app/Console/Commands/ReindexEntities.php
+++ b/app/Console/Commands/ReindexEntities.php
@@ -116,7 +116,7 @@ class ReindexEntities extends Command
             $datasetIds = array_slice($datasetIds, 0, $maxIndex + 1);
         }
 
-        $termExtraction = $this->option('term-extraction'); // Initialize $termExtraction based on the command optio
+        $termExtraction = $this->option('term-extraction'); // Initialize $termExtraction based on the command option
 
         $progressbar = $this->output->createProgressBar(count($datasetIds));
         foreach ($datasetIds as $id) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

FIxed missing variable

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
