### PR TITLE
fixes a few broken rollbacks in migration. also adds indexes on other…

### DIFF
--- a/app/Http/Traits/GetValueByPossibleKeys.php
+++ b/app/Http/Traits/GetValueByPossibleKeys.php
@@ -23,9 +23,11 @@ trait GetValueByPossibleKeys
                 return $value;
             }
         }
-        Log::info('No value found for any of the specified keys', [
-            'keys' => $keys,
-        ]);
+        // Removing, as it doesn't really serve a purpose dumping this to stdout.
+        // Suggest, if we care about it, then we audit it instead.
+        // Log::info('No value found for any of the specified keys', [
+        //     'keys' => $keys,
+        // ]);
         return $default;
     }
 }

--- a/database/migrations/2024_01_30_163819_add_id_locked_field_to_dur_has_datasets_table.php
+++ b/database/migrations/2024_01_30_163819_add_id_locked_field_to_dur_has_datasets_table.php
@@ -20,9 +20,11 @@ return new class () extends Migration {
      */
     public function down(): void
     {
-        Schema::table('dur_has_datasets', function (Blueprint $table) {
-            $table->dropColumn('is_locked');
-        });
+        if (Schema::hasTable('dur_has_datasets')) {
+            Schema::table('dur_has_datasets', function (Blueprint $table) {
+                $table->dropColumn('is_locked');
+            });
+        }
     }
 };
 

--- a/database/migrations/2024_01_30_164453_add_reason_field_to_dur_has_datasets_table.php
+++ b/database/migrations/2024_01_30_164453_add_reason_field_to_dur_has_datasets_table.php
@@ -20,8 +20,10 @@ return new class () extends Migration {
      */
     public function down(): void
     {
-        Schema::table('dur_has_datasets', function (Blueprint $table) {
-            $table->dropColumn('reason');
-        });
+        if (Schema::hasTable('dur_has_datasets')) {
+            Schema::table('dur_has_datasets', function (Blueprint $table) {
+                $table->dropColumn('reason');
+            });
+        }
     }
 };

--- a/database/migrations/2024_02_12_161211_add_team_id_to_collections_table.php
+++ b/database/migrations/2024_02_12_161211_add_team_id_to_collections_table.php
@@ -25,7 +25,6 @@ return new class () extends Migration {
         Schema::disableForeignKeyConstraints();
 
         DB::statement('ALTER TABLE `collections` DROP FOREIGN KEY `collections_team_id_foreign`');
-        DB::statement('ALTER TABLE `collections` DROP KEY `collections_team_id_foreign`');
 
         Schema::table('collections', function (Blueprint $table) {
             $table->dropColumn('team_id');

--- a/database/migrations/2024_05_08_173930_change_license_field_to_tools_table.php
+++ b/database/migrations/2024_05_08_173930_change_license_field_to_tools_table.php
@@ -27,7 +27,6 @@ return new class () extends Migration {
         Schema::disableForeignKeyConstraints();
         DB::table('tools')->update(['license' => null]);
         DB::statement('ALTER TABLE `tools` DROP FOREIGN KEY `tools_license_foreign`');
-        DB::statement('ALTER TABLE `tools` DROP KEY `tools_license_foreign`');
 
         Schema::table('tools', function (Blueprint $table) {
             $table->char('license', 45)->nullable()->change();

--- a/database/migrations/2024_06_21_120801_add__soft_deletes_to_dur_has_datasets.php
+++ b/database/migrations/2024_06_21_120801_add__soft_deletes_to_dur_has_datasets.php
@@ -21,7 +21,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('dur_has_datasets', function (Blueprint $table) {
-            $table->dropSoftDeletes();
+            $table->dropIfExists('deleted_at');
         });
     }
 };

--- a/database/migrations/2024_08_15_101337_other-indexes-on-deleted-at-fields.php
+++ b/database/migrations/2024_08_15_101337_other-indexes-on-deleted-at-fields.php
@@ -1,0 +1,393 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('authorisation_codes', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('cohort_requests', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('collection_has_dataset_version', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('collection_has_durs', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('collection_has_publications', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('collection_has_tools', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('collections', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dar_applications', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dar_integrations', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dar_sections', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dar_templates', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('data_provider_colls', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dataset_version_has_named_entities', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dataset_version_has_spatial_coverage', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dataset_version_has_tool', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dur', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dur_has_dataset_version', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dur_has_keywords', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dur_has_publications', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('dur_has_tools', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('email_templates', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('enquiry_thread_has_dataset_version', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('features', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('federations', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('filters', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('libraries', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('named_entities', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->index('deleted_at');
+            $table->index('link_type');
+        });
+
+        Schema::table('publication_has_tools', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('publications', function (Blueprint $table) {
+            $table->index('deleted_at');
+            $table->index('status');
+        });
+
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->index('deleted_at');
+            $table->index('team_id');
+        });
+
+        Schema::table('question_bank_versions', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('saved_searches', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tags', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tool_has_programming_language', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tool_has_programming_package', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tool_has_tags', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tool_has_type_category', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('tools', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table) {
+            $table->dropIndex('audit_logs_deleted_at_index');
+        });
+
+        Schema::table('authorisation_codes', function (Blueprint $table) {
+            $table->dropIndex('authorisation_codes_deleted_at_index');
+        });
+
+        Schema::table('cohort_requests', function (Blueprint $table) {
+            $table->dropIndex('cohort_requests_deleted_at_index');
+        });
+
+        Schema::table('collection_has_dataset_version', function (Blueprint $table) {
+            $table->dropIndex('collection_has_dataset_version_deleted_at_index');
+        });
+
+        Schema::table('collection_has_durs', function (Blueprint $table) {
+            $table->dropIndex('collection_has_durs_deleted_at_index');
+        });
+
+        Schema::table('collection_has_publications', function (Blueprint $table) {
+            $table->dropIndex('collection_has_publications_deleted_at_index');
+        });
+
+        Schema::table('collection_has_tools', function (Blueprint $table) {
+            $table->dropIndex('collection_has_tools_deleted_at_index');
+        });
+
+        Schema::table('collections', function (Blueprint $table) {
+            $table->dropIndex('collections_deleted_at_index');
+        });
+
+        Schema::table('dar_applications', function (Blueprint $table) {
+            $table->dropIndex('dar_applications_deleted_at_index');
+        });
+
+        Schema::table('dar_integrations', function (Blueprint $table) {
+            $table->dropIndex('dar_integrations_deleted_at_index');
+        });
+
+        Schema::table('dar_sections', function (Blueprint $table) {
+            $table->dropIndex('dar_sections_deleted_at_index');
+        });
+
+        Schema::table('dar_templates', function (Blueprint $table) {
+            $table->dropIndex('dar_templates_deleted_at_index');
+        });
+
+        Schema::table('data_provider_colls', function (Blueprint $table) {
+            $table->dropIndex('data_provider_colls_deleted_at_index');
+        });
+
+        Schema::table('dataset_version_has_named_entities', function (Blueprint $table) {
+            $table->dropIndex('dataset_version_has_named_entities_deleted_at_index');
+        });
+
+        Schema::table('dataset_version_has_spatial_coverage', function (Blueprint $table) {
+            $table->dropIndex('dataset_version_has_spatial_coverage_deleted_at_index');
+        });
+
+        Schema::table('dataset_version_has_tool', function (Blueprint $table) {
+            $table->dropIndex('dataset_version_has_tool_deleted_at_index');
+        });
+
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->dropIndex('datasets_deleted_at_index');
+        });
+
+        Schema::table('dur', function (Blueprint $table) {
+            $table->dropIndex('dur_deleted_at_index');
+        });
+
+        Schema::table('dur_has_dataset_version', function (Blueprint $table) {
+            $table->dropIndex('dur_has_dataset_version_deleted_at_index');
+        });
+
+        Schema::table('dur_has_keywords', function (Blueprint $table) {
+            $table->dropIndex('dur_has_keywords_deleted_at_index');
+        });
+
+        Schema::table('dur_has_publications', function (Blueprint $table) {
+            $table->dropIndex('dur_has_publications_deleted_at_index');
+        });
+
+        Schema::table('dur_has_tools', function (Blueprint $table) {
+            $table->dropIndex('dur_has_tools_deleted_at_index');
+        });
+
+        Schema::table('email_templates', function (Blueprint $table) {
+            $table->dropIndex('email_templates_deleted_at_index');
+        });
+
+        Schema::table('enquiry_thread_has_dataset_version', function (Blueprint $table) {
+            $table->dropIndex('enquiry_thread_has_dataset_version_deleted_at_index');
+        });
+
+        Schema::table('features', function (Blueprint $table) {
+            $table->dropIndex('features_deleted_at_index');
+        });
+
+        Schema::table('federations', function (Blueprint $table) {
+            $table->dropIndex('federations_deleted_at_index');
+        });
+
+        Schema::table('filters', function (Blueprint $table) {
+            $table->dropIndex('filters_deleted_at_index');
+        });
+
+        Schema::table('libraries', function (Blueprint $table) {
+            $table->dropIndex('libraries_deleted_at_index');
+        });
+
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropIndex('licenses_deleted_at_index');
+        });
+
+        Schema::table('named_entities', function (Blueprint $table) {
+            $table->dropIndex('named_entities_deleted_at_index');
+        });
+
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->dropIndex('notifications_deleted_at_index');
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->dropIndex('publication_has_dataset_version_deleted_at_index');
+            $table->dropIndex('publication_has_dataset_version_link_type_index');
+        });
+
+        Schema::table('publication_has_tools', function (Blueprint $table) {
+            $table->dropIndex('publication_has_tools_deleted_at_index');
+        });
+
+        Schema::table('publications', function (Blueprint $table) {
+            $table->dropIndex('publications_deleted_at_index');
+            $table->dropIndex('publications_status_index');
+        });
+
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->dropIndex('question_bank_questions_deleted_at_index');
+            $table->dropIndex('question_bank_questions_team_id_index');
+        });
+
+        Schema::table('question_bank_versions', function (Blueprint $table) {
+            $table->dropIndex('question_bank_versions_deleted_at_index');
+        });
+
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropIndex('reviews_deleted_at_index');
+        });
+
+        Schema::table('saved_searches', function (Blueprint $table) {
+            $table->dropIndex('saved_searches_deleted_at_index');
+        });
+
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropIndex('tags_deleted_at_index');
+        });
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropIndex('teams_deleted_at_index');
+        });
+
+        Schema::table('tool_has_programming_language', function (Blueprint $table) {
+            $table->dropIndex('tool_has_programming_language_deleted_at_index');
+        });
+
+        Schema::table('tool_has_programming_package', function (Blueprint $table) {
+            $table->dropIndex('tool_has_programming_package_deleted_at_index');
+        });
+
+        Schema::table('tool_has_tags', function (Blueprint $table) {
+            $table->dropIndex('tool_has_tags_deleted_at_index');
+        });
+
+        Schema::table('tool_has_type_category', function (Blueprint $table) {
+            $table->dropIndex('tool_has_type_category_deleted_at_index');
+        });
+
+        Schema::table('tools', function (Blueprint $table) {
+            $table->dropIndex('tools_deleted_at_index');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex('users_deleted_at_index');
+        });
+    }
+};


### PR DESCRIPTION
… deleted_at fields after successful theory test recently

## Screenshots (if relevant)

## Describe your changes
Fixes several boken `down`'s in migrations so that rollbacks now complete as they should. Adds in remaining indexes on `deleted_at` field, after a successful theory test before.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
