### PR TITLE
Library - updateOrCreate

### DIFF
--- a/app/Http/Controllers/Api/V1/LibraryController.php
+++ b/app/Http/Controllers/Api/V1/LibraryController.php
@@ -303,10 +303,11 @@ class LibraryController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $library = Library::create([
+            $library = Library::updateOrCreate([
                 'user_id' => (int)$jwtUser['id'],
-                'dataset_id' => $input['dataset_id']
-            ]);
+                'dataset_id' => $input['dataset_id'],
+                'deleted_at' => null,
+            ], []);
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Library entries aren't unique on a combination of user_id/dataset_id - enabling soft-deletes. This had the undesirable side-effect that you could add the same dataset multiple times and the BE didn't mind. This fixes that so that if it is already in the library then the create action makes no change, but it's transparent to the FE.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
