### PR TITLE
Fix - GAT-5099 clamav returns json object

### DIFF
--- a/app/Http/Controllers/Api/V1/UploadController.php
+++ b/app/Http/Controllers/Api/V1/UploadController.php
@@ -75,6 +75,11 @@ class UploadController extends Controller
                 $fileSystem . '.unscanned'
             );
 
+            // if there is an error, storeAs returns false and does not actually throw...
+            if ($filePath === false){
+                throw $file->getError();
+            }
+
             // write to uploads
             $upload = Upload::create([
                 'filename' => $file->getClientOriginalName(),

--- a/app/Http/Controllers/Api/V1/UploadController.php
+++ b/app/Http/Controllers/Api/V1/UploadController.php
@@ -77,7 +77,7 @@ class UploadController extends Controller
 
             // if there is an error, storeAs returns false and does not actually throw...
             if ($filePath === false){
-                throw $file->getError();
+                throw new Exception($file->getError());
             }
 
             // write to uploads

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -101,8 +101,7 @@ class ScanFileUpload implements ShouldQueue
                 'storage' => $this->fileSystem,
             ]
         );
-        $responseData = $response->json()
-        $isInfected = $responseData['isInfected'];
+        $isInfected = $response['isInfected'];
 
         CloudLogger::write('Malware scan completed');
 
@@ -110,7 +109,7 @@ class ScanFileUpload implements ShouldQueue
         if ($isInfected) {
             $upload->update([
                 'status' => 'FAILED',
-                'error' => $responseData['viruses']
+                'error' => $response['viruses']
             ]);
             Storage::disk($this->fileSystem . '.unscanned')
                 ->delete($upload->file_location);

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -101,7 +101,8 @@ class ScanFileUpload implements ShouldQueue
                 'storage' => $this->fileSystem,
             ]
         );
-        $isInfected = $response['isInfected'];
+        $responseData = $response->json()
+        $isInfected = $responseData['isInfected'];
 
         CloudLogger::write('Malware scan completed');
 
@@ -109,7 +110,7 @@ class ScanFileUpload implements ShouldQueue
         if ($isInfected) {
             $upload->update([
                 'status' => 'FAILED',
-                'error' => $response['viruses']
+                'error' => $responseData['viruses']
             ]);
             Storage::disk($this->fileSystem . '.unscanned')
                 ->delete($upload->file_location);


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/4cce57bd-2708-4d43-91dd-cb77241cfbe8)
![image](https://github.com/user-attachments/assets/62376e3a-6019-4858-a50a-fbbbd23170b6)

## Describe your changes
We don't really know... whats going on.. it failing to upload and carrying on... some googling as to why it carries on lead me to this: https://stackoverflow.com/questions/76693040/laravel-storeas-returns-false-and-does-not-upload-the-image it seems storeAs just returns false when it dies and never actually throws.

So far, fails to upload, but carries on. So ClamAV tries to a scan a file that doesnt exist and goes kaboom. Api unsure on how to handle this response just goes kaboom in return..


## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
