### PR TITLE
GAT-4973 :: Unable to filter on Archived Tab on dataset management page

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -192,7 +192,13 @@ class DatasetController extends Controller
                 foreach ($matches as $m) {
                     $version = DatasetVersion::where('dataset_id', $m)
                     ->filterTitle($filterTitle)
-                    ->latest('version')->select('dataset_id')->first();
+                    ->latest('version')->select('dataset_id')
+                    ->when(
+                        $request->has('withTrashed') || $filterStatus === 'ARCHIVED',
+                        function ($query) {
+                            return $query->withTrashed();
+                        }
+                    )->first();
 
                     if ($version) {
                         $titleMatches[] = $version->dataset_id;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Unable to filter on Archived Tab on dataset management page

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-4973

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
