### PR TITLE
Fix upload job timeout

### DIFF
--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -48,6 +48,8 @@ class ScanFileUpload implements ShouldQueue
     private ?int $datasetId = null;
     private ?int $collectionId = null;
 
+    public $timeout = 120; // default timeout is 60
+
     /**
      * Create a new job instance.
      */


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Scan is taking around 40-50s, job is taking around 90s increased timeout to 120s default is 60s - https://laravel.com/docs/11.x/queues#timeout
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
