### PR TITLE
missing user id on tool count

### DIFF
--- a/app/Http/Controllers/Api/V1/ToolController.php
+++ b/app/Http/Controllers/Api/V1/ToolController.php
@@ -272,8 +272,11 @@ class ToolController extends Controller
     {
         try {
             $teamId = $request->query('team_id', null);
+            $userId = $request->query('user_id', null);
             $counts = Tool::when($teamId, function ($query) use ($teamId) {
                 return $query->where('team_id', '=', $teamId);
+            })->when($userId, function ($query) use ($userId) {
+                return $query->where('user_id', '=', $userId);
             })->withTrashed()
                 ->select($field)
                 ->get()


### PR DESCRIPTION
## Screenshots (if relevant)
Before:
<img width="722" alt="image" src="https://github.com/user-attachments/assets/575a4b82-26cf-422d-a43d-e6484b352f71">

* count is coming back for ALL tools rather than user tools!



## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
