### PR TITLE
adds postmigrate command to update SNSDE name to actual

### DIFF
--- a/app/Console/Commands/RenameSNSDEPostMigration.php
+++ b/app/Console/Commands/RenameSNSDEPostMigration.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DataProviderColl;
+
+use Illuminate\Console\Command;
+
+class RenameSNSDEPostMigration extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:rename-s-n-s-d-e-post-migration';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Renames the SNSDE collection to the actual name';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $dp = DataProviderColl::where('name', '=', 'SNSDE')->first();
+        if ($dp) {
+            $dp->update([
+                'name' => 'NHS Research Secure Data Environment (SDE) Network',
+            ]);
+        }
+    }
+}

--- a/app/Console/Commands/RunPostMigrations.php
+++ b/app/Console/Commands/RunPostMigrations.php
@@ -131,6 +131,10 @@ class RunPostMigrations extends Command
                     'sleep' => $sleep,
                 ],
             ],
+            [
+                'command' => 'app:rename-s-n-s-d-e-post-migration',
+                'arguments' => [],
+            ], // update SNSDE to actual name
         ];
 
         foreach ($commands as $commandInfo) {


### PR DESCRIPTION
## Screenshots (if relevant)
N/A

## Describe your changes
Adds a postmigration command to update SNSDE data provider coll to the actual name we want.

## Issue ticket link
Working outside of sprint

## Environment / Configuration changes (if applicable)
No.

## Requires migrations being run?
Appended to end of Run Post Migrations command

## If not using the pre-push hook. Confirm tests pass:

```
Tests:    335 passed (4609 assertions)
  Duration: 51.08s
  Parallel: 4 processes
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
