### PR TITLE
enable gd webp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     npm \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
+    libwebp-dev \
     libmcrypt-dev \
     libxml2-dev \
     libzip-dev \
@@ -23,8 +24,9 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     zip \
     default-mysql-client \ 
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) gd pdo pdo_mysql soap zip iconv bcmath \
+    && docker-php-ext-enable gd \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-configure pcntl --enable-pcntl \
     && docker-php-ext-install pcntl \
@@ -67,6 +69,8 @@ RUN composer install \
     && php artisan config:clear \
     && php artisan ide-helper:generate \
     && php artisan octane:install --server=swoole \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install -j$(nproc) gd \
     && composer dumpautoload
 
 # Generate Swagger

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "behat/behat": "^3.14",
         "behat/mink": "^1.11",
         "behat/mink-goutte-driver": "^2.0",
+        "intervention/image": "^3.7",
         "brianium/paratest": "^7.2",
         "fakerphp/faker": "^1.9.1",
         "friends-of-behat/mink-extension": "^2.7",


### PR DESCRIPTION
## Screenshots (if relevant)

In order for image validation to work via the UploadFile components on gateway-web, webp support is required through gd

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
