### PR TITLE
feature: no duplicate tool name check

### DIFF
--- a/app/Http/Requests/Tool/CreateTool.php
+++ b/app/Http/Requests/Tool/CreateTool.php
@@ -21,13 +21,6 @@ class CreateTool extends BaseFormRequest
             'name' => [
                 'required',
                 'string',
-                function ($attribute, $value, $fail) {
-                    $exists = Tool::withTrashed()->where('name', $value)->count();
-
-                    if ($exists) {
-                        $fail('The selected name already exist.');
-                    }
-                },
             ],
             'url' => [
                 'nullable',

--- a/app/Http/Requests/Tool/EditTool.php
+++ b/app/Http/Requests/Tool/EditTool.php
@@ -27,13 +27,6 @@ class EditTool extends BaseFormRequest
             ],
             'name' => [
                 'string',
-                function ($attribute, $value, $fail) use ($id) {
-                    $exists = Tool::withTrashed()->where('name', $value)->where('id', '<>', $id)->count();
-
-                    if ($exists) {
-                        $fail('The selected name already exist.');
-                    }
-                },
             ],
             'url' => [
                 'nullable',

--- a/app/Http/Requests/Tool/UpdateTool.php
+++ b/app/Http/Requests/Tool/UpdateTool.php
@@ -28,13 +28,6 @@ class UpdateTool extends BaseFormRequest
             'name' => [
                 'required',
                 'string',
-                function ($attribute, $value, $fail) use ($id) {
-                    $exists = Tool::withTrashed()->where('name', $value)->where('id', '<>', $id)->count();
-
-                    if ($exists) {
-                        $fail('The selected name already exist.');
-                    }
-                },
             ],
             'url' => [
                 'nullable',


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1378" alt="Screenshot 2024-09-27 at 11 06 37" src="https://github.com/user-attachments/assets/992bd3c1-6a0e-4b4e-ab28-1f146b2ce3e3">


## Describe your changes
There should be no check for duplicate tool name

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5194

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
