### PR TITLE
enforces unique emails and reduces social login to use email only

### DIFF
--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -76,7 +76,7 @@ class UserController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
         $perPage = request('perPage', Config::get('constants.per_page'));
         $users = [];
-        
+
         try {
             if (count($jwtUser)) {
                 $userIsAdmin = (bool)$jwtUser['is_admin'];
@@ -87,7 +87,7 @@ class UserController extends Controller
                         $chars = $request->query('filterNames');
                         $users = User::where('name', 'like', '%' . $chars . '%')->select('id', 'name')->paginate($perPage, ['*'], 'page');
                     } else {
-                        $users = User::select('id','name')->paginate($perPage, ['*'], 'page');
+                        $users = User::select('id', 'name')->paginate($perPage, ['*'], 'page');
                     }
                 }
             }

--- a/app/Http/Requests/Tool/CreateTool.php
+++ b/app/Http/Requests/Tool/CreateTool.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Tool;
 
-use App\Models\Tool;
 use App\Http\Requests\BaseFormRequest;
 
 class CreateTool extends BaseFormRequest

--- a/app/Http/Requests/Tool/EditTool.php
+++ b/app/Http/Requests/Tool/EditTool.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Tool;
 
-use App\Models\Tool;
 use App\Http\Requests\BaseFormRequest;
 
 class EditTool extends BaseFormRequest

--- a/app/Http/Requests/Tool/UpdateTool.php
+++ b/app/Http/Requests/Tool/UpdateTool.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Tool;
 
-use App\Models\Tool;
 use App\Http\Requests\BaseFormRequest;
 
 class UpdateTool extends BaseFormRequest

--- a/database/migrations/2024_09_24_083655_add_service_to_teams_table.php
+++ b/database/migrations/2024_09_24_083655_add_service_to_teams_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_09_24_083758_add_service_to_data_provider_colls_table.php
+++ b/database/migrations/2024_09_24_083758_add_service_to_data_provider_colls_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2024_09_27_131502_update-users-set-email-unique.php
+++ b/database/migrations/2024_09_27_131502_update-users-set-email-unique.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_email_unique');
+        });
+    }
+};

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_that_user_emails_are_unique()
+    {
+        $user = User::create([
+            'firstname' => 'Test',
+            'lastname' => 'User I',
+            'name' => 'Test User I',
+            'email' => 'test_user_i@doesntexist.com',
+        ]);
+
+        if ($user) {
+            try {
+                $otherUser = User::create([
+                    'firstname' => 'Test',
+                    'lastname' => 'User II',
+                    'name' => 'Test User II',
+                    'email' => 'test_user_i@doesntexist.com',
+                ]);
+            } catch (\Illuminate\Database\QueryException $e) {
+                $this->assertEquals($e->errorInfo[0], '23000'); // code
+                $this->assertEquals($e->errorInfo[2], 'UNIQUE constraint failed: users.email'); // message
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
While debugging an issue for Jemma and Clara I noticed there were a series of duplicated users. This implements a fix to reduce the social login controller to pull only on email address, and not email + provider, as the provider may change every login. Also adds a constraint to the db that emails must be unique.

## Issue ticket link
N/A

## Environment / Configuration changes (if applicable)
N/A

## Requires migrations being run?
Yes.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
