### PR TITLE
fix: GAT-5171 -  If organisation is blank then use what the user has inputted

### DIFF
--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -226,7 +226,7 @@ class EnquiryThreadController extends Controller
                             '[[TEAM_NAME]]' => "",
                             '[[USER_FIRST_NAME]]' => $user->firstname,
                             '[[USER_LAST_NAME]]' => $user->lastname,
-                            '[[USER_ORGANISATION]]' => $user->organisation,
+                            '[[USER_ORGANISATION]]' => isset($user->organisation) ? $user->organisation : $input['organisation'],
                             '[[CONTACT_NUMBER]]' => $input['contact_number'],
                             '[[PROJECT_TITLE]]' => $input['project_title'],
                             '[[RESEARCH_AIM]]' => $input['research_aim'],


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
