### PR TITLE
remove permissions for general individual tools usage

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -473,7 +473,6 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
-            'check.access:permissions,tools.create',
         ],
         'constraint' => [],
     ],
@@ -486,7 +485,6 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
-            'check.access:permissions,tools.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -501,7 +499,6 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
-            'check.access:permissions,tools.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -515,7 +512,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'check.access:permissions,tools.delete',
         ],
         'constraint' => [
             'id' => '[0-9]+',


### PR DESCRIPTION
## Screenshots (if relevant)
N/A

## Describe your changes
When individuals create their own tools. After creation they're unable to administer changes owing to no permissions to do so.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5195

## Environment / Configuration changes (if applicable)
No.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:
Yup.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
