### PR TITLE
fix: get only active collections and public

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -344,7 +344,7 @@ class TeamController extends Controller
                 $tool['user'] = $user;
             }
 
-            $collections = Collection::select('id', 'name', 'image_link', 'created_at', 'updated_at', 'public')->whereIn('id', $this->collections)->get()->toArray();
+            $collections = Collection::select('id', 'name', 'image_link', 'created_at', 'updated_at', 'status', 'public')->whereIn('id', $this->collections)->get()->toArray();
 
             $collections = array_map(function ($collection) {
                 if ($collection['image_link'] && !filter_var($collection['image_link'], FILTER_VALIDATE_URL)) {
@@ -354,7 +354,7 @@ class TeamController extends Controller
             }, $collections);
 
             $collections = array_filter($collections, function($collection) {
-                return $collection->public;
+                return $collection->status === Collection::STATUS_ACTIVE && $collection->public;
             });
 
             $service = array_values(array_filter(explode(",", $dp->service)));


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Returns only collections which are active from the team summary endpoint

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
