### PR TITLE
Fix user id update in collections

### DIFF
--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -469,6 +469,7 @@ class CollectionController extends Controller
                 'mongo_object_id',
                 'mongo_id',
                 'team_id',
+                'user_id',
                 'status',
             ];
             $array = $this->checkEditArray($input, $arrayKeys);
@@ -645,6 +646,7 @@ class CollectionController extends Controller
                 'mongo_object_id',
                 'mongo_id',
                 'team_id',
+                'user_id',
                 'status',
             ];
             $array = $this->checkEditArray($input, $arrayKeys);
@@ -857,6 +859,7 @@ class CollectionController extends Controller
                     'mongo_object_id',
                     'mongo_id',
                     'team_id',
+                    'user_id',
                     'status',
                 ];
                 $array = $this->checkEditArray($input, $arrayKeys);

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -839,7 +839,7 @@ class SearchController extends Controller
 
             $durArray = $response['hits']['hits'];
             $totalResults = $response['hits']['total']['value'];
-            
+
             $matchedIds = [];
             foreach (array_values($durArray) as $i => $d) {
                 $matchedIds[] = $d['_id'];
@@ -1577,7 +1577,7 @@ class SearchController extends Controller
         if (empty($durMatch['datasetVersions']) || !is_iterable($durMatch['datasetVersions'])) {
             return [];
         }
-        
+
         $datasetVersionIds = collect($durMatch['datasetVersions'])->select('dataset_version_id')->toArray();
 
         $datasets = DatasetVersion::whereIn('id', $datasetVersionIds)
@@ -1590,7 +1590,7 @@ class SearchController extends Controller
                 'title' => $dataset['metadata']['metadata']['summary']['shortTitle'],
                 'id' => $dataset['id'],
             ];
-          
+
         }
 
         usort($datasetTitles, function ($a, $b) {
@@ -1599,7 +1599,7 @@ class SearchController extends Controller
 
         return $datasetTitles;
     }
-    
+
 
     /**
      * Sorts results returned by the search service according to sort field and direction

--- a/tests/Feature/CollectionTest.php
+++ b/tests/Feature/CollectionTest.php
@@ -215,7 +215,8 @@ class CollectionTest extends TestCase
             "keywords" => $this->generateKeywords(),
             "dur" => $this->generateDurs(),
             "publications" => $this->generatePublications(),
-            "status" => "ACTIVE"
+            "status" => "ACTIVE",
+            "user_id" => 1
         ];
 
         $response = $this->json(
@@ -345,7 +346,8 @@ class CollectionTest extends TestCase
             "keywords" => $this->generateKeywords(),
             "dur" => $this->generateDurs(),
             "publications" => $this->generatePublications(),
-            "status" => "ACTIVE"
+            "status" => "ACTIVE",
+            "user_id" => 1,
         ];
         $responseUpdate = $this->json(
             'PUT',
@@ -360,6 +362,7 @@ class CollectionTest extends TestCase
         $this->assertTrue((bool) $mockDataUpdate['enabled'] === (bool) $responseUpdate['data']['enabled']);
         $this->assertTrue((bool) $mockDataUpdate['public'] === (bool) $responseUpdate['data']['public']);
         $this->assertTrue((int) $mockDataUpdate['counter'] === (int) $responseUpdate['data']['counter']);
+        $this->assertTrue((int) $mockDataUpdate['user_id'] === (int) $responseUpdate['data']['user_id']);
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Fixing a bug: the collection endpoints didn't allow `user_id` to be set.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
