### PR TITLE
speeds up dataset showing

### DIFF
--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use DB;
+
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Builder;
@@ -88,6 +90,35 @@ class Dataset extends Model
                 return $query->select($fields);
             }
         )->findOrFail($version);
+    }
+
+    public function latestVersionID(int $datasetId): null|int
+    {
+        $result = DB::select(
+            '
+                SELECT 
+                    dv.id,
+                    dv.version
+                FROM dataset_versions dv
+                WHERE
+                    dv.version = (
+                        SELECT 
+                            MAX(version)
+                        FROM dataset_versions dv2
+                        WHERE dv2.dataset_id = dv.dataset_id
+                    )
+                AND dv.dataset_id = :dataset_id
+            ',
+            [
+                'dataset_id' => $datasetId,
+            ]
+        );
+
+        if (count($result) > 0) {
+            return $result[0]->id;
+        }
+
+        return null;
     }
 
     public function latestMetadata(): HasOne

--- a/app/Models/Traits/ModelHelpers.php
+++ b/app/Models/Traits/ModelHelpers.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models\Traits;
+
+use DB;
+
+trait ModelHelpers
+{
+    public function countDursForDatasetVersion(int $datasetVersionId): null|int
+    {
+        $result = DB::select(
+            '
+                SELECT
+                    COUNT(id) AS count
+                FROM dur_has_dataset_version
+                WHERE
+                    dataset_version_id = :dataset_version_id
+                AND
+                    deleted_at = null
+            ',
+            [
+                'dataset_version_id' => $datasetVersionId,
+            ]
+        );
+
+        if (count($result) > 0) {
+            return $result[0]->count;
+        }
+
+        return null;
+    }
+
+    public function countPublicationsForDatasetVersion(int $datasetVersionId): null|int
+    {
+        $result = DB::select(
+            '
+                SELECT
+                    COUNT(id) AS count
+                FROM publication_has_dataset_version
+                WHERE
+                    dataset_version_id = :dataset_version_id
+                AND
+                    deleted_at = null
+            ',
+            [
+                'dataset_version_id' => $datasetVersionId,
+            ]
+        );
+
+        if (count($result) > 0) {
+            return $result[0]->count;
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/CollectionTest.php
+++ b/tests/Feature/CollectionTest.php
@@ -764,7 +764,7 @@ class CollectionTest extends TestCase
         ];
 
         $countBefore = Collection::count();
-        
+
         // create new collection
         $mockDataIn = [
             "name" => "covid",


### PR DESCRIPTION
## Screenshots (if relevant)
Existing under preprod, taking ~600ms per call
![image](https://github.com/user-attachments/assets/3083a9d2-026d-49fc-9dc1-183d227412e7)

New under local, taking ~60ms per call
![image](https://github.com/user-attachments/assets/d5392b99-3f26-44f0-960a-c8a2d04d2244)

## Describe your changes
There were excessive calls to metadata, where people had called various relationships off of DatasetVersions, unknowing that it will non-performantly chain relation calls, and invariably call metadata excessively. I've made a few tweaks to mostly resort to just the ID of the latest metadata version, and to pre-process on that, and only call dataset version when necessary.

I've also replaced some rather slow relationship calls on lookup tables, with raw sql, as we were only after the counts in certain places.

## Issue ticket link
N/A.

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
