### PR TITLE
Give traser default schema versions in metadata upload

### DIFF
--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -264,11 +264,15 @@ class ScanFileUpload implements ShouldQueue
                 'user_id' => $this->userId,
                 'team_id' => $this->teamId,
             ];
+
+            $defineInputSchema = $this->inputSchema ? $this->inputSchema : Config::get('form_hydration.schema.model');
+            $defineInputVersion = $this->inputVersion ? $this->inputVersion : Config::get('form_hydration.schema.latest_version');
+
             $metadataResult = $this->metadataOnboard(
                 $input,
                 $team,
-                $this->inputSchema,
-                $this->inputVersion,
+                $defineInputSchema,
+                $defineInputVersion,
                 $this->elasticIndexing
             );
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Partial fix for issues with metadata upload. Previously if the uploaded metadata wasn't near enough to HDRv3 TRASER couldn't identify which translation map to use. 

This PR adds default values for the schema of the uploaded metadata (defaults to the latest HDR version) so that TRASER can apply the relevant mapping file and the draft dataset can then be loaded into the onboarding form.

The metadata template file also needs updating. This will be addressed in a separate PR.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5466

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
