### PR TITLE
fix: change abstract to title

### DIFF
--- a/app/Http/Traits/DatasetFetch.php
+++ b/app/Http/Traits/DatasetFetch.php
@@ -33,7 +33,7 @@ trait DatasetFetch
             $datasetMetadata = $dataset->latestMetadata()->whereIn('id', $versionIds)->pluck('metadata')->toArray(); // This can be modified to return metadata
 
             if (count($datasetMetadata) > 0) {
-                $datasetTitle = $datasetMetadata[0]['metadata']['summary']['abstract'] ?? null;
+                $datasetTitle = $datasetMetadata[0]['metadata']['summary']['title'] ?? null;
                 $dataset->setAttribute('name', $datasetTitle); // This can be modified to return metadata
             }
             // Add associated dataset versions to the dataset object


### PR DESCRIPTION
<img width="1072" alt="Screenshot 2024-10-28 at 08 22 44" src="https://github.com/user-attachments/assets/f342d0bf-7d3c-4e3e-9629-931b2cdce18d">

Changes abstract to title so that the correct metadata pulls through the front-end. Screenshot confirms that titles appear instead of abstracts

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
