### PR TITLE
Dataset Admin control for TED

### DIFF
--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -87,6 +87,11 @@ class AdminDatasetController extends Controller
     public function triggerTermExtraction(Request $request): JsonResponse
     {
         try {
+
+            if(!Config::get('ted.enabled')) {
+                throw new Exception("TED not enabled and you're trying to trigger TED");
+            }
+
             $partial = $request->input('partial', false);
             $minId = $request->input('minId', 1);
             $maxId = $request->input('maxId', Dataset::max('id'));

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use Config;
 use Exception;
 use Auditor;
 

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -122,7 +122,7 @@ class AdminDatasetController extends Controller
             return response()->json([
                 'message' => "triggered ted",
                 "dataset_ids" => $datasetIds,
-                "ted_data" => $tedData
+                "used_partial" => $partial
             ], 200);
         } catch (Exception $e) {
             Auditor::log([

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -58,7 +58,7 @@ class AdminDatasetController extends Controller
      *         @OA\JsonContent(
      *             type="object",
      *             @OA\Property(property="message", type="string", example="triggered ted"),
-     *             @OA\Property(property="datasetIds", type="array", @OA\Items(type="integer"))
+     *             @OA\Property(property="dataset_ids", type="array", @OA\Items(type="integer"))
      *         )
      *     ),
      *     @OA\Response(

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -17,7 +17,7 @@ class AdminDatasetController extends Controller
 {
     /**
      * @OA\Post(
-     *     path="/datasets/admin_ctrl/trigger/term_extraction",
+     *     path="/api/v1/datasets/admin_ctrl/trigger/term_extraction",
      *     summary="Trigger Term Extraction for Datasets",
      *     description="Triggers the term extraction job for datasets within a specified range and controls whether data is partially indexed in Elasticsearch.",
      *     tags={"Datasets"},

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -87,7 +87,7 @@ class AdminDatasetController extends Controller
     public function triggerTermExtraction(Request $request): JsonResponse
     {
         try {
-            $partial = $request->input('partial', true);
+            $partial = $request->input('partial', false);
             $minId = $request->input('minId', 1);
             $maxId = $request->input('maxId', Dataset::max('id'));
             $elasticIndexing = $request->input('indexElastic', true);

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -15,8 +15,75 @@ use App\Models\Dataset;
 
 class AdminDatasetController extends Controller
 {
-    //protected boolean $allTerms = false;
-
+    /**
+     * @OA\Post(
+     *     path="/datasets/admin_ctrl/trigger/term_extraction",
+     *     summary="Trigger Term Extraction for Datasets",
+     *     description="Triggers the term extraction job for datasets within a specified range and controls whether data is partially indexed in Elasticsearch.",
+     *     tags={"Datasets"},
+     *     security={{"jwt": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="partial",
+     *                 type="boolean",
+     *                 default=true,
+     *                 description="Flag to determine if term extraction should be partial (true) or full (false)"
+     *             ),
+     *             @OA\Property(
+     *                 property="minId",
+     *                 type="integer",
+     *                 default=1,
+     *                 description="Minimum dataset ID to include in the term extraction"
+     *             ),
+     *             @OA\Property(
+     *                 property="maxId",
+     *                 type="integer",
+     *                 description="Maximum dataset ID to include in the term extraction. Defaults to the maximum dataset ID available."
+     *             ),
+     *             @OA\Property(
+     *                 property="indexElastic",
+     *                 type="boolean",
+     *                 default=true,
+     *                 description="Flag to determine if data should be indexed in Elasticsearch"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Term extraction triggered successfully",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="message", type="string", example="triggered ted"),
+     *             @OA\Property(property="datasetIds", type="array", @OA\Items(type="integer"))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="error", type="string", example="An error message detailing the issue")
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         name="Authorization",
+     *         in="header",
+     *         required=true,
+     *         @OA\Schema(type="string"),
+     *         description="JWT token for authorization in the format 'Bearer {token}'"
+     *     ),
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="header",
+     *         required=true,
+     *         @OA\Schema(type="string"),
+     *         description="Role required to access this endpoint, e.g., 'hdruk.superadmin'"
+     *     )
+     * )
+     */
     public function triggerTermExtraction(Request $request): JsonResponse
     {
         try {

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -2,18 +2,61 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use Exception;
+use Auditor;
+
+use App\Http\Controllers\Controller;
+
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use App\Jobs\TermExtraction;
 
 use App\Models\Dataset;
 
 class AdminDatasetController extends Controller
 {
+    //protected boolean $allTerms = false;
+
     public function triggerTermExtraction(Request $request): JsonResponse
     {
-        $input = $request->all();
+        try {
+            $partial = $request->input('partial', true);
+            $minId = $request->input('minId', 1);
+            $maxId = $request->input('maxId', Dataset::max('id'));
 
-        $datsets = Dataset::select('id')->pluck('id');
 
-        return response()->json(['datasets' => $datasets]);
+            $datasetIds = Dataset::whereBetween("id", [$minId, $maxId])
+                            ->select('id')
+                            ->pluck('id');
+
+            foreach ($datasetIds as $id) {
+                $dataset = Dataset::where('id', $id)->first();
+                $latestMetadata = $dataset->lastMetadata();
+                $datasetVersionId = $dataset->latestVersionId($id);
+                $versionNumber = $dataset->lastMetadataVersionNumber()->version;
+                $elasticIndexing = true;
+
+                $tedData = $partial ? $latestMetadata['metadata']['summary'] : $latestMetadata['metadata'];
+
+                TermExtraction::dispatch(
+                    $id,
+                    $datasetVersionId,
+                    $versionNumber,
+                    base64_encode(gzcompress(gzencode(json_encode($tedData)))),
+                    $elasticIndexing,
+                    $partial,
+                );
+            }
+            return response()->json(['message' => "triggered ted","datasetIds" => $datasetIds], 200);
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+
     }
 }

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Illuminate\Http\JsonResponse;
+
+use App\Models\Dataset;
+
+class AdminDatasetController extends Controller
+{
+    public function triggerTermExtraction(Request $request): JsonResponse
+    {
+        $input = $request->all();
+
+        $datsets = Dataset::select('id')->pluck('id');
+
+        return response()->json(['datasets' => $datasets]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -24,7 +24,6 @@ class AdminDatasetController extends Controller
             $minId = $request->input('minId', 1);
             $maxId = $request->input('maxId', Dataset::max('id'));
 
-
             $datasetIds = Dataset::whereBetween("id", [$minId, $maxId])
                             ->select('id')
                             ->pluck('id');

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -23,6 +23,7 @@ class AdminDatasetController extends Controller
             $partial = $request->input('partial', true);
             $minId = $request->input('minId', 1);
             $maxId = $request->input('maxId', Dataset::max('id'));
+            $elasticIndexing = $request->input('indexElastic', true);
 
             $datasetIds = Dataset::whereBetween("id", [$minId, $maxId])
                             ->select('id')
@@ -33,7 +34,6 @@ class AdminDatasetController extends Controller
                 $latestMetadata = $dataset->lastMetadata();
                 $datasetVersionId = $dataset->latestVersionId($id);
                 $versionNumber = $dataset->lastMetadataVersionNumber()->version;
-                $elasticIndexing = true;
 
                 $tedData = $partial ? $latestMetadata['metadata']['summary'] : $latestMetadata['metadata'];
 

--- a/app/Http/Controllers/Api/V1/AdminDatasetController.php
+++ b/app/Http/Controllers/Api/V1/AdminDatasetController.php
@@ -93,7 +93,7 @@ class AdminDatasetController extends Controller
                 throw new Exception("TED not enabled and you're trying to trigger TED");
             }
 
-            $partial = $request->input('partial', false);
+            $partial = $request->input('partial', Config::get('ted.use_partial'));
             $minId = $request->input('minId', 1);
             $maxId = $request->input('maxId', Dataset::max('id'));
             $elasticIndexing = $request->input('indexElastic', true);
@@ -119,7 +119,11 @@ class AdminDatasetController extends Controller
                     $partial,
                 );
             }
-            return response()->json(['message' => "triggered ted","datasetIds" => $datasetIds], 200);
+            return response()->json([
+                'message' => "triggered ted",
+                "dataset_ids" => $datasetIds,
+                "ted_data" => $tedData
+            ], 200);
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',

--- a/config/routes.php
+++ b/config/routes.php
@@ -2100,6 +2100,18 @@ return [
         'middleware' => [],
         'constraint' => [],
     ],
+    [
+        'name' => 'datasets',
+        'method' => 'post',
+        'path' => '/datasets/admin_ctrl/trigger/term_extraction',
+        'methodController' => 'AdminDatasetController@triggerTermExtraction',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
 
 
     // datasets integrations

--- a/tests/Feature/AdminDatasetControllerTest.php
+++ b/tests/Feature/AdminDatasetControllerTest.php
@@ -47,16 +47,18 @@ class AdminDatasetControllerTest extends TestCase
             $this->header
         );
 
-        $content = $response->decodeResponseJson();
-        $response->assertStatus(200);
+        if(config("ted.enabled")) {
+            $response->assertStatus(200);
 
-        // Assert: Check that the job was dispatched and response is correct
-        Queue::assertPushed(TermExtraction::class);
-        $response->assertStatus(200)
-                 ->assertJson([
-                     'message' => 'triggered ted',
-                     'dataset_ids' => $allDatasetIds
-                 ]);
+            // Assert: Check that the job was dispatched and response is correct
+            Queue::assertPushed(TermExtraction::class);
+            $response->assertJson([
+                        'message' => 'triggered ted',
+                        'dataset_ids' => $allDatasetIds
+                    ]);
+        } else {
+            $response->assertStatus(500);
+        }
     }
 
     public function testTriggerTermExtractionWithCustomIds()
@@ -71,14 +73,17 @@ class AdminDatasetControllerTest extends TestCase
             ['minId' => 3, 'maxId' => 5],
             $this->header
         );
-
-        // Assert: Check that the job was dispatched and response is correct
-        Queue::assertPushed(TermExtraction::class);
-        $response->assertStatus(200)
-                 ->assertJson([
-                     'message' => 'triggered ted',
-                     'dataset_ids' => [3, 4, 5],
-                 ]);
+        if(config("ted.enabled")) {
+            // Assert: Check that the job was dispatched and response is correct
+            Queue::assertPushed(TermExtraction::class);
+            $response->assertStatus(200)
+                     ->assertJson([
+                         'message' => 'triggered ted',
+                         'dataset_ids' => [3, 4, 5],
+                     ]);
+        } else {
+            $response->assertStatus(500);
+        }
     }
 
     public function testTriggerTermExtractionHandlesUnauthorised()
@@ -100,7 +105,11 @@ class AdminDatasetControllerTest extends TestCase
 
         //token in header for super-admin
         $response = $this->json('POST', self::TEST_URL_DATASET . '/trigger/term_extraction', [], $this->header);
-        $response->assertStatus(200);
+        if(config("ted.enabled")) {
+            $response->assertStatus(200);
+        } else {
+            $response->assertStatus(500);
+        }
 
     }
 

--- a/tests/Feature/AdminDatasetControllerTest.php
+++ b/tests/Feature/AdminDatasetControllerTest.php
@@ -31,7 +31,75 @@ class AdminDatasetControllerTest extends TestCase
             DatasetVersionSeeder::class,
         ]);
     }
-
+    /**
+     * @OA\Post(
+     *     path="/datasets/admin_ctrl/trigger/term_extraction",
+     *     summary="Trigger Term Extraction for Datasets",
+     *     description="Triggers the term extraction job for datasets within a specified range and controls whether data is partially indexed in Elasticsearch.",
+     *     tags={"Datasets"},
+     *     security={{"jwt": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(
+     *                 property="partial",
+     *                 type="boolean",
+     *                 default=true,
+     *                 description="Flag to determine if term extraction should be partial (true) or full (false)"
+     *             ),
+     *             @OA\Property(
+     *                 property="minId",
+     *                 type="integer",
+     *                 default=1,
+     *                 description="Minimum dataset ID to include in the term extraction"
+     *             ),
+     *             @OA\Property(
+     *                 property="maxId",
+     *                 type="integer",
+     *                 description="Maximum dataset ID to include in the term extraction. Defaults to the maximum dataset ID available."
+     *             ),
+     *             @OA\Property(
+     *                 property="indexElastic",
+     *                 type="boolean",
+     *                 default=true,
+     *                 description="Flag to determine if data should be indexed in Elasticsearch"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Term extraction triggered successfully",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="message", type="string", example="triggered ted"),
+     *             @OA\Property(property="datasetIds", type="array", @OA\Items(type="integer"))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Internal server error",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="error", type="string", example="An error message detailing the issue")
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         name="Authorization",
+     *         in="header",
+     *         required=true,
+     *         @OA\Schema(type="string"),
+     *         description="JWT token for authorization in the format 'Bearer {token}'"
+     *     ),
+     *     @OA\Parameter(
+     *         name="role",
+     *         in="header",
+     *         required=true,
+     *         @OA\Schema(type="string"),
+     *         description="Role required to access this endpoint, e.g., 'hdruk.superadmin'"
+     *     )
+     * )
+     */
     public function testTriggerTermExtractionWithDefaults()
     {
         // Arrange: Ensure the TermExtraction job is queued

--- a/tests/Feature/AdminDatasetControllerTest.php
+++ b/tests/Feature/AdminDatasetControllerTest.php
@@ -55,7 +55,7 @@ class AdminDatasetControllerTest extends TestCase
         $response->assertStatus(200)
                  ->assertJson([
                      'message' => 'triggered ted',
-                     'datasetIds' => $allDatasetIds
+                     'dataset_ids' => $allDatasetIds
                  ]);
     }
 
@@ -77,7 +77,7 @@ class AdminDatasetControllerTest extends TestCase
         $response->assertStatus(200)
                  ->assertJson([
                      'message' => 'triggered ted',
-                     'datasetIds' => [3, 4, 5],
+                     'dataset_ids' => [3, 4, 5],
                  ]);
     }
 

--- a/tests/Feature/AdminDatasetControllerTest.php
+++ b/tests/Feature/AdminDatasetControllerTest.php
@@ -31,75 +31,7 @@ class AdminDatasetControllerTest extends TestCase
             DatasetVersionSeeder::class,
         ]);
     }
-    /**
-     * @OA\Post(
-     *     path="/datasets/admin_ctrl/trigger/term_extraction",
-     *     summary="Trigger Term Extraction for Datasets",
-     *     description="Triggers the term extraction job for datasets within a specified range and controls whether data is partially indexed in Elasticsearch.",
-     *     tags={"Datasets"},
-     *     security={{"jwt": {}}},
-     *     @OA\RequestBody(
-     *         required=true,
-     *         @OA\JsonContent(
-     *             type="object",
-     *             @OA\Property(
-     *                 property="partial",
-     *                 type="boolean",
-     *                 default=true,
-     *                 description="Flag to determine if term extraction should be partial (true) or full (false)"
-     *             ),
-     *             @OA\Property(
-     *                 property="minId",
-     *                 type="integer",
-     *                 default=1,
-     *                 description="Minimum dataset ID to include in the term extraction"
-     *             ),
-     *             @OA\Property(
-     *                 property="maxId",
-     *                 type="integer",
-     *                 description="Maximum dataset ID to include in the term extraction. Defaults to the maximum dataset ID available."
-     *             ),
-     *             @OA\Property(
-     *                 property="indexElastic",
-     *                 type="boolean",
-     *                 default=true,
-     *                 description="Flag to determine if data should be indexed in Elasticsearch"
-     *             )
-     *         )
-     *     ),
-     *     @OA\Response(
-     *         response=200,
-     *         description="Term extraction triggered successfully",
-     *         @OA\JsonContent(
-     *             type="object",
-     *             @OA\Property(property="message", type="string", example="triggered ted"),
-     *             @OA\Property(property="datasetIds", type="array", @OA\Items(type="integer"))
-     *         )
-     *     ),
-     *     @OA\Response(
-     *         response=500,
-     *         description="Internal server error",
-     *         @OA\JsonContent(
-     *             type="object",
-     *             @OA\Property(property="error", type="string", example="An error message detailing the issue")
-     *         )
-     *     ),
-     *     @OA\Parameter(
-     *         name="Authorization",
-     *         in="header",
-     *         required=true,
-     *         @OA\Schema(type="string"),
-     *         description="JWT token for authorization in the format 'Bearer {token}'"
-     *     ),
-     *     @OA\Parameter(
-     *         name="role",
-     *         in="header",
-     *         required=true,
-     *         @OA\Schema(type="string"),
-     *         description="Role required to access this endpoint, e.g., 'hdruk.superadmin'"
-     *     )
-     * )
-     */
+
     public function testTriggerTermExtractionWithDefaults()
     {
         // Arrange: Ensure the TermExtraction job is queued

--- a/tests/Feature/AdminDatasetControllerTest.php
+++ b/tests/Feature/AdminDatasetControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Jobs\TermExtraction;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+use Database\Seeders\DatasetSeeder;
+use Database\Seeders\MinimalUserSeeder;
+
+class AdminDatasetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+    public const TEST_URL_DATASET = '/api/v1/datasets/admin_ctrl';
+
+    protected function setUp(): void
+    {
+        $this->commonSetUp();
+        $this->seed([
+            MinimalUserSeeder::class,
+            DatasetSeeder::class,
+        ]);
+    }
+
+    public function testTriggerTermExtractionWithDefaults()
+    {
+        // Arrange: Ensure the TermExtraction job is queued
+        Queue::fake();
+
+        // Act: Call the endpoint without parameters to use defaults
+        $response = $this->json('POST', self::TEST_URL_DATASET . '/trigger/term_extraction', [], $this->header);
+        //dd($response);
+        // Assert: Check that the job was dispatched and response is correct
+        Queue::assertPushed(TermExtraction::class);
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'message' => 'triggered ted',
+                     'datasetIds' => [1, 10],
+                 ]);
+    }
+
+    public function testTriggerTermExtractionWithCustomIds()
+    {
+        // Arrange: Ensure the TermExtraction job is queued
+        Queue::fake();
+
+        // Act: Call the endpoint with custom minId and maxId
+        $response = $this->json('POST', '/api/v1/admin-dataset/trigger-term-extraction', [
+            'minId' => 1,
+            'maxId' => 10,
+        ]);
+
+        // Assert: Check that the job was dispatched and response is correct
+        Queue::assertPushed(TermExtraction::class);
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'message' => 'triggered ted',
+                     'datasetIds' => [1, 10],
+                 ]);
+    }
+
+    public function testTriggerTermExtractionWithPartialFalse()
+    {
+        // Arrange: Ensure the TermExtraction job is queued
+        Queue::fake();
+
+        // Act: Call the endpoint with partial set to false
+        $response = $this->json('POST', '/api/v1/admin-dataset/trigger-term-extraction', [
+            'partial' => false,
+        ]);
+
+        // Assert: Check that the job was dispatched with partial = false
+        Queue::assertPushed(TermExtraction::class, function ($job) {
+            return !$job->partial;
+        });
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'message' => 'triggered ted',
+                 ]);
+    }
+
+    public function testTriggerTermExtractionHandlesException()
+    {
+        // Simulate an exception during the process by making the max ID unreachable
+        Dataset::shouldReceive('max')->andThrow(new \Exception('Simulated exception'));
+
+        // Act: Call the endpoint
+        $response = $this->json('POST', '/api/v1/admin-dataset/trigger-term-extraction');
+
+        // Assert: Verify response is an error
+        $response->assertStatus(500);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

* New route for superadmin to control the firing of TED

```
curl --location 'http://localhost:8000/api/v1/datasets/admin_ctrl/trigger/term_extraction' \
--header 'Authorization: Bearer <token>
--header 'Content-Type: application/json' \
--data '{
    "partial": true,
    "minId":1,
    "maxId":5
}'
```

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
