### PR TITLE
Link dur to datasets from dur upload

### DIFF
--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -267,12 +267,15 @@ class ScanFileUpload implements ShouldQueue
             if (str_contains($d, env('GATEWAY_URL'))) {
                 $exploded = explode('/', $d);
                 $datasetId = (int) end($exploded);
-                $dvID = Dataset::findOrFail($datasetId)->latestVersionID($datasetId);
-                DurHasDatasetVersion::create([
-                    'dur_id' => $durId,
-                    'dataset_version_id' => $dvID
-                ]);
-                continue;
+                $dataset = Dataset::where('id', $datasetId)->first();
+                if ($dataset) {
+                    $dvID = $dataset->latestVersionID($datasetId);
+                    DurHasDatasetVersion::create([
+                        'dur_id' => $durId,
+                        'dataset_version_id' => $dvID
+                    ]);
+                    continue;
+                }
             }
 
             // Try to string match on dataset titles

--- a/tests/Feature/UploadTest.php
+++ b/tests/Feature/UploadTest.php
@@ -238,8 +238,6 @@ class UploadTest extends TestCase
             ]
         );
 
-        var_dump($response);
-
         $response->assertJsonStructure([
             'data' => [
                 'id',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

The `dur-from-upload` routine attempts to create `DurHasDatasetVersion` linkages from the datasets listed in the upload file. In order it:
- checks for gateway urls
- tries string matching on dataset titles
- if no matches found, it assumes the dataset is a non gateway dataset

Caveat: on an sqlite connection the string matching on dataset titles is skipped because sqlite does not have a `json_unquote` function. This means this functionality is not covered by the tests.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5623

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
