### PR TITLE
bug on assigning collections

### DIFF
--- a/app/Console/Commands/AssignTeamToCollection.php
+++ b/app/Console/Commands/AssignTeamToCollection.php
@@ -47,7 +47,7 @@ class AssignTeamToCollection extends Command
             $teamMongoId = $item['team_id'];
             $teamName = $item['team_name'];
             $team = Team::where("mongo_object_id", $teamMongoId)->select("id")->first();
-            if(!$team && !is_null($teamName)) {
+            if(!$team && !is_null($teamName) && trim($teamName) !== '') {
                 $team = Team::where("name", "like", "%".$teamName."%")->select("id")->first();
             }
             if(!$team) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

* assigning was calling back to `team_id=1` because of blank team names

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
