### PR TITLE
fix/federation test to return proper json format

### DIFF
--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -851,7 +851,10 @@ class FederationController extends Controller
 
         try {
             $response = Http::post(env('GMI_SERVICE_URL') . '/test', $input);
-            return response()->json($response->json());
+            return response()->json([
+                'data' => $response->json(),
+            ], 200);
+
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',


### PR DESCRIPTION
## Screenshots (if relevant)

This changes the format of the data returned for the run federation test endpoint to proper json, so that it is parsed properly on the frontend

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
