### PR TITLE
Handle the case where the pid doesn't correspond to a team.

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -290,7 +290,12 @@ class TeamController extends Controller
     */
     public function getIdFromPid(Request $request, string $pid): JsonResponse
     {
-        $id = Team::where('pid', $pid)->select('id')->first()->id;
+        try {
+            $id = Team::where('pid', $pid)->select('id')->firstOrFail()->id;
+        } catch (Exception $e) {
+            $id = null;
+        }
+
         return response()->json([
             'message' => 'success',
             'data' => $id,

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -258,7 +258,7 @@ class TeamController extends Controller
     *      path="/api/v1/teams/{teamPid}/id",
     *      tags={"Teams"},
     *      summary="TeamController@getIdFromPid",
-    *      description="Get the teamId from a Pid",
+    *      description="Get the teamId from a Pid. Failure to find such a team results in a successful null response.",
     *      security={{"bearerAuth":{}}},
     *      @OA\Parameter(
     *         name="teamPid",
@@ -278,13 +278,6 @@ class TeamController extends Controller
     *              @OA\Property(property="message", type="string"),
     *              @OA\Property(property="data", type="number")
     *          ),
-    *      ),
-    *      @OA\Response(
-    *          response=404,
-    *          description="Not found response",
-    *          @OA\JsonContent(
-    *              @OA\Property(property="message", type="string", example="not found"),
-    *          )
     *      )
     * )
     */


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Some datasets have metadata where `"summary.dataCustodian.identifier"` is the pid of a team that doesn't exist. Before now, this result in an FE crash. This fix returns `null` if the pid is not found. The FE handles this gracefully.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
