### PR TITLE
Change/gat 4915: Multiple downloads on dataset landing page

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1313,12 +1313,77 @@ class DatasetController extends Controller
                     // var_dump($result['metadata']['metadata']);
                     // Add CSV headers
                     fputcsv($handle, $headerRow);
+                    $result = $result['metadata']['metadata'];
                     $rows = [
-                        ['Dataset', 'Name', $result['metadata']['metadata']['summary']['title']],
-                        ['Dataset', 'Gateway URL', $result['metadata']['metadata']['required']['revisions'][0]['url']], //?
-                        ['Dataset', 'Dataset Type', $result['metadata']['metadata']['summary']['datasetType']], //sort out delimiter
-                        ['Dataset', 'Dataset Sub-type', $result['metadata']['metadata']['summary']['datasetSubType']], //sort out delimiter
-                        ['Dataset', 'Collection Sources', $result['metadata']['metadata']['provenance']['origin']['collectionSituation']], //sort out delimiter
+                        ['Dataset', 'Name', $this->getValueFromPath($result, 'summary/title')],
+                        ['Dataset', 'Gateway URL', $this->getValueFromPath($result, 'required/revisions/0/url')], //?
+                        ['Dataset', 'Dataset Type', $this->getValueFromPath($result, 'summary/datasetType')], //sort out delimiter
+                        ['Dataset', 'Dataset Sub-type', $this->getValueFromPath($result, 'summary/datasetSubType')], //sort out delimiter
+                        ['Dataset', 'Collection Sources', $this->getValueFromPath($result, 'provenance/origin/collectionSituation')], //sort out delimiter
+
+                        ['Summary Demographics', 'Population Size', $this->getValueFromPath($result, 'summary/populationSize') === "-1" ? "" : $this->getValueFromPath($result, 'summary/populationSize')], // formatTextDelimiter
+                        ['Summary Demographics', 'Years', $this->getValueFromPath($result, 'provenance/temporal/startDate')], //formatYearStat
+                        ['Summary Demographics', 'Associate BioSamples', $this->getValueFromPath($result, 'coverage/materialType')],
+                        ['Summary Demographics', 'Geographic coverage', $this->getValueFromPath($result, 'coverage/spatial')], //splitStringList
+                        ['Summary Demographics', 'Lead time', $this->getValueFromPath($result, 'accessibility/access/deliveryLeadTime')], //parseLeadTime
+
+                        ['Summary', 'Abstract', $this->getValueFromPath($result, 'summary/abstract')],
+                        ['Summary', 'DOI for dataset', $this->getValueFromPath($result, 'summary/doiName')],
+
+                        ['Documentation', 'Description', $this->getValueFromPath($result, 'documentation/description')],
+                        ['Documentation', 'Dataset type', $this->getValueFromPath($result, 'provenance/origin/datasetType')],
+                        ['Documentation', 'Dataset sub-type', $this->getValueFromPath($result, 'provenance/origin/datasetSubType')],
+                        ['Documentation', 'Dataset population size', $this->getValueFromPath($result, 'summary/populationSize')],
+                        ['Documentation', 'Associated media', $this->getValueFromPath($result, 'documentation/associatedMedia')],
+                        ['Documentation', 'Synthetic data web link', $this->getValueFromPath($result, 'structuralMetadata/syntheticDataWebLink')],
+
+                        ['Keywords', 'Keywords', $this->getValueFromPath($result, 'summary/keywords')],
+
+                        ['Provenance', 'Purpose of dataset collection', $this->getValueFromPath($result, 'provenance/origin/purpose')],
+                        ['Provenance', 'Source of dataset extraction', $this->getValueFromPath($result, 'provenance/origin/source')],
+                        ['Provenance', 'Collection source setting', $this->getValueFromPath($result, 'provenance/origin/collectionSource')],
+                        ['Provenance', 'Patient pathway description', $this->getValueFromPath($result, 'coverage/pathway')],
+                        ['Provenance', 'Image contrast', $this->getValueFromPath($result, 'provenance/origin/imageContrast')],
+                        ['Provenance', 'Biological sample availability', $this->getValueFromPath($result, 'coverage/materialType')],
+
+                        ['Details', 'Publishing frequency', $this->getValueFromPath($result, 'provenance/temporal/publishingFrequency')],
+                        ['Details', 'Version', $this->getValueFromPath($result, 'version')],
+                        ['Details', 'Modified', $this->getValueFromPath($result, 'modified')],
+                        ['Details', 'Distribution release date', $this->getValueFromPath($result, 'provenance/termporal/distributionReleaseDate')],
+                        ['Details', 'Citation Requirements', implode(',', $this->getValueFromPath($result, 'accessibility/usage/resourceCreator'))],
+
+                        ['Coverage', 'Start date', $this->getValueFromPath($result, 'provenance/temporal/startDate')],
+                        ['Coverage', 'End date', $this->getValueFromPath($result, 'provenance/temporal/endDate')],
+                        ['Coverage', 'Time lag', $this->getValueFromPath($result, 'provenance/temporal/timeLag')],
+                        ['Coverage', 'Geographic coverage', $this->getValueFromPath($result, 'coverage/spatial')],
+                        ['Coverage', 'Minimum age range', $this->getValueFromPath($result, 'coverage/typicalAgeRangeMin')],
+                        ['Coverage', 'Maximum age range', $this->getValueFromPath($result, 'coverage/typicalAgeRangeMax')],
+                        ['Coverage', 'Follow-up', $this->getValueFromPath($result, 'coverage/followUp')],
+                        ['Coverage', 'Dataset completeness', $this->getValueFromPath($result, 'coverage/datasetCompleteness')],
+
+                        ['Omics', 'Assay', $this->getValueFromPath($result, 'omics/assay')],
+                        ['Omics', 'Platform', $this->getValueFromPath($result, 'omics/platform')],
+
+                        ['Accessibility', 'Language', $this->getValueFromPath($result, 'accessibility/formatAndStandards/language')],
+                        ['Accessibility', 'Alignment with standardised data models', $this->getValueFromPath($result, 'accessibility/formatAndStandards/conformsTo')],
+                        ['Accessibility', 'Controlled vocabulary', $this->getValueFromPath($result, 'accessibility/formatAndStandards/vocabularyEncodingScheme')],
+                        ['Accessibility', 'Format', $this->getValueFromPath($result, 'accessibility/formatAndStandards/format')],
+
+                        ['Data Access Request', 'Dataset pipeline status', $this->getValueFromPath($result, 'documentation/inPipeline')],
+                        ['Data Access Request', 'Access rights', $this->getValueFromPath($result, 'accessibility/access/accessRights')],
+                        ['Data Access Request', 'Time to dataset access', $this->getValueFromPath($result, 'accessibility/access/deliveryLeadTime')],
+                        ['Data Access Request', 'Access request cost', $this->getValueFromPath($result, 'accessibility/access/accessRequestCost')],
+                        ['Data Access Request', 'Access method category', $this->getValueFromPath($result, 'accessibility/access/accessServiceCategory')],
+                        ['Data Access Request', 'Access mode', $this->getValueFromPath($result, 'accessibility/access/accessMode')],
+                        ['Data Access Request', 'Access service description', $this->getValueFromPath($result, 'accessibility/access/accessService')],
+                        ['Data Access Request', 'Jurisdiction', $this->getValueFromPath($result, 'accessibility/access/jurisdiction')],
+                        ['Data Access Request', 'Data use limitation', $this->getValueFromPath($result, 'accessibility/usage/dataUseLimitation')],
+                        ['Data Access Request', 'Data use requirements', $this->getValueFromPath($result, 'accessibility/usage/dataUseRequirements')],
+                        ['Data Access Request', 'Data Controller', $this->getValueFromPath($result, 'accessibility/access/dataController')],
+                        ['Data Access Request', 'Data Processor', $this->getValueFromPath($result, 'accessibility/access/dataProcessor')],
+                        ['Data Access Request', 'Investigations', $this->getValueFromPath($result, 'enrichmentAndLinkage/investigations')],
+
+                        ['Demographics', 'Demographic Frequency', $this->getValueFromPath($result, 'demographicFrequency')],
                     ];
 
                     // add the given number of rows to the file.
@@ -1449,5 +1514,21 @@ class DatasetController extends Controller
             $metadata = $tmpMetadata;
         }
         return $metadata;
+    }
+
+    public function getValueFromPath(array $item, string $path)
+    {
+        $keys = explode('/', $path);
+
+        $return = $item;
+        foreach ($keys as $key) {
+            if (isset($return[$key])) {
+                $return = $return[$key];
+            } else {
+                return null;
+            }
+        }
+
+        return $return;
     }
 }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1186,6 +1186,97 @@ class DatasetController extends Controller
 
         return $response;
     }
+    /**
+     * @OA\Get(
+     *    path="/api/v1/datasets/export_single/{id}",
+     *    operationId="export_datasets_single",
+     *    tags={"Datasets"},
+     *    summary="DatasetController@export_single",
+     *    description="Export Structural Metadata CSV of a single dataset",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\Parameter(
+     *       name="id",
+     *       in="path",
+     *       description="dataset id",
+     *       required=true,
+     *       example="1",
+     *       @OA\Schema(
+     *          type="integer",
+     *          description="dataset id",
+     *       ),
+     *    ),
+     *    @OA\Response(
+     *       response=200,
+     *       description="CSV file",
+     *       @OA\MediaType(
+     *          mediaType="text/csv",
+     *          @OA\Schema(
+     *             type="string",
+     *             example="Title,""Publisher name"",Version,""Last Activity"",""Method of dataset creation"",Status,""Metadata detail""\n""Publications mentioning HDRUK"",""Health Data Research UK"",2.0.0,""2023-04-21T11:31:00.000Z"",MANUAL,ACTIVE,""{""properties\/accessibility\/usage\/dataUseRequirements"":{""id"":""95c37b03-54c4-468b-bda4-4f53f9aaaadd"",""namespace"":""hdruk.profile"",""key"":""properties\/accessibility\/usage\/dataUseRequirements"",""value"":""N\/A"",""lastUpdated"":""2023-12-14T11:31:11.312Z""},""properties\/required\/gatewayId"":{""id"":""8214d549-db98-453f-93e8-d88c6195ad93"",""namespace"":""hdruk.profile"",""key"":""properties\/required\/gatewayId"",""value"":""1234"",""lastUpdated"":""2023-12-14T11:31:11.311Z""}""",
+     *          )
+     *       )
+     *    ),
+     *    @OA\Response(
+     *       response=400,
+     *       description="Bad request",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="Invalid argument(s)")
+     *       ),
+     *    ),
+     *    @OA\Response(
+     *       response=401,
+     *       description="Unauthorized",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="unauthorized")
+     *       )
+     *    )
+     * )
+     */
+    public function export_single(GetDataset $request, int $id): StreamedResponse
+    {
+        $dataset = Dataset::where('id', '=', $id)->first();
+
+        $result = $dataset->latestVersion();
+
+        // callback function that writes to php://output
+        $response = new StreamedResponse(
+            function () use ($result) {
+                // Open output stream
+                $handle = fopen('php://output', 'w');
+
+                $headerRow = [
+                    'Section',
+                    'Column name',
+                    'Data type',
+                    'Column description',
+                    'Sensitive',
+                ];
+
+                // Add CSV headers
+                fputcsv($handle, $headerRow);
+                // add the given number of rows to the file.
+                foreach ($result['metadata']["metadata"]["structuralMetadata"] as $rowDetails) {
+                    $row = [
+                        $rowDetails["name"] !== null ? $rowDetails["name"] : '',
+                        $rowDetails["columns"][0]["name"] !== null ? $rowDetails["columns"][0]["name"] : '',
+                        $rowDetails["columns"][0]["dataType"] !== null ? $rowDetails["columns"][0]["dataType"] : '',
+                        $rowDetails["columns"][0]["description"] !== null ? str_replace("\n", "", $rowDetails["columns"][0]["description"]) : '',
+                        $rowDetails["columns"][0]["sensitive"] !== null ? $rowDetails["columns"][0]["sensitive"] === true ? "true" : "false" : '',
+                    ];
+                    fputcsv($handle, $row);
+                }
+
+                // Close the output stream
+                fclose($handle);
+            }
+        );
+
+        $response->headers->set('Content-Type', 'text/csv');
+        $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Structural_Metadata.csv"');
+        $response->headers->set('Cache-Control', 'max-age=0');
+
+        return $response;
+    }
 
     /**
      * @OA\Get(

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1271,13 +1271,13 @@ class DatasetController extends Controller
                     // Add CSV headers
                     fputcsv($handle, $headerRow);
                     // add the given number of rows to the file.
-                    foreach ($result['metadata']["metadata"]["structuralMetadata"] as $rowDetails) {
+                    foreach ($result['metadata']['metadata']['structuralMetadata'] as $rowDetails) {
                         $row = [
-                            $rowDetails["name"] !== null ? $rowDetails["name"] : '',
-                            $rowDetails["columns"][0]["name"] !== null ? $rowDetails["columns"][0]["name"] : '',
-                            $rowDetails["columns"][0]["dataType"] !== null ? $rowDetails["columns"][0]["dataType"] : '',
-                            $rowDetails["columns"][0]["description"] !== null ? str_replace("\n", "", $rowDetails["columns"][0]["description"]) : '',
-                            $rowDetails["columns"][0]["sensitive"] !== null ? $rowDetails["columns"][0]["sensitive"] === true ? "true" : "false" : '',
+                            $rowDetails['name'] !== null ? $rowDetails['name'] : '',
+                            $rowDetails['columns'][0]['name'] !== null ? $rowDetails['columns'][0]['name'] : '',
+                            $rowDetails['columns'][0]['dataType'] !== null ? $rowDetails['columns'][0]['dataType'] : '',
+                            $rowDetails['columns'][0]['description'] !== null ? str_replace('\n', '', $rowDetails['columns'][0]['description']) : '',
+                            $rowDetails['columns'][0]['sensitive'] !== null ? $rowDetails['columns'][0]['sensitive'] === true ? 'true' : 'false' : '',
                         ];
                         fputcsv($handle, $row);
                     }
@@ -1293,16 +1293,47 @@ class DatasetController extends Controller
                     // Add CSV headers
                     fputcsv($handle, $headerRow);
                     // add the given number of rows to the file.
-                    foreach ($result['metadata']["metadata"]["observations"] as $rowDetails) {
+                    foreach ($result['metadata']['metadata']['observations'] as $rowDetails) {
                         $row = [
-                            $rowDetails["observedNode"] !== null ? $rowDetails["observedNode"] : '',
-                            $rowDetails["disambiguatingDescription"] !== null ? $rowDetails["disambiguatingDescription"] : '',
-                            $rowDetails["measuredValue"] !== null ? $rowDetails["measuredValue"] : '',
-                            $rowDetails["measuredProperty"] !== null ? $rowDetails["measuredProperty"] : '',
-                            $rowDetails["observationDate"] !== null ? $rowDetails["observationDate"] : '',
+                            $rowDetails['observedNode'] !== null ? $rowDetails['observedNode'] : '',
+                            $rowDetails['disambiguatingDescription'] !== null ? $rowDetails['disambiguatingDescription'] : '',
+                            $rowDetails['measuredValue'] !== null ? $rowDetails['measuredValue'] : '',
+                            $rowDetails['measuredProperty'] !== null ? $rowDetails['measuredProperty'] : '',
+                            $rowDetails['observationDate'] !== null ? $rowDetails['observationDate'] : '',
                         ];
                         fputcsv($handle, $row);
                     }
+                } elseif ($download_type === 'metadata') {
+                    $headerRow = [
+                        'Section',
+                        'Value',
+                        'Field',
+                    ];
+
+                    // var_dump($result['metadata']['metadata']);
+                    // Add CSV headers
+                    fputcsv($handle, $headerRow);
+                    $rows = [
+                        ['Dataset', 'Name', $result['metadata']['metadata']['summary']['title']],
+                        ['Dataset', 'Gateway URL', $result['metadata']['metadata']['required']['revisions'][0]['url']], //?
+                        ['Dataset', 'Dataset Type', $result['metadata']['metadata']['summary']['datasetType']], //sort out delimiter
+                        ['Dataset', 'Dataset Sub-type', $result['metadata']['metadata']['summary']['datasetSubType']], //sort out delimiter
+                        ['Dataset', 'Collection Sources', $result['metadata']['metadata']['provenance']['origin']['collectionSituation']], //sort out delimiter
+                    ];
+
+                    // add the given number of rows to the file.
+                    // foreach ($result['metadata']['metadata']['observations'] as $rowDetails) {
+                    //     $row = [
+                    //         $rowDetails['observedNode'] !== null ? $rowDetails['observedNode'] : '',
+                    //         $rowDetails['disambiguatingDescription'] !== null ? $rowDetails['disambiguatingDescription'] : '',
+                    //         $rowDetails['measuredValue'] !== null ? $rowDetails['measuredValue'] : '',
+                    //         $rowDetails['measuredProperty'] !== null ? $rowDetails['measuredProperty'] : '',
+                    //         $rowDetails['observationDate'] !== null ? $rowDetails['observationDate'] : '',
+                    //     ];
+                    foreach ($rows as $row) {
+                        fputcsv($handle, $row);
+                    }
+                    // }
                 }
 
                 // Close the output stream
@@ -1315,6 +1346,8 @@ class DatasetController extends Controller
             $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Structural_Metadata.csv"');
         } elseif ($download_type === 'observations') {
             $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Observations.csv"');
+        } elseif ($download_type === 'metadata') {
+            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Metadata.csv"');
         } else {
             $response->headers->set('Content-Disposition', 'attachment;filename="placeholder_name.csv"');
         }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1240,7 +1240,7 @@ class DatasetController extends Controller
     public function exportMetadata(ExportDataset $request, int $id): StreamedResponse
     {
         $input = $request->all();
-        $download_type = $input['download_type'];
+        $download_type = strtolower($input['download_type']);
 
         $dataset = Dataset::where('id', '=', $id)->first();
 
@@ -1391,15 +1391,17 @@ class DatasetController extends Controller
         );
 
         $response->headers->set('Content-Type', 'text/csv');
+        $filename = $id . '_' . $result['summary']['title'];
         if ($download_type === 'structural') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Structural_Metadata.csv"');
+            $filename .= '_Structural_Metadata.csv';
         } elseif ($download_type === 'observations') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Observations.csv"');
+            $filename .= '_Observations.csv';
         } elseif ($download_type === 'metadata') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Metadata.csv"');
+            $filename .= '_Metadata.csv';
         } else {
-            $response->headers->set('Content-Disposition', 'attachment;filename="placeholder_name.csv"');
+            $filename .= '.csv';
         }
+        $response->headers->set('Content-Disposition', 'attachment;filename="' . $filename . '"');
         $response->headers->set('Cache-Control', 'max-age=0');
 
         return $response;

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1304,18 +1304,22 @@ class DatasetController extends Controller
 
                     // Add CSV headers
                     fputcsv($handle, $headerRow);
+
+                    // Note that the contents here need to be manually kept up to date with the contents of
+                    // gateway-web-2/src/app/[locale]/(logged-out)/dataset/[datasetId]/config.tsx.
+                    // The 'Summary Demographics' rows match the summary boxes at the top of the dataset landing page
                     $rows = [
                         ['Dataset', 'Name', $this->getValueFromPath($result, 'summary/title')],
-                        ['Dataset', 'Gateway URL', $this->getValueFromPath($result, 'required/revisions/0/url')], //?
-                        ['Dataset', 'Dataset Type', $this->getValueFromPath($result, 'summary/datasetType')], //sort out delimiter
-                        ['Dataset', 'Dataset Sub-type', $this->getValueFromPath($result, 'summary/datasetSubType')], //sort out delimiter
-                        ['Dataset', 'Collection Sources', $this->getValueFromPath($result, 'provenance/origin/collectionSituation')], //sort out delimiter
+                        ['Dataset', 'Gateway URL', $this->getValueFromPath($result, 'required/revisions/0/url')],
+                        ['Dataset', 'Dataset Type', $this->getValueFromPath($result, 'summary/datasetType')],
+                        ['Dataset', 'Dataset Sub-type', $this->getValueFromPath($result, 'summary/datasetSubType')],
+                        ['Dataset', 'Collection Sources', $this->getValueFromPath($result, 'provenance/origin/collectionSituation')],
 
-                        ['Summary Demographics', 'Population Size', $this->getValueFromPath($result, 'summary/populationSize') === "-1" ? "" : $this->getValueFromPath($result, 'summary/populationSize')], // formatTextDelimiter
-                        ['Summary Demographics', 'Years', $this->getValueFromPath($result, 'provenance/temporal/startDate')], //formatYearStat
+                        ['Summary Demographics', 'Population Size', $this->getValueFromPath($result, 'summary/populationSize') === "-1" ? "" : $this->getValueFromPath($result, 'summary/populationSize')],
+                        ['Summary Demographics', 'Years', $this->getValueFromPath($result, 'provenance/temporal/startDate')],
                         ['Summary Demographics', 'Associate BioSamples', $this->getValueFromPath($result, 'coverage/materialType')],
-                        ['Summary Demographics', 'Geographic coverage', $this->getValueFromPath($result, 'coverage/spatial')], //splitStringList
-                        ['Summary Demographics', 'Lead time', $this->getValueFromPath($result, 'accessibility/access/deliveryLeadTime')], //parseLeadTime
+                        ['Summary Demographics', 'Geographic coverage', $this->getValueFromPath($result, 'coverage/spatial')],
+                        ['Summary Demographics', 'Lead time', $this->getValueFromPath($result, 'accessibility/access/deliveryLeadTime')],
 
                         ['Summary', 'Abstract', $this->getValueFromPath($result, 'summary/abstract')],
                         ['Summary', 'DOI for dataset', $this->getValueFromPath($result, 'summary/doiName')],
@@ -1388,11 +1392,11 @@ class DatasetController extends Controller
 
         $response->headers->set('Content-Type', 'text/csv');
         if ($download_type === 'structural') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Structural_Metadata.csv"');
+            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Structural_Metadata.csv"');
         } elseif ($download_type === 'observations') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Observations.csv"');
+            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Observations.csv"');
         } elseif ($download_type === 'metadata') {
-            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['metadata']['metadata']['summary']['title'] . '_Metadata.csv"');
+            $response->headers->set('Content-Disposition', 'attachment;filename="' . $id . '_' . $result['summary']['title'] . '_Metadata.csv"');
         } else {
             $response->headers->set('Content-Disposition', 'attachment;filename="placeholder_name.csv"');
         }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -32,6 +32,7 @@ use App\Http\Requests\Dataset\EditDataset;
 use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Requests\Dataset\CreateDataset;
 use App\Http\Requests\Dataset\DeleteDataset;
+use App\Http\Requests\Dataset\ExportDataset;
 use App\Http\Requests\Dataset\UpdateDataset;
 use App\Exports\DatasetStructuralMetadataExport;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -1205,6 +1206,17 @@ class DatasetController extends Controller
      *          description="dataset id",
      *       ),
      *    ),
+     *    @OA\Parameter(
+     *       name="download_type",
+     *       in="query",
+     *       description="download type",
+     *       required=true,
+     *       example="structural",
+     *       @OA\Schema(
+     *          type="string",
+     *          description="download type",
+     *       ),
+     *    ),
      *    @OA\Response(
      *       response=200,
      *       description="CSV file",
@@ -1232,8 +1244,11 @@ class DatasetController extends Controller
      *    )
      * )
      */
-    public function export_single(GetDataset $request, int $id): StreamedResponse
+    public function export_single(ExportDataset $request, int $id): StreamedResponse
     {
+        $input = $request->all();
+        $download_type = $input['download_type'];
+
         $dataset = Dataset::where('id', '=', $id)->first();
 
         $result = $dataset->latestVersion();

--- a/app/Http/Requests/Dataset/ExportDataset.php
+++ b/app/Http/Requests/Dataset/ExportDataset.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Dataset;
+
+use App\Http\Requests\BaseFormRequest;
+
+class ExportDataset extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:datasets,id',
+            ],
+            'download_type' => [
+                'string',
+                'required',
+                'in:metadata,observations,structural'
+            ]
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -2126,6 +2126,17 @@ return [
     [
         'name' => 'datasets',
         'method' => 'get',
+        'path' => '/datasets/export_single/{id}',
+        'methodController' => 'DatasetController@export_single',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'datasets',
+        'method' => 'get',
         'path' => '/datasets/export/mock',
         'methodController' => 'DatasetController@exportMock',
         'namespaceController' => 'App\Http\Controllers\Api\V1',

--- a/config/routes.php
+++ b/config/routes.php
@@ -2126,8 +2126,8 @@ return [
     [
         'name' => 'datasets',
         'method' => 'get',
-        'path' => '/datasets/export_single/{id}',
-        'methodController' => 'DatasetController@export_single',
+        'path' => '/datasets/export_metadata/{id}',
+        'methodController' => 'DatasetController@exportMetadata',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [],
         'constraint' => [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
A single endpoint serves 3 files' contents, depending on the `download_type` parameter.

Supports https://github.com/HDRUK/gateway-web-2/pull/881 FE

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4915

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
