### PR TITLE
Fix: checkAccessMiddleware 500 when user is not a member of the team

### DIFF
--- a/app/Http/Middleware/CheckAccessMiddleware.php
+++ b/app/Http/Middleware/CheckAccessMiddleware.php
@@ -32,7 +32,8 @@ class CheckAccessMiddleware
         $currentUserRoles = [];
         $currentUserPermissions = [];
         if ($teamId) {
-            if (array_key_exists((string) $teamId, $input['jwt_user']['role_perms']['teams'])) {
+            if (array_key_exists('teams', $input['jwt_user']['role_perms']) &&
+                array_key_exists((string) $teamId, $input['jwt_user']['role_perms']['teams'])) {
                 $currentUserRoles = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['roles'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['roles']));
                 $currentUserPermissions = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['perms'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['perms']));
             } else {

--- a/app/Http/Middleware/CheckAccessMiddleware.php
+++ b/app/Http/Middleware/CheckAccessMiddleware.php
@@ -32,8 +32,13 @@ class CheckAccessMiddleware
         $currentUserRoles = [];
         $currentUserPermissions = [];
         if ($teamId) {
-            $currentUserRoles = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['roles'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['roles']));
-            $currentUserPermissions = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['perms'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['perms']));
+            if (array_key_exists((string) $teamId, $input['jwt_user']['role_perms']['teams'])) {
+                $currentUserRoles = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['roles'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['roles']));
+                $currentUserPermissions = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['perms'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['perms']));
+            } else {
+                $currentUserRoles = array_unique($input['jwt_user']['role_perms']['extra']['roles']);
+                $currentUserPermissions = array_unique($input['jwt_user']['role_perms']['extra']['perms']);
+            }
         } else {
             $currentUserRoles = $input['jwt_user']['role_perms']['summary']['roles'];
             $currentUserPermissions = $input['jwt_user']['role_perms']['summary']['perms'];

--- a/app/Http/Middleware/CheckAccessMiddleware.php
+++ b/app/Http/Middleware/CheckAccessMiddleware.php
@@ -32,8 +32,7 @@ class CheckAccessMiddleware
         $currentUserRoles = [];
         $currentUserPermissions = [];
         if ($teamId) {
-            if (array_key_exists('teams', $input['jwt_user']['role_perms']) &&
-                array_key_exists((string) $teamId, $input['jwt_user']['role_perms']['teams'])) {
+            if (isset($input['jwt_user']['role_perms']['teams'][(string) $teamId])) {
                 $currentUserRoles = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['roles'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['roles']));
                 $currentUserPermissions = array_unique(array_merge($input['jwt_user']['role_perms']['extra']['perms'], $input['jwt_user']['role_perms']['teams'][(string) $teamId]['perms']));
             } else {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Fix a bug in CheckAccessMiddleware when querying access on a team the user is not a member of. This would have raised a 500 due to querying a non-existent array index, because the team entry only gets created if the user is a member of the team.

To recreate the bug, attempt to call an endpoint with `{teamId}` in it, that is subject to a middleware `check.access` constraint such as `check.access:permissions,collections.create`, using a team you are not a member of. It 500s rather than 401.

We also fix a further issue where, when the user is not a member of _any_ team, another non-existent array index bug was triggered.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
