### PR TITLE
adds new route for teams/{id}/datasets, specifically to trim the payl…

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -19,11 +19,12 @@ use App\Http\Traits\IndexElastic;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 
-
+use App\Http\Traits\TrimPayload;
 use App\Http\Traits\MetadataOnboard;
-use Maatwebsite\Excel\Facades\Excel;
 use App\Http\Traits\MetadataVersioning;
 use App\Models\Traits\ModelHelpers;
+
+use Maatwebsite\Excel\Facades\Excel;
 
 use Illuminate\Support\Facades\Storage;
 use MetadataManagementController as MMC;
@@ -46,6 +47,7 @@ class DatasetController extends Controller
     use MetadataOnboard;
     use CheckAccess;
     use ModelHelpers;
+    use TrimPayload;
 
     /**
      * @OA\Get(
@@ -243,6 +245,14 @@ class DatasetController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => 'Dataset get all',
             ]);
+
+            foreach ($datasets->toArray() as $d) {
+                dd($d['latest_metadata']);
+                $d['latest_metadata'] = $this->trimDatasets($d['latest_metadata'], [
+                    'required',
+                    'summary',
+                ]);
+            }
 
             return response()->json(
                 $datasets

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -19,7 +19,6 @@ use App\Http\Traits\IndexElastic;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 
-use App\Http\Traits\TrimPayload;
 use App\Http\Traits\MetadataOnboard;
 use App\Http\Traits\MetadataVersioning;
 use App\Models\Traits\ModelHelpers;
@@ -47,7 +46,6 @@ class DatasetController extends Controller
     use MetadataOnboard;
     use CheckAccess;
     use ModelHelpers;
-    use TrimPayload;
 
     /**
      * @OA\Get(
@@ -245,14 +243,6 @@ class DatasetController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => 'Dataset get all',
             ]);
-
-            foreach ($datasets->toArray() as $d) {
-                dd($d['latest_metadata']);
-                $d['latest_metadata'] = $this->trimDatasets($d['latest_metadata'], [
-                    'required',
-                    'summary',
-                ]);
-            }
 
             return response()->json(
                 $datasets

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -1190,10 +1190,18 @@ class TeamController extends Controller
                 ->paginate($perPage, ['*'], 'page');
 
             foreach ($datasets as &$d) {
-                $d->latestMetadata['metadata'] = $this->trimDatasets($d->latestMetadata['metadata'], [
+                $miniMetadata = $this->trimDatasets($d->latestMetadata['metadata'], [
                     'summary',
                     'required',
                 ]);
+
+                // latestMetadata is a relation and cannot be assigned at this
+                // level, safely. So, unset all forms of metadata on the object
+                // and overwrite with out minimal version
+                unset($d['latest_metadata']);
+                unset($d['latestMetadata']);
+
+                $d['latest_metadata'] = $miniMetadata;
             }
 
             return response()->json([

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -32,6 +32,7 @@ use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Traits\IndexElastic;
 use App\Http\Traits\TeamTransformation;
 use App\Http\Traits\RequestTransformation;
+use App\Http\Traits\TrimPayload;
 
 use MetadataManagementController as MMC;
 
@@ -41,6 +42,7 @@ class TeamController extends Controller
     use IndexElastic;
     use TeamTransformation;
     use RequestTransformation;
+    use TrimPayload;
 
     private $datasets = [];
     private $durs = [];
@@ -1071,6 +1073,135 @@ class TeamController extends Controller
             ]);
 
             throw new Exception($e->getMessage());
+        }
+    }
+
+    public function datasets(Request $request, int $teamId): JsonResponse
+    {
+        try {
+            $filterStatus = $request->query('status', null);
+            $datasetId = $request->query('dataset_id', null);
+            $mongoPId = $request->query('mongo_pid', null);
+            $withMetadata = $request->boolean('with_metadata', true);
+
+            $sort = $request->query('sort', 'created:desc');
+
+            $tmp = explode(':', $sort);
+            $sortField = $tmp[0];
+            $sortDirection = array_key_exists('1', $tmp) ? $tmp[1] : 'asc';
+
+            $sortOnMetadata = str_starts_with($sortField, 'metadata.');
+            $allFields = collect(Dataset::first())->keys()->toArray();
+            if (!$sortOnMetadata && count($allFields) > 0 && !in_array($sortField, $allFields)) {
+                return response()->json([
+                    'message' => '\"' . $sortField . '\" is not a valid fiedl to sort on',
+                ], 400);
+            }
+
+            $validDirections = ['desc', 'asc'];
+
+            if (!in_array($sortDirection, $validDirections)) {
+                return response()->json([
+                    'message' => 'Sort direction must be either: ' .
+                        implode(' OR ', $validDirections) .
+                        '. Not "' . $sortDirection . '"',
+                ], 400);
+            }
+
+            $filterTitle = $request->query('title', null);
+
+            $matches = [];
+
+            $datasets = Dataset::where('team_id', $teamId)
+                ->when($datasetId, function ($query) use ($datasetId) {
+                    return $query->where('datasetid', '=', $datasetId);
+                })
+                ->when($mongoPId, function ($query) use ($mongoPId) {
+                    return $query->where('mongo_pid', '=', $mongoPId);
+                })
+                // LS - Reworked from original in DatasetsController@index, as
+                // that is incorrect and flawed logic
+                ->when(
+                    $request->has('withTrashed'),
+                    function ($query) {
+                        return $query->withTrashed();
+                    }
+                )
+                // LS - This is how it should be done, other places we currently
+                // use both deleted_at and ARCHIVED as a status field. deleted_at
+                // should denote a record has _actually_ been deleted, and therefore
+                // hidden.
+                ->when($filterStatus, function ($query) use ($filterStatus) {
+                    return $query->where('status', '=', $filterStatus);
+                })
+                ->select(['id'])->get();
+
+            foreach ($datasets as $d) {
+                $matches[] = $d->id;
+            }
+
+            if (!empty($filterTitle)) {
+                $titleMatches = [];
+
+                foreach ($matches as $m) {
+                    $version = DatasetVersion::where('dataset_id', $m)
+                        ->filterTitle($filterTitle)
+                        ->select('dataset_id')
+                        ->when(
+                            $request->has('withTrashed'),
+                            function ($query) {
+                                return $query->withTrashed();
+                            }
+                        )
+                        ->when(
+                            $filterStatus,
+                            function ($query) use ($filterStatus) {
+                                return $query->where('status', '=', $filterStatus);
+                            }
+                        )
+                        ->first();
+
+                    if ($version) {
+                        $titleMatches[] = $version->dataset_id;
+                    }
+                }
+
+                $matches = array_intersect($matches, $titleMatches);
+            }
+
+            $perPage = request('per_page', Config::get('constants.per_page'));
+
+            $datasets = Dataset::whereIn('id', $matches)
+                ->when($withMetadata, fn ($query) => $query->with('latestMetadata'))
+                ->when(
+                    $request->has('withTrashed'),
+                    function ($query) {
+                        return $query->withTrashed();
+                    }
+                )
+                ->when($filterStatus, function ($query) use ($filterStatus) {
+                    return $query->where('status', '=', $filterStatus);
+                })
+                ->when(
+                    $sortOnMetadata,
+                    fn ($query) => $query->orderByMetadata($sortField, $sortDirection),
+                    fn ($query) => $query->orderBy($sortField, $sortDirection)
+                )
+                ->paginate($perPage, ['*'], 'page');
+
+            foreach ($datasets as &$d) {
+                $d->latestMetadata['metadata'] = $this->trimDatasets($d->latestMetadata['metadata'], [
+                    'summary',
+                    'required',
+                ]);
+            }
+
+            return response()->json([
+                $datasets,
+            ], 200);
+
+        } catch (Exception $e) {
+            throw new Exception($e);
         }
     }
 

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -1094,7 +1094,7 @@ class TeamController extends Controller
             $allFields = collect(Dataset::first())->keys()->toArray();
             if (!$sortOnMetadata && count($allFields) > 0 && !in_array($sortField, $allFields)) {
                 return response()->json([
-                    'message' => '\"' . $sortField . '\" is not a valid fiedl to sort on',
+                    'message' => '\"' . $sortField . '\" is not a valid field to sort on',
                 ], 400);
             }
 

--- a/app/Http/Traits/TrimPayload.php
+++ b/app/Http/Traits/TrimPayload.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Traits;
+
+trait TrimPayload
+{
+    public function trimDatasets(array $input, array $requiredFields): array
+    {
+        $miniMetadata = $input['metadata'];
+
+        foreach ($miniMetadata as $key => $value) {
+            if (!in_array($key, $requiredFields)) {
+                unset($miniMetadata[$key]);
+            }
+        }
+
+        return $miniMetadata;
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -476,6 +476,20 @@ return [
             'teamId' => '[0-9]+',
         ],
     ],
+    [
+        'name' => 'teams',
+        'method' => 'get',
+        'path' => '/teams/{teamId}/datasets',
+        'methodController' => 'TeamController@datasets',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
 
     // tools
     [


### PR DESCRIPTION
…oad for datasets administration list

## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/e48114c3-79cd-47e2-a51e-a62c9890b781)


## Describe your changes
The datasets administration page (list) under Teams, suffers from pulling back the entire payload, which, for BHF, causes a server error (because it's massive). This provides the bare minimum this page needs, and now loads the BHF datasets in 128ms.

## Issue ticket link

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
