### PR TITLE
fix: (GAT-5762) - Search should only show active collections

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -683,7 +683,7 @@ class SearchController extends Controller
                 $matchedIds[] = $d['_id'];
             }
 
-            $collectionModels = Collection::whereIn('id', $matchedIds)->get();
+            $collectionModels = Collection::whereIn('id', $matchedIds)->where('status', 'ACTIVE')->get();
 
             foreach ($collectionArray as $i => $collection) {
                 $foundFlag = false;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Changed search controller to only show active collections
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5762
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
