### PR TITLE
Fix: correction to column name

### DIFF
--- a/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
+++ b/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
@@ -10,9 +10,6 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        // Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
-        //     $table->dropIndex('dar_app_q_has_enq_threads_equiry_thread_id_index');
-        // });
         Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
             $table->renameColumn('equiry_thread_id', 'enquiry_thread_id');
             $table->renameIndex('dar_app_q_has_enq_threads_equiry_thread_id_index', 'dar_app_q_has_enq_threads_enquiry_thread_id_index');

--- a/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
+++ b/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
+        //     $table->dropIndex('dar_app_q_has_enq_threads_equiry_thread_id_index');
+        // });
+        Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
+            $table->renameColumn('equiry_thread_id', 'enquiry_thread_id');
+            $table->renameIndex('dar_app_q_has_enq_threads_equiry_thread_id_index', 'dar_app_q_has_enq_threads_enquiry_thread_id_index');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
+            $table->renameColumn('enquiry_thread_id', 'equiry_thread_id');
+            $table->renameIndex('dar_app_q_has_enq_threads_enquiry_thread_id_index', 'dar_app_q_has_enq_threads_equiry_thread_id_index');
+        });
+    }
+};

--- a/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
+++ b/database/migrations/2024_11_22_140402_rename_equiry_thread_id.php
@@ -12,6 +12,8 @@ return new class () extends Migration {
     {
         Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
             $table->renameColumn('equiry_thread_id', 'enquiry_thread_id');
+        });
+        Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
             $table->renameIndex('dar_app_q_has_enq_threads_equiry_thread_id_index', 'dar_app_q_has_enq_threads_enquiry_thread_id_index');
         });
 
@@ -24,6 +26,8 @@ return new class () extends Migration {
     {
         Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
             $table->renameColumn('enquiry_thread_id', 'equiry_thread_id');
+        });
+        Schema::table('dar_app_q_has_enq_threads', function (Blueprint $table) {
             $table->renameIndex('dar_app_q_has_enq_threads_enquiry_thread_id_index', 'dar_app_q_has_enq_threads_equiry_thread_id_index');
         });
     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Rename the column 'equiry_thread_id' to 'enquiry_thread_id' and rename the associated index.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
`php artisan migrate` for the `2024_11_22_140402_rename_equiry_thread_id` migration file.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
