### PR TITLE
Migrations for custom questions in qb

### DIFF
--- a/database/migrations/2024_11_21_100036_create_qb_has_team_table.php
+++ b/database/migrations/2024_11_21_100036_create_qb_has_team_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('qb_question_has_team', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('team_id')->unsigned();
+            $table->bigInteger('qb_question_id')->unsigned();
+
+            $table->foreign('team_id')->references('id')->on('teams');
+            $table->foreign('qb_question_id')->references('id')->on('question_bank_questions');
+
+            $table->unique(['team_id', 'qb_question_id']);
+            $table->index('team_id');
+            $table->index('qb_question_id');
+        });
+
+        // Fill with existing data?
+        // Nulls mean all teams have access to the question
+        $questions = DB::select('select id, team_id from question_bank_questions');
+        // ??? all teams or select where is_question_bank is true
+        $qb_teams = DB::table('teams')->select('id')->pluck('id');
+
+        foreach ($questions as $question) {
+            if (is_null($question->team_id)) {
+                foreach ($qb_teams as $team) {
+                    DB::insert(
+                        'insert into qb_question_has_team (team_id, qb_question_id) values (?, ?)',
+                        [$team, $question->id]
+                    );
+                }
+            } else {
+                DB::insert(
+                    'insert into qb_question_has_team (team_id, qb_question_id) values (?, ?)',
+                    [$question->team_id, $question->id]
+                );
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('qb_question_has_team');
+    }
+};

--- a/database/migrations/2024_11_21_100426_update_qb_drop_team_id.php
+++ b/database/migrations/2024_11_21_100426_update_qb_drop_team_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->dropIndex(['team_id']);
+            $table->dropColumn('team_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->bigInteger('team_id')->unsigned();
+            $table->index('team_id');
+        });
+
+        // replace existing data? There isn't really a way to do that so fill with null?
+    }
+};

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -51,7 +51,6 @@ class QuestionBankSeeder extends Seeder
                     $questionModel = QuestionBank::create([
                             'section_id' => $subSectionModel->id,
                             'user_id' => 1,
-                            'team_id' => null,
                             'locked' => 0,
                             'archived' => 0,
                             'archived_date' => null,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adds `qb_question_has_team` table so that questions can available to more than one team. Removes `team_id` column from `question_bank_questions` table.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-3977

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

Yes: `php artisan migrate`.  

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
