### PR TITLE
feat: (GAT-5697) - return publisher team id to frontend if exists

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -197,6 +197,17 @@ class SearchController extends Controller
                 }
 
                 $model['metadata'] = $model->latestVersion()['metadata']['metadata'];
+
+                $metadata = $model['metadata'];
+
+                if (isset($metadata['summary']['publisher']['gatewayId'])) {
+                    $id = $metadata['summary']['publisher']['gatewayId'];
+                    $team = Team::where('pid', $id)->first();
+                    if ($team) {
+                        $metadata['summary']['publisher']['gatewayId'] = $team->id;
+                        $model['metadata'] = $metadata;
+                    }
+                }
                 $model = $model->toArray();
 
                 $datasetsArray[$i]['_source']['created_at'] = $model['created_at'];


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/245c06f7-a099-4fb2-82aa-c2bc329fa2f4)

## Describe your changes

- Frontend needs the id of the publisher be able to link to the data-custodian page, this can be different from the team id, we do however have the pid so use that to get the id and replace it
- Frontend changes coming soon, stay tuned!


## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5697
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
