### PR TITLE
GAT-5362 :: Extend searching of Data Custodian

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -13,3 +13,16 @@ if (! function_exists('convertArrayToStringWithKeyName')) {
         return implode($separator, $temp);
     }
 }
+
+if (! function_exists('convertArrayToArrayWithKeyName')) {
+    function convertArrayToArrayWithKeyName($array, $keyname)
+    {
+        $return = [];
+        foreach ($array as $item) {
+            $return[] = $item[$keyname];
+        }
+        $return = array_unique($return);
+
+        return $return;
+    }
+}

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -10,12 +10,14 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 
 use App\Models\Collection;
+use App\Models\CollectionHasDatasetVersion;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\DatasetVersionHasTool;
 use App\Models\DataProviderColl;
 use App\Models\DataProviderCollHasTeam;
 use App\Models\Dur;
+use App\Models\DurHasDatasetVersion;
 use App\Models\License;
 use App\Models\ProgrammingLanguage;
 use App\Models\ProgrammingPackage;
@@ -144,11 +146,17 @@ trait IndexElastic
         try {
             $datasets = Dataset::where('team_id', $teamId)->get();
 
-            $datasetTitles = array();
-            $locations = array();
-            $dataTypes = array();
+            $datasetTitles = [];
+            $datasetVersionIds = [];
+            $locations = [];
+            $dataTypes = [];
+            $publicationTitles = [];
+            $collectionNames = [];
+            $durTitles = [];
+            $toolNames = [];
             foreach ($datasets as $dataset) {
                 $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
+                $datasetVersionIds[] = $dataset->latestVersion()->id;
                 $metadata = $dataset->latestVersion()->metadata;
                 $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
                 $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
@@ -167,11 +175,50 @@ trait IndexElastic
             }
             usort($datasetTitles, 'strcasecmp');
 
+            // dur
+            if (count($datasetVersionIds)) {
+                $durHasDatasetVersions = DurHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('dur_id')->get();
+                $durIds = convertArrayToArrayWithKeyName($durHasDatasetVersions, 'dur_id');
+                $durs = Dur::whereIn('id', $durIds)->select('project_title')->get();
+                $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
+                $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
+                $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
+                $durTitles = array_unique(array_merge($durTitles, $durByTeamIdTitles));
+            }
+
+            // tools
+            if (count($datasetVersionIds)) {
+                $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
+                $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
+                $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
+                $toolNames = convertArrayToArrayWithKeyName($tools, 'name');
+            }
+
+            // publications
+            if (count($datasetVersionIds)) {
+                $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
+                $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
+                $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
+                $publicationTitles = convertArrayToArrayWithKeyName($publications, 'paper_title');
+            }
+
+            // collections
+            if (count($datasetVersionIds)) {
+                $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
+                $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
+                $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
+                $collectionNames = convertArrayToArrayWithKeyName($collections, 'name');
+            }
+
             $toIndex = [
                 'name' => Team::findOrFail($teamId)->name,
-                'datasetTitles' => $datasetTitles,
+                'datasetTitles' => array_unique($datasetTitles),
                 'geographicLocation' => $locations,
                 'dataType' => $dataTypes,
+                'durTitles' => array_unique($durTitles),
+                'toolNames' => array_unique($toolNames),
+                'publicationTitles' => array_unique($publicationTitles),
+                'collectionNames' => array_unique($collectionNames),
             ];
 
             $params = [

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -183,7 +183,7 @@ trait IndexElastic
                 $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
                 $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
                 $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
-                $durTitles = array_unique(array_merge($durTitles, $durByTeamIdTitles));
+                $durTitles = implode(',', array_unique(array_merge($durTitles, $durByTeamIdTitles)));
             }
 
             // tools
@@ -191,7 +191,7 @@ trait IndexElastic
                 $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
                 $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
                 $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
-                $toolNames = convertArrayToArrayWithKeyName($tools, 'name');
+                $toolNames = convertArrayToStringWithKeyName($tools, 'name');
             }
 
             // publications
@@ -199,7 +199,7 @@ trait IndexElastic
                 $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
                 $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
                 $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
-                $publicationTitles = convertArrayToArrayWithKeyName($publications, 'paper_title');
+                $publicationTitles = convertArrayToStringWithKeyName($publications, 'paper_title');
             }
 
             // collections
@@ -207,7 +207,7 @@ trait IndexElastic
                 $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
                 $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
                 $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
-                $collectionNames = convertArrayToArrayWithKeyName($collections, 'name');
+                $collectionNames = convertArrayToStringWithKeyName($collections, 'name');
             }
 
             $toIndex = [
@@ -215,10 +215,10 @@ trait IndexElastic
                 'datasetTitles' => array_unique($datasetTitles),
                 'geographicLocation' => $locations,
                 'dataType' => $dataTypes,
-                'durTitles' => array_unique($durTitles),
-                'toolNames' => array_unique($toolNames),
-                'publicationTitles' => array_unique($publicationTitles),
-                'collectionNames' => array_unique($collectionNames),
+                'durTitles' => $durTitles,
+                'toolNames' => $toolNames,
+                'publicationTitles' => $publicationTitles,
+                'collectionNames' => $collectionNames,
             ];
 
             $params = [


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2024-12-03 at 13 10 36](https://github.com/user-attachments/assets/6e2e3749-7e21-4e36-a0df-8ffb39b49934)

## Describe your changes
Extend searching of Data Custodian UI

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5362

## Environment / Configuration changes (if applicable)
- remove index `dataprovider` from elasticsearch
```
curl --location --request DELETE 'https://localhost:9200/dataprovider' \
--header 'Authorization: ••••••' \
```
- create index `dataprovider` in elasticsearch
```
curl --location --request POST 'http://localhost:8080/mappings/data_providers' \
--header 'Authorization: Basic ••••••' \
```
- reindex elastic search `php artisan app:reindex-entities dataProviders --sleep=1`

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
