### PR TITLE
Fix datasetsubtype filter

### DIFF
--- a/app/Console/Commands/UpdateDataSubTypeFilter.php
+++ b/app/Console/Commands/UpdateDataSubTypeFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Filter;
+use Illuminate\Console\Command;
+
+class UpdateDataSubTypeFilter extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-datasubtype-filter';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Change the filter entry `datasetSubType` to `dataSubType';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $getFilter = Filter::where(['keys' => 'datasetSubType', 'type' => 'dataset'])->first();
+
+        if (is_null($getFilter)) {
+            $this->warn('Filter dataset::datasetSubType not found');
+            return;
+        }
+
+        $getFilter->keys = 'dataSubType';
+
+        $getFilter->save();
+    }
+}

--- a/database/seeders/FilterSeeder.php
+++ b/database/seeders/FilterSeeder.php
@@ -28,7 +28,7 @@ class FilterSeeder extends Seeder
             'publisherName',
             'containsTissue',
             'dataType',
-            'datasetSubType',
+            'dataSubType',
             'collectionName',
             'dataUseTitles',
             'dateRange',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Change the current `datasetSubType` filter name to `dataSubType` to match the response from search-service.

## Issue ticket link
Fix for https://hdruk.atlassian.net/browse/GAT-5268, supporting https://hdruk.atlassian.net/browse/GAT-5369

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Run `php artisan app:update-datasubtype-filter`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
