### PR TITLE
fix - allow full error in GCP log

### DIFF
--- a/app/Http/Controllers/Api/V1/SocialLoginController.php
+++ b/app/Http/Controllers/Api/V1/SocialLoginController.php
@@ -241,7 +241,7 @@ class SocialLoginController extends Controller
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => $e->getMessage(),
+                'description' => $e,
             ]);
 
             throw new Exception($e->getMessage());

--- a/app/Http/Controllers/Api/V1/SocialLoginController.php
+++ b/app/Http/Controllers/Api/V1/SocialLoginController.php
@@ -244,7 +244,7 @@ class SocialLoginController extends Controller
                 'description' => $e,
             ]);
 
-            throw new Exception($e->getMessage());
+            throw new Exception($e);
         }
     }
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Allow the full log to be displayed in GCP
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
