### PR TITLE
Feature/gat 5782

### DIFF
--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -450,6 +450,7 @@ class QuestionBankController extends Controller
                     'message' => 'Cannot update a question to become a child question'
                 ], 400);
             }
+            // TODO: handle locking
 
             $question->update([
                 'section_id' => $input['section_id'],
@@ -665,6 +666,8 @@ class QuestionBankController extends Controller
                 ], 400);
             }
 
+            // TODO: handle locking
+
             $arrayKeys = [
                 'section_id',
                 'user_id',
@@ -803,6 +806,8 @@ class QuestionBankController extends Controller
                     'message' => 'Cannot delete a child question directly'
                 ], 400);
             }
+
+            // TODO: handle locking?
 
             // For each version of this question, check its children.
             // - Delete all versions of all child question versions and their associated questions,

--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -419,7 +419,7 @@ class QuestionBankController extends Controller
                 'required' => $input['required'],
                 'default' => $input['default'],
                 'question_id' => $question->id,
-                'version' =>  $latestVersion->version + 1,
+                'version' => $latestVersion->version + 1,
             ]);
 
 

--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -227,6 +227,12 @@ class QuestionBankController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
+            if ($input['is_child'] ?? false) {
+                return response()->json([
+                    'message' => 'Cannot create a child question directly'
+                ], 400);
+            }
+
             $question = QuestionBank::create([
                 'section_id' => $input['section_id'],
                 'user_id' => $input['user_id'] ?? $jwtUser['id'],
@@ -234,7 +240,7 @@ class QuestionBankController extends Controller
                 'allow_guidance_override' => $input['allow_guidance_override'],
                 'locked' => $input['locked'] ?? false,
                 'archived' => $input['archived'] ?? false,
-                'is_child' => $input['is_child'] ?? false,
+                'is_child' => false,
             ]);
 
             $questionJson = [
@@ -435,10 +441,14 @@ class QuestionBankController extends Controller
 
             $question = QuestionBank::findOrFail($id);
             if ($question->is_child) {
-                throw new Exception('Cannot update a child question directly');
+                return response()->json([
+                    'message' => 'Cannot update a child question directly'
+                ], 400);
             }
             if ($input['is_child'] ?? false) {
-                throw new Exception('Cannot update a question to become a child question');
+                return response()->json([
+                    'message' => 'Cannot update a question to become a child question'
+                ], 400);
             }
 
             $question->update([
@@ -650,7 +660,9 @@ class QuestionBankController extends Controller
             $question = QuestionBank::findOrFail($id);
 
             if ($input['is_child'] ?? false) {
-                throw new Exception("Cannot edit a question's 'is_child' field");
+                return response()->json([
+                    'message' => "Cannot edit a question's 'is_child' field"
+                ], 400);
             }
 
             $arrayKeys = [
@@ -683,9 +695,9 @@ class QuestionBankController extends Controller
                     'guidance' => $input['guidance'] ?? $latestJson['guidance'],
                     'required' => $input['required'] ?? $latestJson['required'],
                 ];
+                $questionVersion = QuestionBankVersion::where('id', $latestVersion->id)->first();
 
-                $questionVersion = QuestionBankVersion::update([
-                    'id' => $latestVersion->id,
+                $questionVersion = $questionVersion->update([
                     'question_json' => json_encode($questionJson),
                     'required' => $input['required'] ?? $latestVersion->required,
                     'default' => $input['default'] ?? $latestVersion->default,
@@ -787,7 +799,9 @@ class QuestionBankController extends Controller
 
             $question = QuestionBank::findOrFail($id);
             if ($question->is_child) {
-                throw new Exception('Cannot delete a child question directly');
+                return response()->json([
+                    'message' => 'Cannot delete a child question directly'
+                ], 400);
             }
 
             // For each version of this question, check its children.

--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -242,7 +242,7 @@ class QuestionBankController extends Controller
                 'question_json' => json_encode($questionJson),
                 'required' => $input['required'],
                 'default' => $input['default'],
-                'question_parent_id' => $question->id,
+                'question_id' => $question->id,
                 'version' => 1,
             ]);
 
@@ -389,7 +389,7 @@ class QuestionBankController extends Controller
                 'question_json' => json_encode($questionJson),
                 'required' => $input['required'],
                 'default' => $input['default'],
-                'question_parent_id' => $question->id,
+                'question_id' => $question->id,
                 'version' => $latestVersion->version + 1,
             ]);
 
@@ -549,7 +549,7 @@ class QuestionBankController extends Controller
                     'question_json' => json_encode($questionJson),
                     'required' => isset($input['required']) ? $input['required'] : $latestVersion->required,
                     'default' => isset($input['default']) ? $input['default'] : $latestVersion->default,
-                    'question_parent_id' => $id,
+                    'question_id' => $id,
                     'version' => $latestVersion->version + 1,
                 ]);
             }
@@ -649,7 +649,7 @@ class QuestionBankController extends Controller
             //            $question->deleted_at = Carbon::now();
             $question->delete();
 
-            QuestionBankVersion::where('question_parent_id', $id)->delete();
+            QuestionBankVersion::where('question_id', $id)->delete();
             QuestionHasTeam::where('qb_question_id', $id)->delete();
 
             Auditor::log([

--- a/app/Models/QuestionBank.php
+++ b/app/Models/QuestionBank.php
@@ -38,6 +38,7 @@ class QuestionBank extends Model
         'archived_date',
         'force_required',
         'allow_guidance_override',
+        'is_child',
     ];
 
     /**

--- a/app/Models/QuestionBank.php
+++ b/app/Models/QuestionBank.php
@@ -56,12 +56,12 @@ class QuestionBank extends Model
      */
     public function versions(): HasMany
     {
-        return $this->hasMany(QuestionBankVersion::class, 'question_parent_id');
+        return $this->hasMany(QuestionBankVersion::class, 'question_id');
     }
 
     public function latestVersion(): HasOne
     {
-        return $this->hasOne(QuestionBankVersion::class, 'question_parent_id')
+        return $this->hasOne(QuestionBankVersion::class, 'question_id')
             ->orderBy('version', 'desc');
     }
 

--- a/app/Models/QuestionBankVersion.php
+++ b/app/Models/QuestionBankVersion.php
@@ -28,7 +28,7 @@ class QuestionBankVersion extends Model
     public $timestamps = true;
 
     protected $fillable = [
-        'question_parent_id',
+        'question_id',
         'version',
         'default',
         'required',
@@ -48,7 +48,7 @@ class QuestionBankVersion extends Model
      */
     public function question(): belongsTo
     {
-        return $this->belongsTo(QuestionBank::class, 'question_parent_id');
+        return $this->belongsTo(QuestionBank::class, 'question_id');
     }
 
 }

--- a/app/Models/QuestionBankVersion.php
+++ b/app/Models/QuestionBankVersion.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class QuestionBankVersion extends Model
 {
@@ -51,4 +52,23 @@ class QuestionBankVersion extends Model
         return $this->belongsTo(QuestionBank::class, 'question_id');
     }
 
+    public function childVersions(): belongsToMany
+    {
+        return $this->belongsToMany(
+            QuestionBankVersion::class,
+            'question_bank_version_has_child_version',
+            'parent_qbv_id',
+            'child_qbv_id'
+        );
+    }
+
+    public function parentVersion(): belongsTo
+    {
+        return $this->belongsTo(
+            QuestionBankVersion::class,
+            'question_bank_version_has_child_version',
+            'child_qbv_id',
+            'parent_qbv_id'
+        );
+    }
 }

--- a/app/Models/QuestionBankVersionHasChildVersion.php
+++ b/app/Models/QuestionBankVersionHasChildVersion.php
@@ -5,12 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class QuestionBankVersionHasChildVersion extends Model
 {
     use HasFactory;
     use Notifiable;
+    use SoftDeletes;
     use Prunable;
 
     public $timestamps = false;

--- a/app/Models/QuestionBankVersionHasChildVersion.php
+++ b/app/Models/QuestionBankVersionHasChildVersion.php
@@ -5,14 +5,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class QuestionBankVersionHasChildVersion extends Model
 {
     use HasFactory;
     use Notifiable;
-    use SoftDeletes;
     use Prunable;
 
     public $timestamps = false;

--- a/app/Models/QuestionBankVersionHasChildVersion.php
+++ b/app/Models/QuestionBankVersionHasChildVersion.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class QuestionBankVersionHasChildVersion extends Model
+{
+    use HasFactory;
+    use Notifiable;
+    use SoftDeletes;
+    use Prunable;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'parent_qbv_id', 'child_qbv_id', 'condition'
+    ];
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'question_bank_version_has_child_version';
+
+}

--- a/database/migrations/2024_11_25_142600_nested_dar_questions.php
+++ b/database/migrations/2024_11_25_142600_nested_dar_questions.php
@@ -14,13 +14,14 @@ return new class () extends Migration {
             $table->boolean('is_child')->default(false);
         });
         Schema::create('question_bank_version_has_child_version', function (Blueprint $table) {
-            $table->id();
             $table->bigInteger('parent_qbv_id')->unsigned();
             $table->bigInteger('child_qbv_id')->unsigned();
             $table->string('condition')->nullable();
-            $table->foreign('parent_qbv_id')->references('id')->on('question_bank_versions');
-            $table->foreign('child_qbv_id')->references('id')->on('question_bank_versions');
+            $table->foreign('parent_qbv_id')->references('id')->on('question_bank_versions')->onDelete('cascade');
+            $table->foreign('child_qbv_id')->references('id')->on('question_bank_versions')->onDelete('cascade');
             $table->index('parent_qbv_id');
+            $table->primary(['parent_qbv_id', 'child_qbv_id']);
+
         });
 
     }

--- a/database/migrations/2024_11_25_142600_nested_dar_questions.php
+++ b/database/migrations/2024_11_25_142600_nested_dar_questions.php
@@ -14,6 +14,7 @@ return new class () extends Migration {
             $table->boolean('is_child')->default(false);
         });
         Schema::create('question_bank_version_has_child_version', function (Blueprint $table) {
+            $table->softDeletes();
             $table->bigInteger('parent_qbv_id')->unsigned();
             $table->bigInteger('child_qbv_id')->unsigned();
             $table->string('condition')->nullable();

--- a/database/migrations/2024_11_25_142600_nested_dar_questions.php
+++ b/database/migrations/2024_11_25_142600_nested_dar_questions.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->boolean('is_child')->default(false);
+        });
+        Schema::create('question_bank_version_has_child_version', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('parent_qbv_id')->unsigned();
+            $table->bigInteger('child_qbv_id')->unsigned();
+            $table->string('condition')->nullable();
+            $table->foreign('parent_qbv_id')->references('id')->on('question_bank_versions');
+            $table->foreign('child_qbv_id')->references('id')->on('question_bank_versions');
+            $table->index('parent_qbv_id');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('question_bank_version_has_child_version', function (Blueprint $table) {
+            $table->dropForeign(['parent_qbv_id']);
+            $table->dropForeign(['child_qbv_id']);
+        });
+
+        Schema::table('question_bank_version_has_child_version', function (Blueprint $table) {
+            $table->dropIndex('question_bank_version_has_child_version_parent_qbv_id_index');
+        });
+
+        Schema::dropIfExists('question_bank_version_has_child_version');
+
+        Schema::table('question_bank_questions', function (Blueprint $table) {
+            $table->dropColumn('is_child');
+        });
+    }
+};

--- a/database/migrations/2024_12_09_120302_rename_question_parent_id.php
+++ b/database/migrations/2024_12_09_120302_rename_question_parent_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // This reduces confusion about "parent question" to a version, vs "parent-child" relationship between nested versions.
+        Schema::table('question_bank_version', function (Blueprint $table) {
+            $table->dropIndex('question_parent_id');
+            $table->renameColumn('question_parent_id', 'question_id');
+            $table->index('question_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('question_bank_version', function (Blueprint $table) {
+            $table->dropIndex('question_id');
+            $table->renameColumn('question_id', 'question_parent_id');
+            $table->index('question_parent_id');
+        });
+    }
+};

--- a/database/migrations/2024_12_09_120302_rename_question_parent_id.php
+++ b/database/migrations/2024_12_09_120302_rename_question_parent_id.php
@@ -11,8 +11,8 @@ return new class () extends Migration {
     public function up(): void
     {
         // This reduces confusion about "parent question" to a version, vs "parent-child" relationship between nested versions.
-        Schema::table('question_bank_version', function (Blueprint $table) {
-            $table->dropIndex('question_parent_id');
+        Schema::table('question_bank_versions', function (Blueprint $table) {
+            $table->dropIndex('question_bank_versions_question_parent_id_index');
             $table->renameColumn('question_parent_id', 'question_id');
             $table->index('question_id');
         });
@@ -23,8 +23,8 @@ return new class () extends Migration {
      */
     public function down(): void
     {
-        Schema::table('question_bank_version', function (Blueprint $table) {
-            $table->dropIndex('question_id');
+        Schema::table('question_bank_versions', function (Blueprint $table) {
+            $table->dropIndex('question_bank_versions_question_id_index');
             $table->renameColumn('question_id', 'question_parent_id');
             $table->index('question_parent_id');
         });

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -53,7 +53,6 @@ class QuestionBankSeeder extends Seeder
                             'user_id' => 1,
                             'locked' => 0,
                             'archived' => 0,
-                            'team_id' => 1,
                             'archived_date' => null,
                             'force_required' => $question['required'],
                             'allow_guidance_override' => 1,

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -4,6 +4,8 @@ namespace Database\Seeders;
 
 use App\Models\QuestionBank;
 use App\Models\QuestionBankVersion;
+use App\Models\QuestionBankVersionHasChildVersion;
+use App\Models\QuestionHasTeam;
 use App\Models\DataAccessSection;
 
 
@@ -19,9 +21,10 @@ class QuestionBankSeeder extends Seeder
 
 
         DataAccessSection::truncate();
-        QuestionBank::truncate();
-        QuestionBankVersion::truncate();
-
+        QuestionHasTeam::truncate();
+        QuestionBankVersionHasChildVersion::truncate();
+        \DB::table('question_bank_versions')->delete();
+        \DB::table('question_bank_questions')->delete();
 
         $path = storage_path() . '/migration_files/question_bank_data.json';
         $jsonString = file_get_contents($path);
@@ -36,7 +39,6 @@ class QuestionBankSeeder extends Seeder
                 'parent_section' => null,
                 'order' => $count,
             ]);
-
 
             foreach ($section['subSections'] as $subSection) {
                 $subSectionModel = DataAccessSection::create([
@@ -56,9 +58,15 @@ class QuestionBankSeeder extends Seeder
                             'archived_date' => null,
                             'force_required' => $question['required'],
                             'allow_guidance_override' => 1,
+                            'is_child' => 0,
                     ]);
 
-                    QuestionBankVersion::create([
+                    QuestionHasTeam::create([
+                        'qb_question_id' => $questionModel->id,
+                        'team_id' => 1,
+                    ]);
+
+                    $questionVersionModel = QuestionBankVersion::create([
                         'question_id' => $questionModel->id,
                         'version' => 1,
                         'required' => $questionModel->force_required,
@@ -66,6 +74,58 @@ class QuestionBankSeeder extends Seeder
                         'question_json' => json_encode($question),
                         'deleted_at' => null,
                     ]);
+
+                    if (in_array($question['field']['component'], ['RadioGroup', 'CheckboxGroup'])) {
+                        foreach ($question['field']['options'] as $option) {
+                            if ($option['conditional']) {
+                                foreach ($option['conditional'] as $subquestion) {
+                                    $subquestionModel = QuestionBank::create([
+                                        'section_id' => $subSectionModel->id,
+                                        'user_id' => 1,
+                                        'locked' => 0,
+                                        'archived' => 0,
+                                        'archived_date' => null,
+                                        'force_required' => $question['required'],
+                                        'allow_guidance_override' => 1,
+                                        'is_child' => 1,
+                                    ]);
+
+                                    $subquestionJson = [
+                                        'field' => $subquestion,
+                                        'title' => $subquestion['question'] ?? '',
+                                        'guidance' => '',
+                                        'required' => $question['required'],
+                                    ];
+
+                                    $subquestionVersionModel = QuestionBankVersion::create([
+                                        'question_id' => $subquestionModel->id,
+                                        'version' => 1,
+                                        'required' => $subquestionModel->force_required,
+                                        'default' => 0,
+                                        'question_json' => json_encode($subquestionJson),
+                                        'deleted_at' => null,
+                                    ]);
+                                    QuestionBankVersionHasChildVersion::create([
+                                        'parent_qbv_id' => $questionVersionModel->id,
+                                        'child_qbv_id' => $subquestionVersionModel->id,
+                                        'condition' => $option['value'],
+                                    ]);
+                                    QuestionHasTeam::create([
+                                        'qb_question_id' => $subquestionModel->id,
+                                        'team_id' => 1,
+                                    ]);
+                                }
+                            }
+                        }
+                    } else {
+                        // This should never trigger based on the contents of the migration file, but here for safety
+                        foreach ($question['field']['options'] as $option) {
+                            var_dump($question);
+                            if ($option['conditional']) {
+                                var_dump('warning, subquestion not created due to incorrect parent question type');
+                            }
+                        }
+                    }
                 }
             }
 

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -53,6 +53,7 @@ class QuestionBankSeeder extends Seeder
                             'user_id' => 1,
                             'locked' => 0,
                             'archived' => 0,
+                            'team_id' => 1,
                             'archived_date' => null,
                             'force_required' => $question['required'],
                             'allow_guidance_override' => 1,

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -59,7 +59,7 @@ class QuestionBankSeeder extends Seeder
                     ]);
 
                     QuestionBankVersion::create([
-                        'question_parent_id' => $questionModel->id,
+                        'question_id' => $questionModel->id,
                         'version' => 1,
                         'required' => $questionModel->force_required,
                         'default' => 0,

--- a/tests/Feature/EmailServiceTest.php
+++ b/tests/Feature/EmailServiceTest.php
@@ -21,10 +21,11 @@ class EmailServiceTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp([
+        parent::setUp();
+
+        $this->seed([
             EmailTemplateSeeder::class,
         ]);
-        $this->seed();
 
         Bus::fake();
     }

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -172,6 +172,7 @@ class QuestionBankTest extends TestCase
      */
     public function test_the_application_can_create_a_question()
     {
+        $countBefore = QuestionHasTeam::all()->count();
         $response = $this->json(
             'POST',
             'api/v1/questions',
@@ -211,7 +212,7 @@ class QuestionBankTest extends TestCase
             Config::get('statuscodes.STATUS_CREATED.message')
         );
 
-        $this->assertEquals(QuestionHasTeam::all()->count(), Team::all()->count());
+        $this->assertEquals(QuestionHasTeam::all()->count(), $countBefore + Team::all()->count());
 
         // now test with a nested set of questions
         $response = $this->json(
@@ -313,7 +314,7 @@ class QuestionBankTest extends TestCase
             Config::get('statuscodes.STATUS_CREATED.message')
         );
 
-        $this->assertEquals(QuestionHasTeam::all()->count(), 6 * Team::all()->count());
+        $this->assertEquals(QuestionHasTeam::all()->count(), $countBefore + 6 * Team::all()->count());
 
     }
 
@@ -824,6 +825,8 @@ class QuestionBankTest extends TestCase
      */
     public function test_it_can_delete_a_question()
     {
+        $countBefore = QuestionHasTeam::all()->count()
+
         $response = $this->json(
             'POST',
             'api/v1/questions',
@@ -854,7 +857,7 @@ class QuestionBankTest extends TestCase
         $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
         $content = $response->decodeResponseJson();
 
-        $this->assertEquals(QuestionHasTeam::all()->count(), Team::all()->count());
+        $this->assertEquals(QuestionHasTeam::all()->count(), $countBefore + Team::all()->count());
 
         $response = $this->json(
             'DELETE',
@@ -868,7 +871,7 @@ class QuestionBankTest extends TestCase
                 'message',
             ]);
 
-        $this->assertEquals(QuestionHasTeam::all()->count(), 0);
+        $this->assertEquals(QuestionHasTeam::all()->count(), $countBefore);
 
     }
 }

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -825,7 +825,7 @@ class QuestionBankTest extends TestCase
      */
     public function test_it_can_delete_a_question()
     {
-        $countBefore = QuestionHasTeam::all()->count()
+        $countBefore = QuestionHasTeam::all()->count();
 
         $response = $this->json(
             'POST',

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -58,6 +58,7 @@ class QuestionBankTest extends TestCase
                         'archived_date',
                         'force_required',
                         'allow_guidance_override',
+                        'is_child',
                     ],
                 ],
                 'first_page_url',
@@ -104,7 +105,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );
@@ -131,7 +133,8 @@ class QuestionBankTest extends TestCase
                     'archived',
                     'archived_date',
                     'force_required',
-                    'allow_guidance_override'
+                    'allow_guidance_override',
+                    'is_child',
                 ],
             ]);
     }
@@ -177,7 +180,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );
@@ -255,7 +259,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );
@@ -284,7 +289,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );
@@ -336,7 +342,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );
@@ -433,7 +440,8 @@ class QuestionBankTest extends TestCase
                 'guidance' => 'Something helpful',
                 'required' => 0,
                 'default' => 0,
-                'version' => 1
+                'version' => 1,
+                'is_child' => 0,
             ],
             $this->header
         );


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Adds nested question functionality to DAM.

Also renames `QuestionBankVersion::question_parent_id` to `question_id` to reduce confusion between the terminology used between nested questions (parent-child) and a `QuestionBankVersion` and its associated `QuestionBank` question.

~~This will be followed be a further PR that updates the QuestionBankSeeder to parse the migrated questions into this nested form. Keeping that out of this one for sanity's sake.~~
Update: I have also updated the Seeder just to keep it in one place

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5782

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Yes - 2 migrations, plus rerun the QuestionBankSeeder: `php artisan db:seed --class=QuestionBankSeeder` ⚠️ note that this _will drop all contents from the questions tables_ (`dar_sections`, `qb_question_has_team`, `question_bank_version_has_child_version`, `question_bank_versions`, `question_bank_questions`), so should only be run once, before any users make any changes to questions.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
