### PR TITLE
Add DAR applications, template and sections endpoints and tests

### DIFF
--- a/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
@@ -1,0 +1,503 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Config;
+use Auditor;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Traits\RequestTransformation;
+use App\Http\Requests\DataAccessApplication\GetDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\EditDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\CreateDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\DeleteDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\UpdateDataAccessApplication;
+use App\Models\DataAccessApplication;
+
+class DataAccessApplicationController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/applications",
+     *      summary="List of DAR applications",
+     *      description="List of DAR applications",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                      @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                      @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $applications = DataAccessApplication::paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication get all',
+            ]);
+
+            return response()->json(
+                $applications
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/applications/{id}",
+     *      summary="Return a single DAR application",
+     *      description="Return a single DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@show",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                  @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                  @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function show(GetDataAccessApplication $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $application = DataAccessApplication::findOrFail($id);
+
+            if ($application) {
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'GET',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataAccessApplication get ' . $id,
+                ]);
+
+                return response()->json([
+                    'message' => Config::get('statuscodes.STATUS_OK.message'),
+                    'data' => $application,
+                ], Config::get('statuscodes.STATUS_OK.code'));
+            }
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')
+            ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/dar/applications",
+     *      summary="Create a new DAR application",
+     *      description="Creates a new DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@store",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessApplication definition",
+     *          @OA\JsonContent(
+     *              required={},
+     *              @OA\Property(property="applicant_id", type="integer", example="1"),
+     *              @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *              @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="success"),
+     *             @OA\Property(property="data", type="integer", example="100")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function store(CreateDataAccessApplication $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $application = DataAccessApplication::create([
+                'applicant_id' => isset($input['applicant_id']) ? $input['applicant_id'] : $jwtUser['id'],
+                'submission_status' => isset($input['submission_status']) ? $input['submission_status'] : 'DRAFT',
+            ]);
+
+            // application has questions
+            // TODO update with template merging logic
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'CREATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication ' . $application->id . ' created',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_CREATED.message'),
+                'data' => $application->id,
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *      path="/api/v1/dar/applications/{id}",
+     *      summary="Update a system DAR application",
+     *      description="Update a system DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessApplication definition",
+     *          @OA\JsonContent(
+     *              required={"applicant_id","submission_status","approval_status"},
+     *              @OA\Property(property="applicant_id", type="integer", example="1"),
+     *              @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *              @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                  @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                  @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function update(UpdateDataAccessApplication $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $application = DataAccessApplication::findOrFail($id);
+
+            $application->update([
+                'applicant_id' => $input['applicant_id'],
+                'submission_status' => $input['submission_status'],
+                'approval_status' => isset($input['approval_status']) ? $input['approval_status'] : $application->approval_status,
+            ]);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessApplication::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *      path="/api/v1/dar/applications/{id}",
+     *      summary="Edit a system DAR application",
+     *      description="Edit a system DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessApplication definition",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="applicant_id", type="integer", example="1"),
+     *              @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *              @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                  @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                  @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function edit(EditDataAccessApplication $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $application = DataAccessApplication::findOrFail($id);
+
+            $arrayKeys = [
+                'applicant_id',
+                'submission_status',
+                'approval_status',
+            ];
+            $array = $this->checkEditArray($input, $arrayKeys);
+            $application->update($array);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessApplication::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v1/dar/applications/{id}",
+     *      summary="Delete a system DAR application",
+     *      description="Delete a system DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@destroy",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroy(DeleteDataAccessApplication $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $application = DataAccessApplication::findOrFail($id);
+            $application->delete();
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication ' . $id . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/DataAccessSectionController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessSectionController.php
@@ -1,0 +1,516 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Config;
+use Auditor;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Traits\RequestTransformation;
+use App\Http\Requests\DataAccessSection\GetDataAccessSection;
+use App\Http\Requests\DataAccessSection\EditDataAccessSection;
+use App\Http\Requests\DataAccessSection\CreateDataAccessSection;
+use App\Http\Requests\DataAccessSection\DeleteDataAccessSection;
+use App\Http\Requests\DataAccessSection\UpdateDataAccessSection;
+use App\Models\DataAccessSection;
+
+class DataAccessSectionController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/sections",
+     *      summary="List of DAR sections",
+     *      description="List of DAR sections",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="name", type="string", example="Safe People"),
+     *                      @OA\Property(property="description", type="string", example="Who has access?"),
+     *                      @OA\Property(property="parent_section", type="integer", example="1"),
+     *                      @OA\Property(property="order", type="integer", example="1"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $sections = DataAccessSection::paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessSection get all',
+            ]);
+
+            return response()->json(
+                $sections
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/sections/{id}",
+     *      summary="Return a single DAR section",
+     *      description="Return a single DAR section",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@show",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR section id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR section id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Safe People"),
+     *                  @OA\Property(property="description", type="string", example="Who has access?"),
+     *                  @OA\Property(property="parent_section", type="integer", example="1"),
+     *                  @OA\Property(property="order", type="integer", example="1"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function show(GetDataAccessSection $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $section = DataAccessSection::findOrFail($id);
+
+            if ($section) {
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'GET',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataAccessSection get ' . $id,
+                ]);
+
+                return response()->json([
+                    'message' => Config::get('statuscodes.STATUS_OK.message'),
+                    'data' => $section,
+                ], Config::get('statuscodes.STATUS_OK.code'));
+            }
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')
+            ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/dar/sections",
+     *      summary="Create a new DAR section",
+     *      description="Creates a new DAR section",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@store",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessSection definition",
+     *          @OA\JsonContent(
+     *              required={"name","description","order"},
+     *              @OA\Property(property="name", type="string", example="Safe People"),
+     *              @OA\Property(property="description", type="string", example="Who has access?"),
+     *              @OA\Property(property="parent_section", type="integer", example="1"),
+     *              @OA\Property(property="order", type="integer", example="1"),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="success"),
+     *             @OA\Property(property="data", type="integer", example="100")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function store(CreateDataAccessSection $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $section = DataAccessSection::create([
+                'name' => $input['name'],
+                'description' => $input['description'],
+                'parent_section' => $input['parent_section'] ?? null,
+                'order' => $input['order'],
+            ]);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'CREATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessSection ' . $section->id . ' created',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_CREATED.message'),
+                'data' => $section->id,
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *      path="/api/v1/dar/sections/{id}",
+     *      summary="Update a system DAR section",
+     *      description="Update a system DAR section",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR section id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR section id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessSection definition",
+     *          @OA\JsonContent(
+     *              required={"name","description","order"},
+     *              @OA\Property(property="name", type="string", example="Safe People"),
+     *              @OA\Property(property="description", type="string", example="Who has access?"),
+     *              @OA\Property(property="parent_section", type="integer", example="1"),
+     *              @OA\Property(property="order", type="integer", example="1"),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Safe People"),
+     *                  @OA\Property(property="description", type="string", example="Who has access?"),
+     *                  @OA\Property(property="parent_section", type="integer", example="1"),
+     *                  @OA\Property(property="order", type="integer", example="1"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function update(UpdateDataAccessSection $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $section = DataAccessSection::findOrFail($id);
+
+            $section->update([
+                'name' => $input['name'],
+                'description' => $input['description'],
+                'parent_section' => $input['parent_section'] ?? $section->parent_section,
+                'order' => $input['order'],
+            ]);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessSection ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessSection::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *      path="/api/v1/dar/sections/{id}",
+     *      summary="Edit a system DAR section",
+     *      description="Edit a system DAR section",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR section id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR section id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessSection definition",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="name", type="string", example="Safe People"),
+     *              @OA\Property(property="description", type="string", example="Who has access?"),
+     *              @OA\Property(property="parent_section", type="integer", example="1"),
+     *              @OA\Property(property="order", type="integer", example="1"),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Safe People"),
+     *                  @OA\Property(property="description", type="string", example="Who has access?"),
+     *                  @OA\Property(property="parent_section", type="integer", example="1"),
+     *                  @OA\Property(property="order", type="integer", example="1"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function edit(EditDataAccessSection $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $section = DataAccessSection::findOrFail($id);
+
+            $arrayKeys = [
+                'name',
+                'description',
+                'parent_section',
+                'order',
+            ];
+            $array = $this->checkEditArray($input, $arrayKeys);
+            $section->update($array);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessSection ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessSection::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v1/dar/sections/{id}",
+     *      summary="Delete a system DAR section",
+     *      description="Delete a system DAR section",
+     *      tags={"DataAccessSection"},
+     *      summary="DataAccessSection@destroy",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR section id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR section id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroy(DeleteDataAccessSection $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $section = DataAccessSection::findOrFail($id);
+            $section->delete();
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessSection ' . $id . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
@@ -1,0 +1,559 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Config;
+use Auditor;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Traits\RequestTransformation;
+use App\Http\Requests\DataAccessTemplate\GetDataAccessTemplate;
+use App\Http\Requests\DataAccessTemplate\EditDataAccessTemplate;
+use App\Http\Requests\DataAccessTemplate\CreateDataAccessTemplate;
+use App\Http\Requests\DataAccessTemplate\DeleteDataAccessTemplate;
+use App\Http\Requests\DataAccessTemplate\UpdateDataAccessTemplate;
+use App\Models\DataAccessTemplate;
+use App\Models\DataAccessTemplateHasQuestion;
+use App\Models\QuestionBank;
+
+class DataAccessTemplateController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/templates",
+     *      summary="List of DAR templates",
+     *      description="List of DAR templates",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="team_id", type="integer", example="1"),
+     *                      @OA\Property(property="user_id", type="integer", example="1"),
+     *                      @OA\Property(property="published", type="boolean", example="true"),
+     *                      @OA\Property(property="locked", type="boolean", example="false"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $templates = DataAccessTemplate::paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate get all',
+            ]);
+
+            return response()->json(
+                $templates
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/dar/templates/{id}",
+     *      summary="Return a single DAR template",
+     *      description="Return a single DAR template",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@show",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR template id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR template id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="team_id", type="integer", example="1"),
+     *                  @OA\Property(property="user_id", type="integer", example="1"),
+     *                  @OA\Property(property="published", type="boolean", example="true"),
+     *                  @OA\Property(property="locked", type="boolean", example="false"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function show(GetDataAccessTemplate $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $template = DataAccessTemplate::with('questions')->findOrFail($id);
+
+            if ($template) {
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'GET',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataAccessTemplate get ' . $id,
+                ]);
+
+                return response()->json([
+                    'message' => Config::get('statuscodes.STATUS_OK.message'),
+                    'data' => $template,
+                ], Config::get('statuscodes.STATUS_OK.code'));
+            }
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')
+            ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/dar/templates",
+     *      summary="Create a new DAR template",
+     *      description="Creates a new DAR template",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@store",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessTemplate definition",
+     *          @OA\JsonContent(
+     *              required={"team_id"},
+     *              @OA\Property(property="team_id", type="integer", example="1"),
+     *              @OA\Property(property="user_id", type="integer", example="1"),
+     *              @OA\Property(property="published", type="boolean", example="true"),
+     *              @OA\Property(property="locked", type="boolean", example="false"),
+     *              @OA\Property(property="questions", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="1"),
+     *                      @OA\Property(property="guidance", type="string", example="Custom guidance"),
+     *                      @OA\Property(property="required", type="boolean", example="true"),
+     *                      @OA\Property(property="order", type="integer", example="1"),
+     *                  )
+     *              ),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="success"),
+     *             @OA\Property(property="data", type="integer", example="100")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function store(CreateDataAccessTemplate $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $template = DataAccessTemplate::create([
+                'user_id' => isset($input['user_id']) ? $input['user_id'] : $jwtUser['id'],
+                'team_id' => $input['team_id'],
+                'published' => isset($input['published']) ? $input['published'] : false,
+                'locked' => isset($input['locked']) ? $input['locked'] : false,
+            ]);
+
+            if (isset($input['questions'])) {
+                $this->insertTemplateHasQuestions($input['questions'], $template);
+            }
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'CREATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate ' . $template->id . ' created',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_CREATED.message'),
+                'data' => $template->id,
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *      path="/api/v1/dar/templates/{id}",
+     *      summary="Update a system DAR template",
+     *      description="Update a system DAR template",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR template id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR template id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessTemplate definition",
+     *          @OA\JsonContent(
+     *              required={"team_id"},
+     *              @OA\Property(property="team_id", type="integer", example="1"),
+     *              @OA\Property(property="user_id", type="integer", example="1"),
+     *              @OA\Property(property="published", type="boolean", example="true"),
+     *              @OA\Property(property="locked", type="boolean", example="false"),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="team_id", type="integer", example="1"),
+     *                  @OA\Property(property="user_id", type="integer", example="1"),
+     *                  @OA\Property(property="published", type="boolean", example="true"),
+     *                  @OA\Property(property="locked", type="boolean", example="false"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function update(UpdateDataAccessTemplate $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $template = DataAccessTemplate::findOrFail($id);
+
+            $template->update([
+                'user_id' => isset($input['user_id']) ? $input['user_id'] : $jwtUser['id'],
+                'team_id' => $input['team_id'],
+                'published' => isset($input['published']) ? $input['published'] : $template->published,
+                'locked' => isset($input['locked']) ? $input['locked'] : $template->locked,
+            ]);
+
+            if (isset($input['questions'])) {
+                DataAccessTemplateHasQuestion::where('template_id', $id)->delete();
+                $this->insertTemplateHasQuestions($input['questions'], $template);
+            }
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessTemplate::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *      path="/api/v1/dar/templates/{id}",
+     *      summary="Edit a system DAR template",
+     *      description="Edit a system DAR template",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR template id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR template id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataAccessTemplate definition",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="applicant_id", type="integer", example="1"),
+     *              @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *              @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                  @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                  @OA\Property(property="approval_status", type="string", example="APPROVED"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function edit(EditDataAccessTemplate $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $template = DataAccessTemplate::findOrFail($id);
+
+            $arrayKeys = [
+                'team_id',
+                'user_id',
+                'published',
+                'locked',
+            ];
+            $array = $this->checkEditArray($input, $arrayKeys);
+            $template->update($array);
+
+            if (isset($input['questions'])) {
+                DataAccessTemplateHasQuestion::where('template_id', $id)->delete();
+                $this->insertTemplateHasQuestions($input['questions'], $template);
+            }
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => DataAccessTemplate::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v1/dar/templates/{id}",
+     *      summary="Delete a system DAR template",
+     *      description="Delete a system DAR template",
+     *      tags={"DataAccessTemplate"},
+     *      summary="DataAccessTemplate@destroy",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR template id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR template id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroy(DeleteDataAccessTemplate $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $template = DataAccessTemplate::findOrFail($id);
+            DataAccessTemplateHasQuestion::where('template_id', $template->id)->delete();
+            $template->delete();
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate ' . $id . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    private function insertTemplateHasQuestions(array $questions, DataAccessTemplate $template): void
+    {
+        $count = 1;
+        foreach ($questions as $q) {
+            $question = QuestionBank::where('id', $q['id'])->with('latestVersion')->first();
+            $isRequired = $question->force_required ? true : $q['required'] ?? false;
+            if (($question->allow_guidance_override) && isset($q['guidance'])) {
+                $guidance = $q['guidance'];
+            } else {
+                $questionContent = json_decode($question['latestVersion']['question_json'], true);
+                $guidance = $questionContent['guidance'];
+            }
+            DataAccessTemplateHasQuestion::create([
+                'template_id' => $template->id,
+                'question_id' => $question->id,
+                'guidance' => $guidance,
+                'required' => $isRequired,
+                'order' => $q['order'] ?? $count,
+            ]);
+            $count += 1;
+        }
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/CreateDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/CreateDataAccessApplication.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class CreateDataAccessApplication extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'applicant_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'submission_status' => [
+                'string',
+                'in:DRAFT,SUBMITTED,FEEDBACK'
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/DeleteDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/DeleteDataAccessApplication.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class DeleteDataAccessApplication extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/EditDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/EditDataAccessApplication.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class EditDataAccessApplication extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+            'applicant_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'submission_status' => [
+                'string',
+                'in:DRAFT,SUBMITTED,FEEDBACK',
+            ],
+            'approval_status' => [
+                'string',
+                'in:APPROVED,APPROVED_COMMENTS,REJECTED',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/GetDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/GetDataAccessApplication.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetDataAccessApplication extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/UpdateDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/UpdateDataAccessApplication.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class UpdateDataAccessApplication extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+            'applicant_id' => [
+                'integer',
+                'required',
+                'exists:users,id',
+            ],
+            'submission_status' => [
+                'string',
+                'required',
+                'in:DRAFT,SUBMITTED,FEEDBACK',
+            ],
+            'approval_status' => [
+                'string',
+                'in:APPROVED,APPROVED_COMMENTS,REJECTED',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessSection/CreateDataAccessSection.php
+++ b/app/Http/Requests/DataAccessSection/CreateDataAccessSection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessSection;
+
+use App\Http\Requests\BaseFormRequest;
+
+class CreateDataAccessSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+            ],
+            'description' => [
+                'required',
+                'string',
+            ],
+            'parent_section' => [
+                'integer',
+            ],
+            'order' => [
+                'required',
+                'integer',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/DataAccessSection/DeleteDataAccessSection.php
+++ b/app/Http/Requests/DataAccessSection/DeleteDataAccessSection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessSection;
+
+use App\Http\Requests\BaseFormRequest;
+
+class DeleteDataAccessSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_sections,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessSection/EditDataAccessSection.php
+++ b/app/Http/Requests/DataAccessSection/EditDataAccessSection.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\DataAccessSection;
+
+use App\Http\Requests\BaseFormRequest;
+
+class EditDataAccessSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_sections,id',
+            ],
+            'name' => [
+                'string',
+            ],
+            'description' => [
+                'string',
+            ],
+            'parent_section' => [
+                'integer',
+            ],
+            'order' => [
+                'integer',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessSection/GetDataAccessSection.php
+++ b/app/Http/Requests/DataAccessSection/GetDataAccessSection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessSection;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetDataAccessSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_sections,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessSection/UpdateDataAccessSection.php
+++ b/app/Http/Requests/DataAccessSection/UpdateDataAccessSection.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\DataAccessSection;
+
+use App\Http\Requests\BaseFormRequest;
+
+class UpdateDataAccessSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_sections,id',
+            ],
+            'name' => [
+                'required',
+                'string',
+            ],
+            'description' => [
+                'required',
+                'string',
+            ],
+            'parent_section' => [
+                'integer',
+            ],
+            'order' => [
+                'required',
+                'integer',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/CreateDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/CreateDataAccessTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class CreateDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'user_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'team_id' => [
+                'required',
+                'integer',
+                'exists:teams,id',
+            ],
+            'published' => [
+                'boolean',
+            ],
+            'locked' => [
+                'boolean',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/DeleteDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/DeleteDataAccessTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class DeleteDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_templates,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/EditDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/EditDataAccessTemplate.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class EditDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_templates,id',
+            ],
+            'user_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'team_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'published' => [
+                'boolean',
+            ],
+            'locked' => [
+                'boolean',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/GetDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/GetDataAccessTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_templates,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/UpdateDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/UpdateDataAccessTemplate.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class UpdateDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_templates,id',
+            ],
+            'user_id' => [
+                'integer',
+                'exists:users,id',
+            ],
+            'team_id' => [
+                'required',
+                'integer',
+                'exists:teams,id',
+            ],
+            'published' => [
+                'boolean',
+            ],
+            'locked' => [
+                'boolean',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Models/DataAccessApplicationAnswer.php
+++ b/app/Models/DataAccessApplicationAnswer.php
@@ -33,4 +33,14 @@ class DataAccessApplicationAnswer extends Model
     {
         return $this->belongsTo(User::class, 'contributor_id');
     }
+
+    public function application(): BelongsTo
+    {
+        return $this->belongsTo(DataAccessApplication::class, 'application_id');
+    }
+
+    public function question(): BelongsTo
+    {
+        return $this->belongsTo(QuestionBank::class, 'question_id');
+    }
 }

--- a/app/Models/DataAccessApplicationHasQuestion.php
+++ b/app/Models/DataAccessApplicationHasQuestion.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Prunable;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class DataAccessTemplateHasQuestion extends Model
+class DataAccessApplicationHasQuestion extends Model
 {
     use HasFactory;
     use Notifiable;
@@ -19,16 +19,16 @@ class DataAccessTemplateHasQuestion extends Model
      *
      * @var string
      */
-    protected $table = 'dar_template_has_questions';
+    protected $table = 'dar_application_has_questions';
 
     public $timestamps = false;
 
     protected $fillable = [
-        'template_id',
+        'application_id',
         'question_id',
         'guidance',
         'required',
-        'order'
+        'order',
+        'teams'
     ];
-
 }

--- a/app/Models/DataAccessSection.php
+++ b/app/Models/DataAccessSection.php
@@ -18,7 +18,8 @@ class DataAccessSection extends Model
 
     protected $fillable = [
         'name',
-        'sub_section',
+        'description',
+        'parent_section',
         'order',
     ];
 }

--- a/app/Models/DataAccessTemplate.php
+++ b/app/Models/DataAccessTemplate.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class DataAccessTemplate extends Model
@@ -39,5 +40,10 @@ class DataAccessTemplate extends Model
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);
+    }
+
+    public function questions(): HasMany
+    {
+        return $this->hasMany(DataAccessTemplateHasQuestion::class, 'template_id');
     }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -3723,4 +3723,241 @@ return [
             'id' => '[0-9]+',
         ],
     ],
+
+    // dar/applications
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => '/dar/applications',
+        'methodController' => 'DataAccessApplicationController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => '/dar/applications/{id}',
+        'methodController' => 'DataAccessApplicationController@show',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'post',
+        'path' => '/dar/applications',
+        'methodController' => 'DataAccessApplicationController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'put',
+        'path' => '/dar/applications/{id}',
+        'methodController' => 'DataAccessApplicationController@update',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'patch',
+        'path' => '/dar/applications/{id}',
+        'methodController' => 'DataAccessApplicationController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'delete',
+        'path' => '/dar/applications/{id}',
+        'methodController' => 'DataAccessApplicationController@destroy',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+
+    // dar/templates
+    [
+        'name' => 'dar/templates',
+        'method' => 'get',
+        'path' => '/dar/templates',
+        'methodController' => 'DataAccessTemplateController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'get',
+        'path' => '/dar/templates/{id}',
+        'methodController' => 'DataAccessTemplateController@show',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'post',
+        'path' => '/dar/templates',
+        'methodController' => 'DataAccessTemplateController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'put',
+        'path' => '/dar/templates/{id}',
+        'methodController' => 'DataAccessTemplateController@update',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'patch',
+        'path' => '/dar/templates/{id}',
+        'methodController' => 'DataAccessTemplateController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'delete',
+        'path' => '/dar/templates/{id}',
+        'methodController' => 'DataAccessTemplateController@destroy',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+
+    // dar/sections
+    [
+        'name' => 'dar/sections',
+        'method' => 'get',
+        'path' => '/dar/sections',
+        'methodController' => 'DataAccessSectionController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/sections',
+        'method' => 'get',
+        'path' => '/dar/sections/{id}',
+        'methodController' => 'DataAccessSectionController@show',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/sections',
+        'method' => 'post',
+        'path' => '/dar/sections',
+        'methodController' => 'DataAccessSectionController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/sections',
+        'method' => 'put',
+        'path' => '/dar/sections/{id}',
+        'methodController' => 'DataAccessSectionController@update',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/sections',
+        'method' => 'patch',
+        'path' => '/dar/sections/{id}',
+        'methodController' => 'DataAccessSectionController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/sections',
+        'method' => 'delete',
+        'path' => '/dar/sections/{id}',
+        'methodController' => 'DataAccessSectionController@destroy',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
 ];

--- a/database/factories/DataAccessTemplateFactory.php
+++ b/database/factories/DataAccessTemplateFactory.php
@@ -3,7 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\User;
+use App\Models\Team;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DataAccessTemplate>
@@ -18,7 +18,7 @@ class DataAccessTemplateFactory extends Factory
     public function definition(): array
     {
         return [
-            'team_id' => User::all()->random()->id,
+            'team_id' => Team::all()->random()->id,
             'user_id' => 1,
             'published' => fake()->randomElement([0, 1]),
             'locked' => 0,

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Config;
+use Tests\TestCase;
+use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\DataAccessApplicationSeeder;
+
+use Tests\Traits\MockExternalApis;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+class DataAccessApplicationTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->seed([
+            MinimalUserSeeder::class,
+            DataAccessApplicationSeeder::class,
+        ]);
+    }
+
+    /**
+     * List all dar applications.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_dar_applications()
+    {
+        $response = $this->get('api/v1/dar/applications', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'applicant_id',
+                        'submission_status',
+                        'approval_status',
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
+     * Returns a single dar application
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_a_single_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+                'approval_status' => 'APPROVED_COMMENTS'
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+
+        $response = $this->get('api/v1/dar/applications/' . $content['data'], $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'applicant_id',
+                    'submission_status',
+                    'approval_status',
+                ],
+            ]);
+    }
+
+    /**
+     * Fails to return a single dar application
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_list_a_single_dar_application()
+    {
+        $beyondId = DB::table('dar_applications')->max('id') + 1;
+        $response = $this->get('api/v1/dar/applications/' . $beyondId, $this->header);
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'));
+    }
+
+    /**
+     * Creates a new dar application
+     *
+     * @return void
+     */
+    public function test_the_application_can_create_a_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+                'approval_status' => 'APPROVED_COMMENTS'
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        // Test application created with default values
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $response = $this->get('api/v1/dar/applications/' . $content['data'], $this->header);
+
+        $this->assertEquals('DRAFT', $response['data']['submission_status']);
+        $this->assertNull($response['data']['approval_status']);
+    }
+
+    /**
+     * Fails to create a new application
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_create_a_dar_application()
+    {
+        // Attempt to create application with incorrect values
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'INVALID',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'))
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'errors',
+            ]);
+    }
+
+    /**
+     * Tests that a dar application record can be updated
+     *
+     * @return void
+     */
+    public function test_the_application_can_update_a_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+
+        $response = $this->json(
+            'PUT',
+            'api/v1/dar/applications/' . $content['data'],
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'SUBMITTED',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($content['data']['submission_status'], 'SUBMITTED');
+    }
+
+    /**
+     * Tests that a dar application record can be edited
+     *
+     * @return void
+     */
+    public function test_the_application_can_edit_a_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+        $applicationId = $content['data'];
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/dar/applications/' . $applicationId,
+            [
+                'submission_status' => 'SUBMITTED',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($content['data']['submission_status'], 'SUBMITTED');
+        $this->assertNull($content['data']['approval_status']);
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/dar/applications/' . $applicationId,
+            [
+                'approval_status' => 'APPROVED',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($content['data']['approval_status'], 'APPROVED');
+    }
+
+    /**
+     * Tests it can delete a dar application
+     *
+     * @return void
+     */
+    public function test_it_can_delete_a_dar_application()
+    {
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+
+        $response = $this->json(
+            'DELETE',
+            'api/v1/dar/applications/' . $content['data'],
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+    }
+}

--- a/tests/Feature/DataAccessSectionTest.php
+++ b/tests/Feature/DataAccessSectionTest.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Config;
+use Tests\TestCase;
+use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\QuestionBankSeeder;
+
+use Tests\Traits\MockExternalApis;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+class DataAccessSectionTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->seed([
+            MinimalUserSeeder::class,
+            QuestionBankSeeder::class,
+        ]);
+    }
+
+    /**
+     * List all dar sections.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_dar_sections()
+    {
+        $response = $this->get('api/v1/dar/sections', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'name',
+                        'description',
+                        'parent_section',
+                        'order',
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
+     * Returns a single dar application
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_a_single_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A section',
+                'description' => 'A test section',
+                'order' => 1,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+
+        $response = $this->get('api/v1/dar/sections/' . $content['data'], $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'name',
+                    'description',
+                    'parent_section',
+                    'order',
+                ],
+            ]);
+    }
+
+    /**
+     * Fails to return a single dar section
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_list_a_single_dar_section()
+    {
+        $beyondId = DB::table('dar_sections')->max('id') + 1;
+        $response = $this->get('api/v1/dar/sections/' . $beyondId, $this->header);
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'));
+    }
+
+    /**
+     * Creates a new dar section
+     *
+     * @return void
+     */
+    public function test_the_application_can_create_a_dar_section()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A section',
+                'description' => 'A test section',
+                'order' => 1,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $response = $this->get('api/v1/dar/sections/' . $content['data'], $this->header);
+        // Test parent section defaulted to null
+        $this->assertNull($response['data']['parent_section']);
+    }
+
+    /**
+     * Fails to create a new section
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_create_a_dar_section()
+    {
+        // Attempt to create section with incomplete information
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A new section',
+                'order' => 1
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'))
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'errors',
+            ]);
+    }
+
+    /**
+     * Tests that a dar section record can be updated
+     *
+     * @return void
+     */
+    public function test_the_application_can_update_a_dar_section()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A section',
+                'description' => 'A test section',
+                'order' => 1,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+
+        $response = $this->json(
+            'PUT',
+            'api/v1/dar/sections/' . $content['data'],
+            [
+                'name' => 'A section',
+                'description' => 'Updated',
+                'order' => 1,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals('Updated', $content['data']['description']);
+        $this->assertEquals('A section', $content['data']['name']);
+    }
+
+    /**
+     * Tests that a dar section record can be edited
+     *
+     * @return void
+     */
+    public function test_the_application_can_edit_a_dar_section()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A section',
+                'description' => 'A test section',
+                'order' => 1,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+        $sectionId = $content['data'];
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/dar/sections/' . $sectionId,
+            [
+                'description' => 'Edited',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals('Edited', $content['data']['description']);
+        $this->assertEquals('A section', $content['data']['name']);
+    }
+
+    /**
+     * Tests it can delete a dar section
+     *
+     * @return void
+     */
+    public function test_it_can_delete_a_dar_section()
+    {
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/sections',
+            [
+                'name' => 'A section',
+                'description' => 'A test section',
+                'order' => 1,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+
+        $response = $this->json(
+            'DELETE',
+            'api/v1/dar/sections/' . $content['data'],
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+    }
+}

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace Tests\Feature;
+
+// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Config;
+use Tests\TestCase;
+use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\DataAccessTemplateSeeder;
+use Database\Seeders\QuestionBankSeeder;
+
+use Tests\Traits\MockExternalApis;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+class DataAccessTemplateTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->seed([
+            MinimalUserSeeder::class,
+            QuestionBankSeeder::class,
+            DataAccessTemplateSeeder::class,
+        ]);
+    }
+
+    /**
+     * List all dar templates.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_dar_templates()
+    {
+        $response = $this->get('api/v1/dar/templates', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'user_id',
+                        'team_id',
+                        'published',
+                        'locked',
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
+     * Returns a single dar application
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_a_single_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => false,
+                'locked' => false,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+
+        $response = $this->get('api/v1/dar/templates/' . $content['data'], $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'user_id',
+                    'team_id',
+                    'published',
+                    'locked',
+                    'questions',
+                ],
+            ]);
+    }
+
+    /**
+     * Fails to return a single dar template
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_list_a_single_dar_template()
+    {
+        $beyondId = DB::table('dar_templates')->max('id') + 1;
+        $response = $this->get('api/v1/dar/templates/' . $beyondId, $this->header);
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'));
+    }
+
+    /**
+     * Creates a new dar template
+     *
+     * @return void
+     */
+    public function test_the_application_can_create_a_dar_template()
+    {
+        // Create a question to associate with the template
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $questionId = $response->decodeResponseJson()['data'];
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => true,
+                'locked' => true,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                        'required' => true,
+                        'guidance' => 'Custom guidance',
+                        'order' => 2,
+                    ]
+                ]
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $response = $this->get('api/v1/dar/templates/' . $content['data'], $this->header);
+
+        $this->assertEquals(true, $response['data']['published']);
+        $this->assertEquals(true, $response['data']['locked']);
+
+        $this->assertEquals('Custom guidance', $response['data']['questions'][0]['guidance']);
+        $this->assertEquals(2, $response['data']['questions'][0]['order']);
+
+        // Test template created with default values
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                    ]
+                ]
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $response = $this->get('api/v1/dar/templates/' . $content['data'], $this->header);
+
+        $this->assertEquals(false, $response['data']['published']);
+        $this->assertEquals(false, $response['data']['locked']);
+
+        $this->assertEquals('Something helpful', $response['data']['questions'][0]['guidance']);
+        $this->assertEquals(1, $response['data']['questions'][0]['order']);
+    }
+
+    /**
+     * Fails to create a new template
+     *
+     * @return void
+     */
+    public function test_the_application_fails_to_create_a_dar_template()
+    {
+        // Attempt to create template when no team id provided
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'))
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'errors',
+            ]);
+    }
+
+    /**
+     * Tests that a dar template record can be updated
+     *
+     * @return void
+     */
+    public function test_the_application_can_update_a_dar_template()
+    {
+        // Create a question to associate with the template
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $questionId = $response->decodeResponseJson()['data'];
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => false,
+                'locked' => false,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                        'required' => true,
+                        'guidance' => 'Custom guidance',
+                        'order' => 2,
+                    ]
+                ]
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+        $templateId = $content['data'];
+
+        $response = $this->json(
+            'PUT',
+            'api/v1/dar/templates/' . $templateId,
+            [
+                'team_id' => 1,
+                'published' => true,
+                'locked' => true,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                        'required' => true,
+                        'guidance' => 'Custom guidance updated',
+                        'order' => 2,
+                    ]
+                ]
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $response = $this->get('api/v1/dar/templates/' . $templateId, $this->header);
+        $content = $response->decodeResponseJson();
+
+        $this->assertEquals(true, $content['data']['published']);
+        $this->assertEquals(true, $content['data']['locked']);
+        $this->assertEquals('Custom guidance updated', $content['data']['questions'][0]['guidance']);
+    }
+
+    /**
+     * Tests that a dar template record can be edited
+     *
+     * @return void
+     */
+    public function test_the_application_can_edit_a_dar_template()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => false,
+                'locked' => false,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+        $templateId = $content['data'];
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/dar/templates/' . $templateId,
+            [
+                'locked' => true,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(false, $content['data']['published']);
+        $this->assertEquals(true, $content['data']['locked']);
+    }
+
+    /**
+     * Tests it can delete a dar template
+     *
+     * @return void
+     */
+    public function test_it_can_delete_a_dar_template()
+    {
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => false,
+                'locked' => false,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $content = $response->decodeResponseJson();
+
+        $response = $this->json(
+            'DELETE',
+            'api/v1/dar/templates/' . $content['data'],
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Updates models and adds controllers with basic CRUD operations for DAR related objects (DataAccessApplications, DataAccessSections and DataAccessTemplate). 

The more complex logic and bespoke endpoints are not included (e.g. merging DAR templates, saving answers) because these will be addressed in future tickets (https://hdruk.atlassian.net/browse/GAT-5899, https://hdruk.atlassian.net/browse/GAT-5848). 

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5897

## Environment / Configuration changes (if applicable)

No

## Requires migrations being run?

No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
