### PR TITLE
fix: (GAT-5969) - script to change publisher name and id

### DIFF
--- a/app/Console/Commands/ChangeMetaPublisher.php
+++ b/app/Console/Commands/ChangeMetaPublisher.php
@@ -68,26 +68,22 @@ class ChangeMetaPublisher extends Command
                         if (isset($metadata['metadata']['summary']['publisher'])) {
                             $metadata['metadata']['summary']['publisher']['name'] = $team->name;
                             $metadata['metadata']['summary']['publisher']['gatewayId'] = $targetPublisherId;
-
-    
                             $latestVersion->metadata = json_encode($metadata);
-
-
                             $latestVersion->save();
 
                             $this->info('Metadata updated for Dataset ID ' . $dataset->id);
                         } else {
-                            $this->error('Publisher field not found in metadata for Dataset ID ' . $dataset->id);
+                            $this->warn('Publisher field not found in metadata for Dataset ID ' . $dataset->id);
                         }
                     } else {
-                        $this->error('Latest version not found for Dataset ID ' . $dataset->id);
+                        $this->warn('Latest version not found for Dataset ID ' . $dataset->id);
                     }
                 } else {
-                    $this->error('Dataset not found for ID ' . $item);
+                    $this->warn('Dataset not found for ID ' . $item);
                 }
             }
         } else {
-            $this->error('Team not found for Publisher ID ' . $targetPublisherId);
+            $this->warn('Team not found for Publisher ID ' . $targetPublisherId);
         }
     }
 }

--- a/app/Console/Commands/ChangeMetaPublisher.php
+++ b/app/Console/Commands/ChangeMetaPublisher.php
@@ -68,7 +68,7 @@ class ChangeMetaPublisher extends Command
                         if (isset($metadata['metadata']['summary']['publisher'])) {
                             $metadata['metadata']['summary']['publisher']['name'] = $team->name;
                             $metadata['metadata']['summary']['publisher']['gatewayId'] = $targetPublisherId;
-                            $latestVersion->metadata = json_encode($metadata);
+                            $latestVersion->metadata = $metadata;
                             $latestVersion->save();
 
                             $this->info('Metadata updated for Dataset ID ' . $dataset->id);

--- a/app/Console/Commands/ChangeMetaPublisher.php
+++ b/app/Console/Commands/ChangeMetaPublisher.php
@@ -46,15 +46,14 @@ class ChangeMetaPublisher extends Command
             917,
         ];
 
-        // Target Publisher ID
-        $targetPublisherId = 99;
+        // Target Team
+        $targetTeamId = 99;
 
-
-        $team = Team::where('name', 'like', '%' . $targetPublisherId . '%')->first();
+        $team = Team::where('id', $targetTeamId)->first();
 
         if ($team) {
-            $this->info($team->name . ' is what will be used for Publisher Name');
-
+            $this->info($team->name . ' is what will be used for publisher.name');
+            $this->info($targetTeamId . ' is what will be used for publisher.gatewayId');
             // Loop through each dataset
             foreach ($items as $item) {
                 $dataset = Dataset::where('id', $item)->first();
@@ -63,11 +62,12 @@ class ChangeMetaPublisher extends Command
                       $latestVersion = $dataset->latestVersion();
 
                     if ($latestVersion) {
-                        $metadata = json_decode($latestVersion->metadata, true);
+
+                        $metadata = $latestVersion->metadata;
 
                         if (isset($metadata['metadata']['summary']['publisher'])) {
                             $metadata['metadata']['summary']['publisher']['name'] = $team->name;
-                            $metadata['metadata']['summary']['publisher']['gatewayId'] = $targetPublisherId;
+                            $metadata['metadata']['summary']['publisher']['gatewayId'] = $targetTeamId;
                             $latestVersion->metadata = $metadata;
                             $latestVersion->save();
 
@@ -83,7 +83,7 @@ class ChangeMetaPublisher extends Command
                 }
             }
         } else {
-            $this->warn('Team not found for Publisher ID ' . $targetPublisherId);
+            $this->warn('Team not found for ID ' . $targetTeamId);
         }
     }
 }

--- a/app/Console/Commands/ChangeMetaPublisher.php
+++ b/app/Console/Commands/ChangeMetaPublisher.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Team;
+use App\Models\Dataset;
+use Illuminate\Console\Command;
+
+class ChangeMetaPublisher extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:change-meta-publisher';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This will change the metadata.metadata.summary.publisher.name and the metadata.metadata.summary.publisher.gatewayId to what is provided';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // These are the dataset IDs we want to change
+        $items = [
+            989,
+            986,
+            979,
+            977,
+            962,
+            960,
+            959,
+            958,
+            956,
+            953,
+            952,
+            950,
+            921,
+            919,
+            917,
+        ];
+
+        // Target Publisher ID
+        $targetPublisherId = 99;
+
+
+        $team = Team::where('name', 'like', '%' . $targetPublisherId . '%')->first();
+
+        if ($team) {
+            $this->info($team->name . ' is what will be used for Publisher Name');
+
+            // Loop through each dataset
+            foreach ($items as $item) {
+                $dataset = Dataset::where('id', $item)->first();
+
+                if ($dataset) {
+                      $latestVersion = $dataset->latestVersion();
+
+                    if ($latestVersion) {
+                        $metadata = json_decode($latestVersion->metadata, true);
+
+                        if (isset($metadata['metadata']['summary']['publisher'])) {
+                            $metadata['metadata']['summary']['publisher']['name'] = $team->name;
+                            $metadata['metadata']['summary']['publisher']['gatewayId'] = $targetPublisherId;
+
+    
+                            $latestVersion->metadata = json_encode($metadata);
+
+
+                            $latestVersion->save();
+
+                            $this->info('Metadata updated for Dataset ID ' . $dataset->id);
+                        } else {
+                            $this->error('Publisher field not found in metadata for Dataset ID ' . $dataset->id);
+                        }
+                    } else {
+                        $this->error('Latest version not found for Dataset ID ' . $dataset->id);
+                    }
+                } else {
+                    $this->error('Dataset not found for ID ' . $item);
+                }
+            }
+        } else {
+            $this->error('Team not found for Publisher ID ' . $targetPublisherId);
+        }
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)
Results with dummy data locally:
![image](https://github.com/user-attachments/assets/ace6fd99-03e7-4f08-84da-68f7fb301126)
![image](https://github.com/user-attachments/assets/df527e6f-9d66-4e9d-984b-2cc03502465e)

## Describe your changes
I am still investigating how this has happened, but this will fix the data and is reusable.

The script will get the team based of the ID provided, then loop through the datasets provided to update the metadata publisher name and gatewayid, the name is the team name from the id and gatewayid is the id provided.
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5969
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
