### PR TITLE
Update v2 controllers to use camel_case for per_page param

### DIFF
--- a/app/Http/Controllers/Api/V2/CollectionController.php
+++ b/app/Http/Controllers/Api/V2/CollectionController.php
@@ -98,7 +98,7 @@ class CollectionController extends Controller
     public function index(Request $request): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = Collection::with([
                 'keywords',

--- a/app/Http/Controllers/Api/V2/TeamCollectionController.php
+++ b/app/Http/Controllers/Api/V2/TeamCollectionController.php
@@ -96,7 +96,7 @@ class TeamCollectionController extends Controller
     public function indexActive(Request $request, int $teamId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexTeamCollection(
                 $teamId,
@@ -179,7 +179,7 @@ class TeamCollectionController extends Controller
     public function indexDraft(Request $request, int $teamId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexTeamCollection(
                 $teamId,
@@ -262,7 +262,7 @@ class TeamCollectionController extends Controller
     public function indexArchived(Request $request, int $teamId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexTeamCollection(
                 $teamId,

--- a/app/Http/Controllers/Api/V2/UserCollectionController.php
+++ b/app/Http/Controllers/Api/V2/UserCollectionController.php
@@ -96,7 +96,7 @@ class UserCollectionController extends Controller
     public function indexActive(Request $request, int $userId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexUserCollection(
                 $userId,
@@ -179,7 +179,7 @@ class UserCollectionController extends Controller
     public function indexDraft(Request $request, int $userId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexUserCollection(
                 $userId,
@@ -262,7 +262,7 @@ class UserCollectionController extends Controller
     public function indexArchived(Request $request, int $userId): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
 
             $collections = $this->indexUserCollection(
                 $userId,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Remove v2 uses of `perPage`, use only `per_page`.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
