### PR TITLE
GAT-6021 :: Random Emails failing to send on preprod

### DIFF
--- a/app/EnquiriesManagementController/EnquiriesManagementController.php
+++ b/app/EnquiriesManagementController/EnquiriesManagementController.php
@@ -209,7 +209,7 @@ class EnquiriesManagementController
         }
 
         foreach ($in['thread']['dataCustodians'] as $d) {
-            $dataCustodiansStr .= '<p style="text-indent: 15px">' . $d . '</p>';
+            $dataCustodiansStr .= '<p><b>' . $d . '</b></p>';
         }
 
         $str .= 'Name: ' . $in['message']['message_body']['[[USER_FIRST_NAME]]'] . ' ' . $in['message']['message_body']['[[USER_LAST_NAME]]'] . '<br/>';

--- a/app/Mail/Email.php
+++ b/app/Mail/Email.php
@@ -92,7 +92,6 @@ class Email extends Mailable
                 'action_type' => 'MJML',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
-                'full_stack' => json_encode($e),
             ]);
             throw new MailSendException('Error rendering MJML to HTML. Please check logs for details.');
         }

--- a/app/Mail/Email.php
+++ b/app/Mail/Email.php
@@ -85,6 +85,8 @@ class Email extends Mailable
             if ($response->successful()) {
                 return $response->json()['html'];
             }
+
+            throw new MailSendException('Unable to contact MJML API - aborting');
         } catch (Exception $e) {
             CloudLogger::write([
                 'action_type' => 'MJML',
@@ -92,7 +94,7 @@ class Email extends Mailable
                 'description' => $e->getMessage(),
                 'full_stack' => json_encode($e),
             ]);
-            throw new MailSendException('unable to contact mjml api - aborting');
+            throw new MailSendException('Error rendering MJML to HTML. Please check logs for details.');
         }
     }
 

--- a/app/Mail/Email.php
+++ b/app/Mail/Email.php
@@ -92,6 +92,7 @@ class Email extends Mailable
                 'action_type' => 'MJML',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
+                'full_stack' => json_encode($e),
             ]);
             throw new MailSendException('Error rendering MJML to HTML. Please check logs for details.');
         }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Random Emails failing to send on preprod.

## Issue ticket link
Random Emails failing to send on preprod.
Since this fail happens randomly without much information, I suspect it is related to the content. This update was sent to identify more details.

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
