### PR TITLE
fix: (GAT-5866) only show active publications

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'fix/GAT-5866'
+      - 'dev'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/GAT-5866
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/GAT-5866
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - 'fix/GAT-5866'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/GAT-5866
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/GAT-5866
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -442,7 +442,7 @@ class DatasetController extends Controller
             $dataset->setAttribute('publications', $dataset->allActivePublications  ?? []);
             $dataset->setAttribute('named_entities', $dataset->allNamedEntities  ?? []);
             $dataset->setAttribute('collections', $dataset->allCollections  ?? []);
-            
+
             $outputSchemaModel = $request->query('schema_model');
             $outputSchemaModelVersion = $request->query('schema_version');
 
@@ -455,10 +455,10 @@ class DatasetController extends Controller
                     $dataset->setAttribute('versions', [$withLinks]);
                 }
             }
-            
+
             if ($outputSchemaModel && $outputSchemaModelVersion) {
                 $latestVersion = $dataset->latestVersion();
-                
+
                 $translated = MMC::translateDataModelType(
                     json_encode($latestVersion->metadata),
                     $outputSchemaModel,

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -439,7 +439,7 @@ class DatasetController extends Controller
             $dataset->setAttribute('collections_count', count($dataset->allCollections));
             $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages  ?? []);
             $dataset->setAttribute('durs', $dataset->allDurs  ?? []);
-            $dataset->setAttribute('publications', $dataset->allActivePublicationsAttribute  ?? []);
+            $dataset->setAttribute('publications', $dataset->allActivePublications  ?? []);
             $dataset->setAttribute('named_entities', $dataset->allNamedEntities  ?? []);
             $dataset->setAttribute('collections', $dataset->allCollections  ?? []);
             

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -439,10 +439,10 @@ class DatasetController extends Controller
             $dataset->setAttribute('collections_count', count($dataset->allCollections));
             $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages  ?? []);
             $dataset->setAttribute('durs', $dataset->allDurs  ?? []);
-            $dataset->setAttribute('publications', $dataset->allPublications  ?? []);
+            $dataset->setAttribute('publications', $dataset->allActivePublicationsAttribute  ?? []);
             $dataset->setAttribute('named_entities', $dataset->allNamedEntities  ?? []);
             $dataset->setAttribute('collections', $dataset->allCollections  ?? []);
-
+            
             $outputSchemaModel = $request->query('schema_model');
             $outputSchemaModelVersion = $request->query('schema_version');
 
@@ -455,10 +455,10 @@ class DatasetController extends Controller
                     $dataset->setAttribute('versions', [$withLinks]);
                 }
             }
-
+            
             if ($outputSchemaModel && $outputSchemaModelVersion) {
                 $latestVersion = $dataset->latestVersion();
-
+                
                 $translated = MMC::translateDataModelType(
                     json_encode($latestVersion->metadata),
                     $outputSchemaModel,

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -308,22 +308,19 @@ class Dataset extends Model
 
         // Step 2: Use the version IDs to find all related entityIDs through the linkage table
         $linkageRecords = $linkageTable::whereIn('dataset_version_id', $versionIds)
-            ->when(
-                $filterActive,
-                function ($query) {
-                    return $query->where('status', self::STATUS_ACTIVE);
+        ->when(
+            $includeIntermediate,
+            function ($query) {
+                return $query->get();
+            },
+            function ($query) use ($foreignTableId, $filterActive) {
+                if ($filterActive) {
+                    $query->where('status', self::STATUS_ACTIVE);
                 }
-            )
-            ->when(
-                $includeIntermediate,
-                function ($query) {
-                    return $query->get();
-                },
-                function ($query) use ($foreignTableId) {
-                    return $query->get([$foreignTableId, 'dataset_version_id']);
-                }
-            );
-
+                return $query->get([$foreignTableId, 'dataset_version_id']);
+            }
+        );
+    
 
         $entityIds = $linkageRecords->pluck($foreignTableId)->unique()->toArray();
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -311,7 +311,7 @@ class Dataset extends Model
             ->when(
                 $filterActive,
                 function ($query) {
-                    return $query->where('status', STATUS_ACTIVE);
+                    return $query->where('status', $this->STATUS_ACTIVE);
                 }
             )
             ->when(

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -314,9 +314,6 @@ class Dataset extends Model
                 return $query->get();
             },
             function ($query) use ($foreignTableId, $filterActive) {
-                if ($filterActive) {
-                    $query->where('status', self::STATUS_ACTIVE);
-                }
                 return $query->get([$foreignTableId, 'dataset_version_id']);
             }
         );
@@ -325,7 +322,11 @@ class Dataset extends Model
         $entityIds = $linkageRecords->pluck($foreignTableId)->unique()->toArray();
 
         // Step 3: Retrieve all entities using the collected entities IDs
-        $entities = $targetTable::whereIn('id', $entityIds)->get();
+        $entities = $targetTable::whereIn('id', $entityIds)
+            ->when($filterActive, function ($query) {
+                return $query->where('status', self::STATUS_ACTIVE);
+            })
+            ->get();
 
         // Iterate through each entity and add associated dataset versions
         foreach ($entities as $entity) {

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -317,7 +317,7 @@ class Dataset extends Model
                     return $query->get([$foreignTableId, 'dataset_version_id']);
                 }
             );
-    
+
 
         $entityIds = $linkageRecords->pluck($foreignTableId)->unique()->toArray();
 
@@ -331,7 +331,7 @@ class Dataset extends Model
         // Iterate through each entity and add associated dataset versions
         foreach ($entities as $entity) {
             // Retrieve dataset version IDs associated with the current entity
-            
+
             $filteredLinkage = $linkageRecords->where($foreignTableId, $entity->id);
 
             if($includeIntermediate) {

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -308,15 +308,15 @@ class Dataset extends Model
 
         // Step 2: Use the version IDs to find all related entityIDs through the linkage table
         $linkageRecords = $linkageTable::whereIn('dataset_version_id', $versionIds)
-        ->when(
-            $includeIntermediate,
-            function ($query) {
-                return $query->get();
-            },
-            function ($query) use ($foreignTableId, $filterActive) {
-                return $query->get([$foreignTableId, 'dataset_version_id']);
-            }
-        );
+            ->when(
+                $includeIntermediate,
+                function ($query) {
+                    return $query->get();
+                },
+                function ($query) use ($foreignTableId) {
+                    return $query->get([$foreignTableId, 'dataset_version_id']);
+                }
+            );
     
 
         $entityIds = $linkageRecords->pluck($foreignTableId)->unique()->toArray();

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -311,7 +311,7 @@ class Dataset extends Model
             ->when(
                 $filterActive,
                 function ($query) {
-                    return $query->where('status', $this->STATUS_ACTIVE);
+                    return $query->where('status', self::STATUS_ACTIVE);
                 }
             )
             ->when(


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/21311919-1a55-4486-9455-c1a755e1be66)

## Describe your changes
Extra optional boolean param on getRelationsViaDatasetVersion for only getting active relations, this has been done to only get the active publications on the dataset call
## Issue ticket link
https://hdruk.atlassian.net/jira/software/c/projects/GAT/boards/51?assignee=712020%3A05fbbf0f-9386-469a-a212-84cfbf9cc587&selectedIssue=GAT-5866
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
