### PR TITLE
Fix: add missing condition field to Question Bank controller responses.

### DIFF
--- a/app/Models/QuestionBankVersion.php
+++ b/app/Models/QuestionBankVersion.php
@@ -59,7 +59,7 @@ class QuestionBankVersion extends Model
             'question_bank_version_has_child_version',
             'parent_qbv_id',
             'child_qbv_id'
-        );
+        )->withPivot('condition');
     }
 
     public function parentVersion(): belongsTo


### PR DESCRIPTION
Return the condition which controls the relationship between parent and child.

## Screenshots (if relevant)

## Describe your changes
Question Bank Controller responses contained the link to the child versions but omitted the condition governing the relationship. This is now fixed.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
