### PR TITLE
Rewrite /questions CRUD endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -14,14 +14,13 @@ use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Carbon;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\QuestionBank\GetQuestionBank;
-use App\Http\Requests\QuestionBank\GetQuestionBankSection;
-use App\Http\Requests\QuestionBank\GetQuestionBankVersion;
-use App\Http\Requests\QuestionBank\EditQuestionBank;
 use App\Http\Requests\QuestionBank\CreateQuestionBank;
 use App\Http\Requests\QuestionBank\DeleteQuestionBank;
-use App\Http\Requests\QuestionBank\LockingQuestionBank;
+use App\Http\Requests\QuestionBank\EditQuestionBank;
+use App\Http\Requests\QuestionBank\GetQuestionBank;
+use App\Http\Requests\QuestionBank\GetQuestionBankVersion;
 use App\Http\Requests\QuestionBank\UpdateQuestionBank;
+use App\Http\Requests\QuestionBank\UpdateStatusQuestionBank;
 use App\Http\Traits\RequestTransformation;
 
 class QuestionBankController extends Controller
@@ -103,6 +102,154 @@ class QuestionBankController extends Controller
 
     /**
      * @OA\Get(
+     *      path="/api/v1/questions/standard",
+     *      summary="List of standard question bank questions",
+     *      description="List of standard question bank questions",
+     *      tags={"QuestionBank"},
+     *      summary="QuestionBank@indexStandard",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="section_id", type="integer", example="1"),
+     *                      @OA\Property(property="user_id", type="integer", example="1"),
+     *                      @OA\Property(property="locked", type="boolean", example="false"),
+     *                      @OA\Property(property="archived", type="boolean", example="true"),
+     *                      @OA\Property(property="archived_date", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="force_required", type="boolean", example="false"),
+     *                      @OA\Property(property="allow_guidance_override", type="boolean", example="true"),
+     *                      @OA\Property(property="is_child", type="boolean", example="true"),
+     *                      @OA\Property(property="question_type", type="string", example="STANDARD"),
+     *                      @OA\Property(property="latest_version", type="object", example=""),
+     *                      @OA\Property(property="versions", type="object", example=""),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function indexStandard(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $questions = QuestionBank::with([
+                'latestVersion', 'versions', 'versions.childVersions'
+            ])->where('question_type', QuestionBank::STANDARD_TYPE)
+            ->where('archived', false)
+            ->paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'QuestionBank get all standard',
+            ]);
+
+            return response()->json(
+                $questions
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/questions/custom",
+     *      summary="List of custom question bank questions",
+     *      description="List of custom question bank questions",
+     *      tags={"QuestionBank"},
+     *      summary="QuestionBank@indexCustom",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="section_id", type="integer", example="1"),
+     *                      @OA\Property(property="user_id", type="integer", example="1"),
+     *                      @OA\Property(property="locked", type="boolean", example="false"),
+     *                      @OA\Property(property="archived", type="boolean", example="true"),
+     *                      @OA\Property(property="archived_date", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="force_required", type="boolean", example="false"),
+     *                      @OA\Property(property="allow_guidance_override", type="boolean", example="true"),
+     *                      @OA\Property(property="is_child", type="boolean", example="true"),
+     *                      @OA\Property(property="question_type", type="string", example="STANDARD"),
+     *                      @OA\Property(property="latest_version", type="object", example=""),
+     *                      @OA\Property(property="versions", type="object", example=""),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function indexCustom(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $questions = QuestionBank::with([
+                'latestVersion', 'versions', 'versions.childVersions'
+            ])->where('question_type', QuestionBank::CUSTOM_TYPE)
+            ->where('archived', false)
+            ->paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'QuestionBank get all custom',
+            ]);
+
+            return response()->json(
+                $questions
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
      *      path="/api/v1/questions/archived",
      *      summary="List of archived question bank questions",
      *      description="List of archived question bank questions",
@@ -157,80 +304,6 @@ class QuestionBankController extends Controller
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => 'QuestionBank get all archived',
-            ]);
-
-            return response()->json(
-                $questions
-            );
-        } catch (Exception $e) {
-            Auditor::log([
-                'user_id' => (int)$jwtUser['id'],
-                'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => $e->getMessage(),
-            ]);
-
-            throw new Exception($e->getMessage());
-        }
-    }
-
-    /**
-     * @OA\Get(
-     *      path="/api/v1/questions/section/{sectionId}",
-     *      summary="List of question bank questions by section",
-     *      description="List of question bank questions by section",
-     *      tags={"QuestionBank"},
-     *      summary="QuestionBank@indexBySection",
-     *      security={{"bearerAuth":{}}},
-     *      @OA\Response(
-     *          response=200,
-     *          description="Success",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string"),
-     *              @OA\Property(property="data", type="array",
-     *                  @OA\Items(
-     *                      @OA\Property(property="id", type="integer", example="123"),
-     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
-     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
-     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
-     *                      @OA\Property(property="section_id", type="integer", example="1"),
-     *                      @OA\Property(property="user_id", type="integer", example="1"),
-     *                      @OA\Property(property="locked", type="boolean", example="false"),
-     *                      @OA\Property(property="archived", type="boolean", example="true"),
-     *                      @OA\Property(property="archived_date", type="datetime", example="2023-04-03 12:00:00"),
-     *                      @OA\Property(property="force_required", type="boolean", example="false"),
-     *                      @OA\Property(property="allow_guidance_override", type="boolean", example="true"),
-     *                      @OA\Property(property="is_child", type="boolean", example="true"),
-     *                      @OA\Property(property="question_type", type="string", example="STANDARD"),
-     *                      @OA\Property(property="latest_version", type="object", example=""),
-     *                      @OA\Property(property="versions", type="object", example=""),
-     *                  )
-     *              )
-     *          )
-     *      )
-     * )
-     */
-    public function indexBySection(GetQuestionBankSection $request, int $sectionId): JsonResponse
-    {
-        try {
-            $input = $request->all();
-            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-
-            $questions = QuestionBank::with([
-                'latestVersion', 'versions', 'versions.childVersions'
-            ])->where('archived', false)
-            ->where('section_id', $sectionId)
-            ->paginate(
-                Config::get('constants.per_page'),
-                ['*'],
-                'page'
-            );
-
-            Auditor::log([
-                'user_id' => (int)$jwtUser['id'],
-                'action_type' => 'GET',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => 'QuestionBank get all by section',
             ]);
 
             return response()->json(
@@ -893,11 +966,11 @@ class QuestionBankController extends Controller
 
     /**
      * @OA\Patch(
-     *      path="/api/v1/questions/{id}/{locking}",
-     *      summary="Lock or unlock a question bank question",
-     *      description="Lock or unlock a question bank question",
+     *      path="/api/v1/questions/{id}/{status}",
+     *      summary="Lock, unlock, archive or unarchive a question bank question",
+     *      description="Lock, unlock, archive or unarchive a question bank question",
      *      tags={"QuestionBank"},
-     *      summary="QuestionBank@locking",
+     *      summary="QuestionBank@updateStatus",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
      *         name="id",
@@ -918,7 +991,7 @@ class QuestionBankController extends Controller
      *         example="lock",
      *         @OA\Schema(
      *            type="string",
-     *            description="lock | unlock",
+     *            description="lock | unlock | archive | unarchive",
      *         ),
      *      ),
      *      @OA\Response(
@@ -944,27 +1017,39 @@ class QuestionBankController extends Controller
      *      )
      * )
      */
-    public function locking(LockingQuestionBank $request, int $id, string $locking): JsonResponse
+    public function updateStatus(UpdateStatusQuestionBank $request, int $id, string $status): JsonResponse
     {
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
-            $question = QuestionBank::findOrFail($id)->with('latestVersion.childVersions')->get();
+            $question = QuestionBank::where('id', $id)->with('latestVersion.childVersions')->first();
 
-            $locked = $locking === 'lock' ? true : false;
-            $question->update(['locked' => $locked]);
+            if ($question['is_child']) {
+                return response()->json([
+                    'message' => "Cannot update a child question's status, update the parent question."
+                ], 400);
+            }
 
-            // lock children too
-            foreach ($question['latest_version']['child_versions'] as $v) {
-                QuestionBank::where('id', $v['question_id'])->update(['locked' => $locked]);
+            if (in_array($status, ['lock', 'unlock'])) {
+                $locked = $status === 'lock' ? true : false;
+                $question->update(['locked' => $locked]);
+                foreach ($question['latestVersion']['childVersions'] as $v) {
+                    QuestionBank::where('id', $v['question_id'])->update(['locked' => $locked]);
+                }
+            } elseif (in_array($status, ['archive', 'unarchive'])) {
+                $archived = $status === 'archive' ? true : false;
+                $question->update(['archived' => $archived]);
+                foreach ($question['latestVersion']['childVersions'] as $v) {
+                    QuestionBank::where('id', $v['question_id'])->update(['archived' => $archived]);
+                }
             }
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
                 'action_type' => 'UPDATE',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => 'QuestionBank ' . $id . ' updated',
+                'description' => 'QuestionBank ' . $id . ' status updated',
             ]);
 
             return response()->json([

--- a/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
@@ -61,22 +61,20 @@ class TeamQuestionBankController extends Controller
                 ->select('qb_question_id')
                 ->pluck('qb_question_id');
 
-            $questionsCustom = QuestionBank::with([
+            $query = QuestionBank::with([
                 'latestVersion', 'versions', 'versions.childVersions'
             ])->where('archived', false)
-            ->whereIn('id', $teamQuestions)
-            ->where('section_id', $sectionId)
-            ->get()
-            ->toArray();
+            ->where('section_id', $sectionId);
 
+            $questionsCustom = (clone $query)
+                ->whereIn('id', $teamQuestions)
+                ->get()
+                ->toArray();
 
-            $questionsStandard = QuestionBank::with([
-                'latestVersion', 'versions', 'versions.childVersions'
-            ])->where('archived', false)
-            ->where('question_type', 'STANDARD')
-            ->where('section_id', $sectionId)
-            ->get()
-            ->toArray();
+            $questionsStandard = (clone $query)
+                ->where('question_type', 'STANDARD')
+                ->get()
+                ->toArray();
 
             $questions = array_merge($questionsCustom, $questionsStandard);
 

--- a/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Auditor;
+use Exception;
+use App\Models\QuestionBank;
+use App\Models\QuestionHasTeam;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\QuestionBank\GetQuestionBankSection;
+use App\Http\Traits\RequestTransformation;
+
+class TeamQuestionBankController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/teams/{teamId}/questions/section/{sectionId}",
+     *      summary="List of question bank questions by section",
+     *      description="List of question bank questions by section",
+     *      tags={"QuestionBank"},
+     *      summary="TeamQuestionBank@indexBySection",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="section_id", type="integer", example="1"),
+     *                      @OA\Property(property="user_id", type="integer", example="1"),
+     *                      @OA\Property(property="locked", type="boolean", example="false"),
+     *                      @OA\Property(property="archived", type="boolean", example="true"),
+     *                      @OA\Property(property="archived_date", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="force_required", type="boolean", example="false"),
+     *                      @OA\Property(property="allow_guidance_override", type="boolean", example="true"),
+     *                      @OA\Property(property="is_child", type="boolean", example="true"),
+     *                      @OA\Property(property="question_type", type="string", example="STANDARD"),
+     *                      @OA\Property(property="latest_version", type="object", example=""),
+     *                      @OA\Property(property="versions", type="object", example=""),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function indexBySection(GetQuestionBankSection $request, int $teamId, int $sectionId): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $teamQuestions = QuestionHasTeam::where('team_id', $teamId)
+                ->select('qb_question_id')
+                ->pluck('qb_question_id');
+
+            $questionsCustom = QuestionBank::with([
+                'latestVersion', 'versions', 'versions.childVersions'
+            ])->where('archived', false)
+            ->whereIn('id', $teamQuestions)
+            ->where('section_id', $sectionId)
+            ->get()
+            ->toArray();
+
+
+            $questionsStandard = QuestionBank::with([
+                'latestVersion', 'versions', 'versions.childVersions'
+            ])->where('archived', false)
+            ->where('question_type', 'STANDARD')
+            ->where('section_id', $sectionId)
+            ->get()
+            ->toArray();
+
+            $questions = array_merge($questionsCustom, $questionsStandard);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'QuestionBank get all by section',
+            ]);
+
+            return response()->json([
+                'data' => $questions
+            ]);
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+}

--- a/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
+++ b/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\QuestionBank;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetQuestionBankSection extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'sectionId' => [
+                'int',
+                'required',
+                'exists:dar_sections,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['sectionId' => $this->route('sectionId')]);
+    }
+}

--- a/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
+++ b/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
@@ -19,6 +19,11 @@ class GetQuestionBankSection extends BaseFormRequest
                 'required',
                 'exists:dar_sections,id',
             ],
+            'sectionId' => [
+                'int',
+                'required',
+                'exists:teams,id',
+            ],
         ];
     }
 
@@ -29,6 +34,9 @@ class GetQuestionBankSection extends BaseFormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['sectionId' => $this->route('sectionId')]);
+        $this->merge([
+            'sectionId' => $this->route('sectionId'),
+            'teamId' => $this->route('teamId'),
+        ]);
     }
 }

--- a/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
+++ b/app/Http/Requests/QuestionBank/GetQuestionBankSection.php
@@ -19,7 +19,7 @@ class GetQuestionBankSection extends BaseFormRequest
                 'required',
                 'exists:dar_sections,id',
             ],
-            'sectionId' => [
+            'teamId' => [
                 'int',
                 'required',
                 'exists:teams,id',

--- a/app/Http/Requests/QuestionBank/GetQuestionBankVersion.php
+++ b/app/Http/Requests/QuestionBank/GetQuestionBankVersion.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\QuestionBank;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetQuestionBankVersion extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:question_bank_versions,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/QuestionBank/LockingQuestionBank.php
+++ b/app/Http/Requests/QuestionBank/LockingQuestionBank.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\QuestionBank;
+
+use App\Http\Requests\BaseFormRequest;
+
+class LockingQuestionBank extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:question_bank_questions,id',
+            ],
+            'locking' => [
+                'required',
+                'string',
+                'in:lock,unlock',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'id' => $this->route('id'),
+            'locking' => $this->route('locking'),
+        ]);
+    }
+}

--- a/app/Http/Requests/QuestionBank/UpdateStatusQuestionBank.php
+++ b/app/Http/Requests/QuestionBank/UpdateStatusQuestionBank.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\QuestionBank;
 
 use App\Http\Requests\BaseFormRequest;
 
-class LockingQuestionBank extends BaseFormRequest
+class UpdateStatusQuestionBank extends BaseFormRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -19,10 +19,10 @@ class LockingQuestionBank extends BaseFormRequest
                 'required',
                 'exists:question_bank_questions,id',
             ],
-            'locking' => [
+            'status' => [
                 'required',
                 'string',
-                'in:lock,unlock',
+                'in:lock,unlock,archive,unarchive',
             ],
         ];
     }
@@ -36,7 +36,7 @@ class LockingQuestionBank extends BaseFormRequest
     {
         $this->merge([
             'id' => $this->route('id'),
-            'locking' => $this->route('locking'),
+            'status' => $this->route('status'),
         ]);
     }
 }

--- a/app/Models/QuestionBank.php
+++ b/app/Models/QuestionBank.php
@@ -78,4 +78,9 @@ class QuestionBank extends Model
     {
         return $this->belongsToMany(Team::class, 'qb_question_has_team');
     }
+
+    public function section(): BelongsTo
+    {
+        return $this->belongsTo(DataAccessSection::class);
+    }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -3673,6 +3673,20 @@ return [
     ],
     [
         'name' => 'questions',
+        'method' => 'get',
+        'path' => '/questions/version/{id}',
+        'methodController' => 'QuestionBankController@showVersion',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,question-bank.read',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'questions',
         'method' => 'post',
         'path' => '/questions',
         'methodController' => 'QuestionBankController@store',

--- a/config/routes.php
+++ b/config/routes.php
@@ -3660,6 +3660,30 @@ return [
     [
         'name' => 'questions',
         'method' => 'get',
+        'path' => '/questions/standard',
+        'methodController' => 'QuestionBankController@indexStandard',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,question-bank.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'questions',
+        'method' => 'get',
+        'path' => '/questions/custom',
+        'methodController' => 'QuestionBankController@indexCustom',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,question-bank.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'questions',
+        'method' => 'get',
         'path' => '/questions/archived',
         'methodController' => 'QuestionBankController@indexArchived',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
@@ -3672,8 +3696,8 @@ return [
     [
         'name' => 'questions',
         'method' => 'get',
-        'path' => '/questions/section/{sectionId}',
-        'methodController' => 'QuestionBankController@indexBySection',
+        'path' => '/teams/{teamId}/questions/section/{sectionId}',
+        'methodController' => 'TeamQuestionBankController@indexBySection',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
@@ -3755,8 +3779,8 @@ return [
     [
         'name' => 'questions',
         'method' => 'patch',
-        'path' => '/questions/{id}/{locking}',
-        'methodController' => 'QuestionBankController@locking',
+        'path' => '/questions/{id}/{status}',
+        'methodController' => 'QuestionBankController@updateStatus',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',

--- a/config/routes.php
+++ b/config/routes.php
@@ -3660,6 +3660,30 @@ return [
     [
         'name' => 'questions',
         'method' => 'get',
+        'path' => '/questions/archived',
+        'methodController' => 'QuestionBankController@indexArchived',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,question-bank.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'questions',
+        'method' => 'get',
+        'path' => '/questions/section/{sectionId}',
+        'methodController' => 'QuestionBankController@indexBySection',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,question-bank.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'questions',
+        'method' => 'get',
         'path' => '/questions/{id}',
         'methodController' => 'QuestionBankController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
@@ -3718,6 +3742,21 @@ return [
         'method' => 'patch',
         'path' => '/questions/{id}',
         'methodController' => 'QuestionBankController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:permissions,question-bank.update',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'questions',
+        'method' => 'patch',
+        'path' => '/questions/{id}/{locking}',
+        'methodController' => 'QuestionBankController@locking',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -146,12 +146,99 @@ class QuestionBankTest extends TestCase
                     'question_type',
                     'is_child',
                     'latest_version',
-                        'latest_version',
-                        'versions' => [
-                            0 => ['child_versions']
-                        ],
+                    'versions' => [
+                        0 => ['child_versions']
+                    ],
+                    'section',
                 ],
             ]);
+
+        $response = $this->get('api/v1/questions/' . $content['data'] . '?with_section=0&with_versions=0', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'section_id',
+                    'user_id',
+                    'locked',
+                    'archived',
+                    'archived_date',
+                    'force_required',
+                    'allow_guidance_override',
+                    'question_type',
+                    'is_child',
+                    'latest_version',
+                ],
+            ]);
+    }
+
+    /**
+     * Returns a single question version
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_a_single_question_version()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1,
+                'is_child' => 0,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+
+        $response = $this->get('api/v1/questions/' . $content['data'], $this->header);
+        $questionVersionId = $response->decodeResponseJson()['data']['latest_version']['id'];
+
+        $response = $this->get('api/v1/questions/version/' . $questionVersionId, $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'question_id',
+                    'version',
+                    'default',
+                    'required',
+                    'question_json',
+                ],
+            ]);
+
+
     }
 
     /**

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -86,6 +86,172 @@ class QuestionBankTest extends TestCase
     }
 
     /**
+     * List all standard questions.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_standard_questions()
+    {
+        // Create a standard question to list
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'question_type' => 'STANDARD',
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1,
+                'is_child' => 0,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $response = $this->get('api/v1/questions/standard', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'section_id',
+                        'user_id',
+                        'locked',
+                        'archived',
+                        'archived_date',
+                        'force_required',
+                        'allow_guidance_override',
+                        'question_type',
+                        'is_child',
+                        'latest_version',
+                        'versions' => [
+                            0 => ['child_versions']
+                        ],
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
+     * List all custom questions.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_custom_questions()
+    {
+        // Create a custom question to list
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'question_type' => 'CUSTOM',
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1,
+                'is_child' => 0,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $response = $this->get('api/v1/questions/custom', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'section_id',
+                        'user_id',
+                        'locked',
+                        'archived',
+                        'archived_date',
+                        'force_required',
+                        'allow_guidance_override',
+                        'question_type',
+                        'is_child',
+                        'latest_version',
+                        'versions' => [
+                            0 => ['child_versions']
+                        ],
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
      * List all archived questions.
      *
      * @return void
@@ -182,6 +348,8 @@ class QuestionBankTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
+                'team_id' => [1],
+                'question_type' => 'CUSTOM',
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'field' => [
@@ -208,12 +376,12 @@ class QuestionBankTest extends TestCase
             ->assertJsonStructure([
                 'message',
             ]);
+        $questionId = $response->decodeResponseJson()['data'];
 
-        $response = $this->get('api/v1/questions/section/1', $this->header);
+        $response = $this->get('api/v1/teams/1/questions/section/1', $this->header);
 
         $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
             ->assertJsonStructure([
-                'current_page',
                 'data' => [
                     0 => [
                         'id',
@@ -233,21 +401,14 @@ class QuestionBankTest extends TestCase
                         'versions' => [
                             0 => ['child_versions']
                         ],
-                    ],
+                    ]
                 ],
-                'first_page_url',
-                'from',
-                'last_page',
-                'last_page_url',
-                'links',
-                'next_page_url',
-                'path',
-                'per_page',
-                'prev_page_url',
-                'to',
-                'total',
             ]);
 
+        $content = $response->decodeResponseJson();
+        $ids = array_column($content['data'], 'id');
+
+        $this->assertContains($questionId, $ids);
     }
 
     /**
@@ -1105,11 +1266,228 @@ class QuestionBankTest extends TestCase
     }
 
     /**
+     * Test if can update the status of a question
+     *
+     * @return void
+     */
+    public function test_the_application_can_update_the_status_of_a_question()
+    {
+        // create a question with children
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'force_required' => false,
+                'allow_guidance_override' => false,
+                'locked' => false,
+                'archived' => false,
+                'is_child' => false,
+                'field' => [
+                    'options' => [
+                        'yes',
+                        'no'
+                    ],
+                    'component' => 'RadioGroup',
+                    'validations' => []
+                ],
+                'title' => 'Is this a test?',
+                'guidance' => 'You tell me',
+                'required' => false,
+                'default' => 0,
+                'children' => [
+                    'yes' => [
+                        [
+                            'force_required' => false,
+                            'allow_guidance_override' => false,
+                            'field' => [
+                                'options' => [
+                                    'yes',
+                                    'no'
+                                ],
+                                'component' => 'RadioGroup',
+                                'validations' => []
+                            ],
+                            'title' => 'Are you sure it is?',
+                            'guidance' => 'Second chance to confirm',
+                            'required' => false,
+                            'default' => 1
+                        ],
+                    ],
+                    'no' => [
+                        [
+                            'force_required' => false,
+                            'allow_guidance_override' => false,
+                            'field' => [
+                                'component' => 'TextField',
+                                'validations' => []
+                            ],
+                            'title' => 'And why do you say that?',
+                            'guidance' => 'Please explain',
+                            'required' => false,
+                            'default' => 1
+                        ]
+                    ]
+                ]
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $questionId = $content['data'];
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $questionId . '/lock',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/questions/' . $questionId,
+            [],
+            $this->header
+        );
+
+        $content = $response->decodeResponseJson();
+        $this->assertTrue($content['data']['locked']);
+
+        // get children ids and check they are also locked
+        $childIds = array_column($content['data']['latest_version']['child_versions'], 'question_id');
+        foreach ($childIds as $id) {
+            $response = $this->json(
+                'GET',
+                'api/v1/questions/' . $id,
+                [],
+                $this->header
+            );
+            $content = $response->decodeResponseJson();
+            $this->assertTrue($content['data']['locked']);
+        }
+
+        // Test unlocking the same way
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $questionId . '/unlock',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/questions/' . $questionId,
+            [],
+            $this->header
+        );
+
+        $content = $response->decodeResponseJson();
+        $this->assertTrue(!$content['data']['locked']);
+
+        // get children ids and check they are also locked
+        $childIds = array_column($content['data']['latest_version']['child_versions'], 'question_id');
+        foreach ($childIds as $id) {
+            $response = $this->json(
+                'GET',
+                'api/v1/questions/' . $id,
+                [],
+                $this->header
+            );
+            $content = $response->decodeResponseJson();
+            $this->assertTrue(!$content['data']['locked']);
+        }
+
+        // test archiving
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $questionId . '/archive',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/questions/' . $questionId,
+            [],
+            $this->header
+        );
+
+        $content = $response->decodeResponseJson();
+        $this->assertTrue($content['data']['archived']);
+
+        // get children ids and check they are also archived
+        $childIds = array_column($content['data']['latest_version']['child_versions'], 'question_id');
+        foreach ($childIds as $id) {
+            $response = $this->json(
+                'GET',
+                'api/v1/questions/' . $id,
+                [],
+                $this->header
+            );
+            $content = $response->decodeResponseJson();
+            $this->assertTrue($content['data']['archived']);
+        }
+
+        // Test unarchiving the same way
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $questionId . '/unarchive',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/questions/' . $questionId,
+            [],
+            $this->header
+        );
+
+        $content = $response->decodeResponseJson();
+        $this->assertTrue(!$content['data']['archived']);
+
+        // get children ids and check they are also archived
+        $childIds = array_column($content['data']['latest_version']['child_versions'], 'question_id');
+        foreach ($childIds as $id) {
+            $response = $this->json(
+                'GET',
+                'api/v1/questions/' . $id,
+                [],
+                $this->header
+            );
+            $content = $response->decodeResponseJson();
+            $this->assertTrue(!$content['data']['archived']);
+        }
+
+        // test updating a child question's status fails
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $childIds[0] . '/lock',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'));
+    }
+
+    /**
      * Tests it can delete a question
      *
      * @return void
      */
-    public function test_it_can_delete_a_question()
+    public function test_the_application_can_delete_a_question()
     {
         $countBefore = QuestionHasTeam::all()->count();
 

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -86,6 +86,171 @@ class QuestionBankTest extends TestCase
     }
 
     /**
+     * List all archived questions.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_archived_questions()
+    {
+        // Create an archived question to list
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'archived' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1,
+                'is_child' => 0,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $response = $this->get('api/v1/questions/archived', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'section_id',
+                        'user_id',
+                        'locked',
+                        'archived',
+                        'archived_date',
+                        'force_required',
+                        'allow_guidance_override',
+                        'question_type',
+                        'is_child',
+                        'latest_version',
+                        'versions' => [
+                            0 => ['child_versions']
+                        ],
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
+     * List all questions from a section.
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_questions_by_section()
+    {
+        // Create a question in section 1 to list
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1,
+                'is_child' => 0,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $response = $this->get('api/v1/questions/section/1', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'section_id',
+                        'user_id',
+                        'locked',
+                        'archived',
+                        'archived_date',
+                        'force_required',
+                        'allow_guidance_override',
+                        'question_type',
+                        'is_child',
+                        'latest_version',
+                        'versions' => [
+                            0 => ['child_versions']
+                        ],
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+    }
+
+    /**
      * Returns a single question
      *
      * @return void


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Implements the following endpoints under the /questions api:
- `GET /questions/standard`: returns all standard questions 
- `GET /questions/custom`: returns all custom questions
- `GET /questions/archived`: returns all archived questions
- `GET /teams/{teamId}/questions/section/{sectionId}`: returns all standard questions and all custom questions in the specified section belonging to the specified team
- `GET /questions/version/{id}`: returns the specified question version
- `PATCH /questions/{id}/{status}`: updates the status of the specified question, options for `status` are `lock`, `unlock`, `archive`, `unarchive`

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5898

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
