### PR TITLE
CRUD endpoints for applications and templates

### DIFF
--- a/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
@@ -31,6 +31,17 @@ class DataAccessTemplateController extends Controller
      *      tags={"DataAccessTemplate"},
      *      summary="DataAccessTemplate@index",
      *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="with_questions",
+     *         in="query",
+     *         description="Include questions in response",
+     *         required=false,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="Include questions in response",
+     *         ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -54,11 +65,15 @@ class DataAccessTemplateController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        try {
-            $input = $request->all();
-            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $templates = DataAccessTemplate::paginate(
+        try {
+
+            $withQuestions = $request->boolean('with_questions', false);
+
+            $templates = DataAccessTemplate::when($withQuestions, fn ($query) => $query->with('questions'))
+            ->paginate(
                 Config::get('constants.per_page'),
                 ['*'],
                 'page'

--- a/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessTemplateController.php
@@ -152,7 +152,16 @@ class DataAccessTemplateController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $template = DataAccessTemplate::with('questions')->findOrFail($id);
+            $template = DataAccessTemplate::where('id', $id)->with('questions')->first();
+            foreach ($template['questions'] as $i => $q) {
+                $version = QuestionBank::with([
+                    'latestVersion',
+                    'latestVersion.childVersions',
+                ])->where('id', $q->question_id)
+                    ->first()
+                    ->toArray();
+                $template['questions'][$i]['latest_version'] = $version['latest_version'];
+            }
 
             if ($template) {
                 Auditor::log([

--- a/app/Http/Controllers/Api/V1/TeamDataAccessTemplateController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessTemplateController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Auditor;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\QuestionBank\GetTeamDataAccessTemplate;
+use App\Http\Traits\RequestTransformation;
+
+class TeamDataAccessTemplateController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/teams/{teamId}/dar/templates",
+     *      summary="List of dar templates belonging to a team",
+     *      description="List of dar templates belonging to a team",
+     *      tags={"TeamDataAccessTemplate"},
+     *      summary="TeamDataAccessTemplate@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="team_id", type="integer", example="1"),
+     *                      @OA\Property(property="user_id", type="integer", example="1"),
+     *                      @OA\Property(property="published", type="boolean", example="true"),
+     *                      @OA\Property(property="locked", type="boolean", example="false"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(GetTeamDataAccessTemplate $request, int $teamId): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $templates = DataAccessTemplate::where('team_id', $teamId)
+            ->with('questions')
+            ->paginate(
+                Config::get('constants.per_page'),
+                ['*'],
+                'page'
+            );
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessTemplate get all by team',
+            ]);
+
+            return response()->json([
+                'data' => $templates
+            ]);
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+}

--- a/app/Http/Controllers/Api/V1/TeamDataAccessTemplateController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessTemplateController.php
@@ -3,11 +3,13 @@
 namespace App\Http\Controllers\Api\V1;
 
 use Auditor;
+use Config;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\QuestionBank\GetTeamDataAccessTemplate;
+use App\Http\Requests\DataAccessTemplate\GetTeamDataAccessTemplate;
 use App\Http\Traits\RequestTransformation;
+use App\Models\DataAccessTemplate;
 
 class TeamDataAccessTemplateController extends Controller
 {
@@ -63,9 +65,9 @@ class TeamDataAccessTemplateController extends Controller
                 'description' => 'DataAccessTemplate get all by team',
             ]);
 
-            return response()->json([
-                'data' => $templates
-            ]);
+            return response()->json(
+                $templates
+            );
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Requests/DataAccessApplication/CreateDataAccessApplicationAnswer.php
+++ b/app/Http/Requests/DataAccessApplication/CreateDataAccessApplicationAnswer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class CreateDataAccessApplicationAnswer extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+            'answers' => [
+                'array',
+                'required',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/DataAccessTemplate/GetTeamDataAccessTemplate.php
+++ b/app/Http/Requests/DataAccessTemplate/GetTeamDataAccessTemplate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\DataAccessTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetTeamDataAccessTemplate extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'teamId' => [
+                'int',
+                'required',
+                'exists:teams,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['teamId' => $this->route('teamId')]);
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -3926,6 +3926,18 @@ return [
     [
         'name' => 'dar/templates',
         'method' => 'get',
+        'path' => '/teams/{teamId}/dar/templates',
+        'methodController' => 'TeamDataAccessTemplateController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,data-access-template.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/templates',
+        'method' => 'get',
         'path' => '/dar/templates/{id}',
         'methodController' => 'DataAccessTemplateController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',

--- a/config/routes.php
+++ b/config/routes.php
@@ -3833,9 +3833,34 @@ return [
     ],
     [
         'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => '/dar/applications/{id}/answers',
+        'methodController' => 'DataAccessApplicationController@showAnswers',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
         'method' => 'post',
         'path' => '/dar/applications',
         'methodController' => 'DataAccessApplicationController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'put',
+        'path' => '/dar/applications/{id}/answers',
+        'methodController' => 'DataAccessApplicationController@storeAnswers',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -190,6 +190,82 @@ class DataAccessApplicationTest extends TestCase
     }
 
     /**
+     * Adds answers to a dar application
+     *
+     * @return void
+     */
+    public function test_the_application_can_add_answers_to_a_dar_application()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+                'approval_status' => 'APPROVED_COMMENTS',
+                'dataset_ids' => [1,2],
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+        $applicationId = $response->decodeResponseJson()['data'];
+
+        $response = $this->json(
+            'PUT',
+            'api/v1/dar/applications/' . $applicationId . '/answers',
+            [
+                'answers' => [
+                    0 => [
+                        'question_id' => 1,
+                        'answer' => [
+                            'value' => 'an answer'
+                        ]
+                    ],
+                    1 => [
+                        'question_id' => 2,
+                        'answer' => [
+                            'value' => 'another answer'
+                        ]
+                    ],
+                ]
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        // Test it can retrieve the answers
+        $response = $this->json(
+            'GET',
+            'api/v1/dar/applications/' . $applicationId . '/answers',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'question_id',
+                        'application_id',
+                        'answer' => [
+                            'value'
+                        ],
+                        'contributor_id',
+                    ]
+                ]
+            ]);
+
+    }
+
+    /**
      * Creates a new dar application with merged template
      *
      * @return void

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -74,11 +74,11 @@ class DataAccessTemplateTest extends TestCase
     }
 
     /**
-     * Returns a single dar application
+     * Returns a single dar template
      *
      * @return void
      */
-    public function test_the_application_can_list_a_single_dar_application()
+    public function test_the_application_can_list_a_single_dar_template()
     {
         $response = $this->json(
             'POST',
@@ -114,6 +114,67 @@ class DataAccessTemplateTest extends TestCase
                     'questions',
                 ],
             ]);
+    }
+
+    /**
+     * Test listing dar templates by team
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_dar_templates_by_team()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => 1,
+                'published' => false,
+                'locked' => false,
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $templateId = $content['data'];
+
+        $response = $this->get('api/v1/teams/' . 1 . '/dar/templates/', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'user_id',
+                        'team_id',
+                        'published',
+                        'locked',
+                    ],
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+        $templates = $response->decodeResponseJson()['data'];
+
+        $this->assertContains($templateId, array_column($templates, 'id'));
     }
 
     /**

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -80,13 +80,51 @@ class DataAccessTemplateTest extends TestCase
      */
     public function test_the_application_can_list_a_single_dar_template()
     {
+        // Create a question to associate with the template
+        $response = $this->json(
+            'POST',
+            'api/v1/questions',
+            [
+                'section_id' => 1,
+                'user_id' => 1,
+                'force_required' => 0,
+                'allow_guidance_override' => 1,
+                'field' => [
+                    'options' => [],
+                    'component' => 'TextArea',
+                    'validations' => [
+                        [
+                            'min' => 1,
+                            'message' => 'Please enter a value'
+                        ]
+                    ]
+                ],
+                'title' => 'Test question',
+                'guidance' => 'Something helpful',
+                'required' => 0,
+                'default' => 0,
+                'version' => 1
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $questionId = $response->decodeResponseJson()['data'];
+
         $response = $this->json(
             'POST',
             'api/v1/dar/templates',
             [
                 'team_id' => 1,
-                'published' => false,
+                'published' => true,
                 'locked' => false,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                        'required' => true,
+                        'guidance' => 'Custom guidance',
+                        'order' => 2,
+                    ]
+                ]
             ],
             $this->header
         );
@@ -111,7 +149,19 @@ class DataAccessTemplateTest extends TestCase
                     'team_id',
                     'published',
                     'locked',
-                    'questions',
+                    'questions' => [
+                        0 => [
+                            'template_id',
+                            'question_id',
+                            'guidance',
+                            'required',
+                            'order',
+                            'latest_version' => [
+                                'question_json',
+                                'child_versions'
+                            ],
+                        ]
+                    ],
                 ],
             ]);
     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Endpoints added:
- `GET /dar/applications/{id}/answers`: retrieve answers to a dar application
- `PUT /dar/applications/{id}/answers`: update answers to a dar application (answers with a given question id will overwrite existing answers with that question id)
- `GET /teams/{teamId}/dar/templates`: list all templates belonging to a team

Endpoints expanded:
- `GET /dar/templates?with_questions=1`: added the option to return questions
- `GET /dar/templates/{id}`: now includes questions and latest question version

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5899

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
