### PR TITLE
fix: (GAT-5945-4) - format titles on collections post v2

### DIFF
--- a/app/Http/Controllers/Api/V2/CollectionController.php
+++ b/app/Http/Controllers/Api/V2/CollectionController.php
@@ -358,7 +358,9 @@ class CollectionController extends Controller
                 'status',
             ];
             $array = $this->checkEditArray($input, $arrayKeys);
-
+            if (array_key_exists('name', $input)) {
+                $array['name'] = format_clean_input($input['name']);
+            }
             $collection = Collection::create($array);
             $collectionId = (int) $collection->id;
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Formatting of the name was missed off from V2 endpoint, added this in.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5946
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
