### PR TITLE
GAT-5844 :: uploading Data Uses from a .xls file creates additional blank data use records

### DIFF
--- a/app/Imports/DataUsesTemplateImport.php
+++ b/app/Imports/DataUsesTemplateImport.php
@@ -4,12 +4,13 @@ namespace App\Imports;
 
 use Carbon\Carbon;
 
-use App\Http\Traits\MapOrganisationSector;
 use App\Models\Dur;
 use Maatwebsite\Excel\Concerns\ToModel;
+use App\Http\Traits\MapOrganisationSector;
 use Maatwebsite\Excel\Concerns\WithStartRow;
+use Maatwebsite\Excel\Concerns\WithValidation;
 
-class DataUsesTemplateImport implements ToModel, WithStartRow
+class DataUsesTemplateImport implements ToModel, WithStartRow, WithValidation
 {
     use MapOrganisationSector;
 
@@ -83,5 +84,20 @@ class DataUsesTemplateImport implements ToModel, WithStartRow
     private function calculateExcelDate(int $excelDate)
     {
         return Carbon::parse('1900-01-01')->addDays($excelDate);
+    }
+
+    public function rules(): array
+    {
+        return [
+            '0' => [
+                'required',
+                function ($attribute, $value, $fail) {
+                    // Skip validation if the cell is empty
+                    if (is_null($value) || trim($value) === '' || strlen(trim($value)) === 0) {
+                        return;
+                    }
+                },
+            ]
+        ];
     }
 }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
uploading Data Uses from a .xls file creates additional blank data use records

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5844

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
