### PR TITLE
feat/GAT-5759: setting Data Custodians on questions

### DIFF
--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -919,6 +919,7 @@ class QuestionBankController extends Controller
                 'archived_date' => ($input['archived'] ?? false) ? Carbon::now() : null,
                 'is_child' => false,
                 'question_type' => $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE,
+                'team_ids' => $input['all_custodians'] ? [] : $input['team_ids'],
             ]);
 
             $questionVersion = $this->createVersion($input, $question, 1);
@@ -1077,6 +1078,7 @@ class QuestionBankController extends Controller
                 'archived_date' => ($input['archived'] ?? false) ? Carbon::now() : null,
                 'is_child' => false,
                 'question_type' => $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE,
+                'team_ids' => $input['all_custodians'] ? [] : $input['team_ids'],
             ]);
 
             $latestVersion = $question->latestVersion()->first()->version;
@@ -1246,8 +1248,8 @@ class QuestionBankController extends Controller
                 ]);
             }
 
+            QuestionHasTeam::where('qb_question_id', $id)->delete();
             if ($question->question_type === QuestionBank::CUSTOM_TYPE) {
-                QuestionHasTeam::where('qb_question_id', $id)->delete();
                 if ($input['team_ids']) {
                     foreach ($input['team_ids'] as $t) {
                         QuestionHasTeam::create([
@@ -1577,8 +1579,8 @@ class QuestionBankController extends Controller
 
     private function updateQuestionHasTeams(QuestionBank $question, array $input)
     {
+        QuestionHasTeam::where('qb_question_id', $question->id)->delete();
         if ($question->question_type === QuestionBank::CUSTOM_TYPE) {
-            QuestionHasTeam::where('qb_question_id', $question->id)->delete();
             if (isset($input['team_ids']) && $input['team_ids']) {
                 foreach ($input['team_ids'] as $t) {
                     QuestionHasTeam::create([

--- a/app/Http/Controllers/Api/V1/QuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/QuestionBankController.php
@@ -730,6 +730,7 @@ class QuestionBankController extends Controller
             $question = QuestionBank::with([
                 'latestVersion',
                 'latestVersion.childVersions',
+                'teams',
             ])->findOrFail($id);
 
             if ($question) {
@@ -862,7 +863,7 @@ class QuestionBankController extends Controller
      *              required={"field", "section_id", "guidance", "title", "force_required", "allow_guidance_override", "component", "validations", "options"},
      *              @OA\Property(property="section_id", type="integer", example="1"),
      *              @OA\Property(property="user_id", type="integer", example="1"),
-     *              @OA\Property(property="team_id", type="array", @OA\Items()),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
      *              @OA\Property(property="locked", type="boolean", example="false"),
      *              @OA\Property(property="archived", type="boolean", example="false"),
      *              @OA\Property(property="required", type="boolean", example="false"),
@@ -917,7 +918,7 @@ class QuestionBankController extends Controller
                 'archived' => $input['archived'] ?? false,
                 'archived_date' => ($input['archived'] ?? false) ? Carbon::now() : null,
                 'is_child' => false,
-                'question_type' => $input['question_type'] ?? QuestionBank::STANDARD_TYPE,
+                'question_type' => $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE,
             ]);
 
             $questionVersion = $this->createVersion($input, $question, 1);
@@ -976,7 +977,7 @@ class QuestionBankController extends Controller
      *              required={"field", "section_id", "guidance", "title", "force_required", "allow_guidance_override"},
      *              @OA\Property(property="section_id", type="integer", example="1"),
      *              @OA\Property(property="user_id", type="integer", example="1"),
-     *              @OA\Property(property="team_id", type="array", @OA\Items()),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
      *              @OA\Property(property="locked", type="boolean", example="false"),
      *              @OA\Property(property="archived", type="boolean", example="false"),
      *              @OA\Property(property="is_child", type="boolean", example="false"),
@@ -1075,7 +1076,7 @@ class QuestionBankController extends Controller
                 'archived' => $input['archived'] ?? false,
                 'archived_date' => ($input['archived'] ?? false) ? Carbon::now() : null,
                 'is_child' => false,
-                'question_type' => $input['question_type'] ?? QuestionBank::STANDARD_TYPE,
+                'question_type' => $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE,
             ]);
 
             $latestVersion = $question->latestVersion()->first()->version;
@@ -1134,7 +1135,7 @@ class QuestionBankController extends Controller
      *          @OA\JsonContent(
      *              @OA\Property(property="section_id", type="integer", example="1"),
      *              @OA\Property(property="user_id", type="integer", example="1"),
-     *              @OA\Property(property="team_id", type="array", @OA\Items()),
+     *              @OA\Property(property="team_ids", type="array", @OA\Items()),
      *              @OA\Property(property="locked", type="boolean", example="false"),
      *              @OA\Property(property="archived", type="boolean", example="false"),
      *              @OA\Property(property="force_required", type="boolean", example="false"),
@@ -1206,11 +1207,13 @@ class QuestionBankController extends Controller
                 'allow_guidance_override',
                 'locked',
                 'archived',
-                'question_type',
             ];
             $array = $this->checkEditArray($input, $arrayKeys);
             if ($array['archived'] ?? false) {
                 $array['archived_date'] = Carbon::now();
+            }
+            if (array_key_exists('all_custodians', $input)) {
+                $array['question_type'] = $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE;
             }
             $question->update($array);
 
@@ -1245,8 +1248,8 @@ class QuestionBankController extends Controller
 
             if ($question->question_type === QuestionBank::CUSTOM_TYPE) {
                 QuestionHasTeam::where('qb_question_id', $id)->delete();
-                if ($input['team_id']) {
-                    foreach ($input['team_id'] as $t) {
+                if ($input['team_ids']) {
+                    foreach ($input['team_ids'] as $t) {
                         QuestionHasTeam::create([
                             'qb_question_id' => $question->id,
                             'team_id' => $t,
@@ -1536,6 +1539,7 @@ class QuestionBankController extends Controller
                             'archived' => $child['archived'] ?? false,
                             'archived_date' => ($child['archived'] ?? false) ? Carbon::now() : null,
                             'is_child' => true,
+                            'question_type' => $input['all_custodians'] ? QuestionBank::STANDARD_TYPE : QuestionBank::CUSTOM_TYPE,
                         ]);
 
                         $field = [
@@ -1575,8 +1579,8 @@ class QuestionBankController extends Controller
     {
         if ($question->question_type === QuestionBank::CUSTOM_TYPE) {
             QuestionHasTeam::where('qb_question_id', $question->id)->delete();
-            if (isset($input['team_id']) && $input['team_id']) {
-                foreach ($input['team_id'] as $t) {
+            if (isset($input['team_ids']) && $input['team_ids']) {
+                foreach ($input['team_ids'] as $t) {
                     QuestionHasTeam::create([
                         'qb_question_id' => $question->id,
                         'team_id' => $t,

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1067,6 +1067,7 @@ class SearchController extends Controller
                 $response = Http::post($urlString, $input);
 
                 $pubArray = $response['hits']['hits'];
+                var_dump('$pubArray', $pubArray);
                 $totalResults = $response['hits']['total']['value'];
                 $matchedIds = [];
                 foreach (array_values($pubArray) as $i => $d) {
@@ -1074,7 +1075,7 @@ class SearchController extends Controller
                 }
 
                 $pubModels = Publication::whereIn('id', $matchedIds)->get();
-
+                var_dump('$pubModels', $pubModels);
                 foreach ($pubArray as $i => $p) {
                     $foundFlag = false;
                     foreach ($pubModels as $model) {
@@ -1096,6 +1097,7 @@ class SearchController extends Controller
                             $datasets = $model->allDatasets;
                             $datasetLinkTypes = [];
                             $datasetVersions = [];
+                            var_dump('$datasets', $datasets);
                             foreach ($datasets as $dataset) {
                                 $linkType = PublicationHasDatasetVersion::where([
                                     ['publication_id', '=', $model['id']],
@@ -1140,9 +1142,11 @@ class SearchController extends Controller
                     }
                 }
                 $input['field'] = ['TITLE', 'ABSTRACT', 'METHODS'];
+                // var_dump($input);
                 $response = Http::post($urlString, $input);
-
+                // var_dump('$response', $response);
                 $pubArray = $response['resultList']['result'];
+                // var_dump('$pubArray', $pubArray);
                 $totalResults = $response['hitCount'];
                 foreach ($pubArray as $i => $paper) {
                     $pubArray[$i]['testid'] = $paper;

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1067,7 +1067,6 @@ class SearchController extends Controller
                 $response = Http::post($urlString, $input);
 
                 $pubArray = $response['hits']['hits'];
-                var_dump('$pubArray', $pubArray);
                 $totalResults = $response['hits']['total']['value'];
                 $matchedIds = [];
                 foreach (array_values($pubArray) as $i => $d) {
@@ -1075,7 +1074,7 @@ class SearchController extends Controller
                 }
 
                 $pubModels = Publication::whereIn('id', $matchedIds)->get();
-                var_dump('$pubModels', $pubModels);
+
                 foreach ($pubArray as $i => $p) {
                     $foundFlag = false;
                     foreach ($pubModels as $model) {
@@ -1097,7 +1096,6 @@ class SearchController extends Controller
                             $datasets = $model->allDatasets;
                             $datasetLinkTypes = [];
                             $datasetVersions = [];
-                            var_dump('$datasets', $datasets);
                             foreach ($datasets as $dataset) {
                                 $linkType = PublicationHasDatasetVersion::where([
                                     ['publication_id', '=', $model['id']],
@@ -1142,11 +1140,9 @@ class SearchController extends Controller
                     }
                 }
                 $input['field'] = ['TITLE', 'ABSTRACT', 'METHODS'];
-                // var_dump($input);
                 $response = Http::post($urlString, $input);
-                // var_dump('$response', $response);
+
                 $pubArray = $response['resultList']['result'];
-                // var_dump('$pubArray', $pubArray);
                 $totalResults = $response['hitCount'];
                 foreach ($pubArray as $i => $paper) {
                     $pubArray[$i]['testid'] = $paper;

--- a/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
+++ b/app/Http/Controllers/Api/V1/TeamQuestionBankController.php
@@ -77,7 +77,7 @@ class TeamQuestionBankController extends Controller
                 ->pluck('qb_question_id');
 
             $query = QuestionBank::with([
-                'latestVersion', 'latestVersion.childVersions'
+                'latestVersion', 'latestVersion.childVersions', 'teams'
             ])->where('archived', false)
             ->where('section_id', $sectionId)
             ->when(

--- a/app/Http/Requests/QuestionBank/CreateQuestionBank.php
+++ b/app/Http/Requests/QuestionBank/CreateQuestionBank.php
@@ -50,10 +50,10 @@ class CreateQuestionBank extends BaseFormRequest
                 'string',
                 'in:STANDARD,CUSTOM',
             ],
-            'team_id' => [
+            'team_ids' => [
                 'array'
             ],
-            'team_id.*' => [
+            'team_ids.*' => [
                 'integer'
             ],
             'options' => [
@@ -66,6 +66,9 @@ class CreateQuestionBank extends BaseFormRequest
             'validations' => [
                 'array',
             ],
+            'all_custodians' => [
+                'boolean',
+            ]
         ];
     }
 }

--- a/app/Http/Requests/QuestionBank/EditQuestionBank.php
+++ b/app/Http/Requests/QuestionBank/EditQuestionBank.php
@@ -52,11 +52,14 @@ class EditQuestionBank extends BaseFormRequest
             'default' => [
                 'boolean',
             ],
-            'team_id' => [
+            'team_ids' => [
                 'array'
             ],
-            'team_id.*' => [
+            'team_ids.*' => [
                 'integer'
+            ],
+            'all_custodians' => [
+                'boolean',
             ]
         ];
     }

--- a/app/Http/Requests/QuestionBank/UpdateQuestionBank.php
+++ b/app/Http/Requests/QuestionBank/UpdateQuestionBank.php
@@ -55,10 +55,10 @@ class UpdateQuestionBank extends BaseFormRequest
                 'required',
                 'boolean',
             ],
-            'team_id' => [
+            'team_ids' => [
                 'array'
             ],
-            'team_id.*' => [
+            'team_ids.*' => [
                 'integer'
             ],
             'options' => [
@@ -71,6 +71,9 @@ class UpdateQuestionBank extends BaseFormRequest
             'validations' => [
                 'array',
             ],
+            'all_custodians' => [
+                'boolean',
+            ]
         ];
     }
 

--- a/app/Http/Traits/QuestionBankHelpers.php
+++ b/app/Http/Traits/QuestionBankHelpers.php
@@ -34,6 +34,16 @@ trait QuestionBankHelpers
                 : $question['teams']->toArray(),
             'id'
         );
+
+        $teams = [];
+        foreach ($question['teams'] as $team) {
+            $teams[] = [
+                'id' => $team['id'],
+                'name' => $team['name'],
+            ];
+        }
+
+        $questionVersion['teams'] = $teams;
         $questionVersion['all_custodians'] = $question['question_type'] === QuestionBank::STANDARD_TYPE;
         // decode json for the FE to easily digest
         foreach ($questionVersion['question_json'] as $key => $value) {

--- a/app/Http/Traits/QuestionBankHelpers.php
+++ b/app/Http/Traits/QuestionBankHelpers.php
@@ -22,7 +22,6 @@ trait QuestionBankHelpers
             'allow_guidance_override',
             'is_child',
             'question_type',
-            'teams',
         ];
 
         foreach ($keys as $key) {

--- a/app/Http/Traits/QuestionBankHelpers.php
+++ b/app/Http/Traits/QuestionBankHelpers.php
@@ -29,7 +29,12 @@ trait QuestionBankHelpers
             $questionVersion[$key] = $question[$key];
         }
 
-        $questionVersion['team_ids'] = array_column($question['teams']->toArray(), 'id');
+        $questionVersion['team_ids'] = array_column(
+            is_array($question['teams'])
+                ? $question['teams']
+                : $question['teams']->toArray(),
+            'id'
+        );
         $questionVersion['all_custodians'] = $question['question_type'] === QuestionBank::STANDARD_TYPE;
         // decode json for the FE to easily digest
         foreach ($questionVersion['question_json'] as $key => $value) {

--- a/app/Http/Traits/QuestionBankHelpers.php
+++ b/app/Http/Traits/QuestionBankHelpers.php
@@ -22,12 +22,15 @@ trait QuestionBankHelpers
             'allow_guidance_override',
             'is_child',
             'question_type',
+            'teams',
         ];
 
         foreach ($keys as $key) {
             $questionVersion[$key] = $question[$key];
         }
 
+        $questionVersion['team_ids'] = array_column($question['teams']->toArray(), 'id');
+        $questionVersion['all_custodians'] = $question['question_type'] === QuestionBank::STANDARD_TYPE;
         // decode json for the FE to easily digest
         foreach ($questionVersion['question_json'] as $key => $value) {
             $questionVersion[$key] = $value;

--- a/app/Models/QuestionBank.php
+++ b/app/Models/QuestionBank.php
@@ -77,7 +77,7 @@ class QuestionBank extends Model
 
     public function teams(): BelongsToMany
     {
-        return $this->belongsToMany(Team::class, 'qb_question_has_team');
+        return $this->belongsToMany(Team::class, 'qb_question_has_team', 'qb_question_id', 'team_id');
     }
 
     public function section(): BelongsTo

--- a/database/seeders/QuestionBankSeeder.php
+++ b/database/seeders/QuestionBankSeeder.php
@@ -68,12 +68,8 @@ class QuestionBankSeeder extends Seeder
                             'force_required' => $question['force_required'] ?? 0,
                             'allow_guidance_override' => 1,
                             'is_child' => 0,
-                    ]);
-
-                    QuestionHasTeam::create([
-                        'qb_question_id' => $questionModel->id,
-                        'team_id' => 1,
-                    ]);
+                            'question_type' => QuestionBank::STANDARD_TYPE,
+                        ]);
 
                     $questionForJson = [
                         'field' => [
@@ -107,6 +103,7 @@ class QuestionBankSeeder extends Seeder
                                         'force_required' => $question['force_required'] ?? 0,
                                         'allow_guidance_override' => 1,
                                         'is_child' => 1,
+                                        'question_type' => QuestionBank::STANDARD_TYPE,
                                     ]);
 
                                     $component = $subquestion['input']['type'];
@@ -136,10 +133,6 @@ class QuestionBankSeeder extends Seeder
                                         'parent_qbv_id' => $questionVersionModel->id,
                                         'child_qbv_id' => $subquestionVersionModel->id,
                                         'condition' => $option['value'],
-                                    ]);
-                                    QuestionHasTeam::create([
-                                        'qb_question_id' => $subquestionModel->id,
-                                        'team_id' => 1,
                                     ]);
                                 }
                             }

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -939,6 +939,7 @@ class DataAccessApplicationTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -90,6 +90,7 @@ class DataAccessTemplateTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -255,6 +256,7 @@ class DataAccessTemplateTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -369,10 +371,11 @@ class DataAccessTemplateTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
-                'team_id' => [2],
+                'team_ids' => [2],
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'CUSTOM',
+                'all_custodians' => false,
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
@@ -436,6 +439,7 @@ class DataAccessTemplateTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -200,6 +200,7 @@ class QuestionBankTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
+                'team_ids' => [1, 2],
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'CUSTOM',

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -115,6 +115,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'STANDARD',
+                'all_custodians' => true,
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
@@ -167,6 +168,7 @@ class QuestionBankTest extends TestCase
                         'component',
                         'validations',
                         'version_id',
+                        'all_custodians',
                     ],
                 ],
                 'first_page_url',
@@ -201,6 +203,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'CUSTOM',
+                'all_custodians' => false,
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
@@ -253,6 +256,7 @@ class QuestionBankTest extends TestCase
                         'component',
                         'validations',
                         'version_id',
+                        'all_custodians',
                     ],
                 ],
                 'first_page_url',
@@ -301,6 +305,7 @@ class QuestionBankTest extends TestCase
                 'default' => 0,
                 'version' => 1,
                 'is_child' => 0,
+                'all_custodians' => true,
             ],
             $this->header
         );
@@ -339,6 +344,7 @@ class QuestionBankTest extends TestCase
                         'component',
                         'validations',
                         'version_id',
+                        'all_custodians',
                     ],
                 ],
                 'first_page_url',
@@ -370,8 +376,9 @@ class QuestionBankTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
-                'team_id' => [1],
+                'team_ids' => [1],
                 'question_type' => 'CUSTOM',
+                'all_custodians' => false,
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
@@ -426,6 +433,7 @@ class QuestionBankTest extends TestCase
                         'component',
                         'validations',
                         'version_id',
+                        'all_custodians',
                     ],
                 ],
             ]);
@@ -465,6 +473,7 @@ class QuestionBankTest extends TestCase
                 'default' => 0,
                 'version' => 1,
                 'is_child' => 0,
+                'all_custodians' => true,
             ],
             $this->header
         );
@@ -503,6 +512,7 @@ class QuestionBankTest extends TestCase
                     'component',
                     'validations',
                     'version_id',
+                    'all_custodians',
                 ],
             ]);
     }
@@ -523,6 +533,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -599,6 +610,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -635,10 +647,11 @@ class QuestionBankTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
-                'team_id' => [1],
+                'team_ids' => [1],
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'CUSTOM',
+                'all_custodians' => false,
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
@@ -678,6 +691,7 @@ class QuestionBankTest extends TestCase
                 "allow_guidance_override" => true,
                 "is_child" => 0,
                 "question_type" => "STANDARD",
+                'all_custodians' => true,
                 "title" => "Please provide the legal basis to process confidential information",
                 "guidance" => "Please confirm if consent is in place or underway for all disclosures of confidential information, if you have Section 251 exemption, or any other legal basis that you require for the project.\n\nFor England and Wales, please specify if Section 251 exemption is currently being sought and if so, please provide a Confidentiality Advisory group reference code.\n\nIn Scotland applications are required for the consented and unconsented use of data.\n",
                 "options" => [
@@ -805,6 +819,7 @@ class QuestionBankTest extends TestCase
                 "allow_guidance_override" => true,
                 "is_child" => 0,
                 "question_type" => "STANDARD",
+                'all_custodians' => true,
                 "guidance" => "Please confirm if consent is in place or underway for all disclosures of confidential information, if you have Section 251 exemption, or any other legal basis that you require for the project.\n\nFor England and Wales, please specify if Section 251 exemption is currently being sought and if so, please provide a Confidentiality Advisory group reference code.\n\nIn Scotland applications are required for the consented and unconsented use of data.\n",
                 "options" => [
                     [
@@ -915,6 +930,7 @@ class QuestionBankTest extends TestCase
                     ]
                 ],
                 'title' => 'Test question',
+                'all_custodians' => true,
                 'section_id' => 1,
                 'user_id' => 1,
                 'force_required' => 0,
@@ -953,6 +969,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -985,6 +1002,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -1037,6 +1055,7 @@ class QuestionBankTest extends TestCase
                 "allow_guidance_override" => true,
                 "is_child" => 0,
                 "question_type" => "STANDARD",
+                'all_custodians' => true,
                 "title" => "Please provide the legal basis to process confidential information",
                 "guidance" => "Please confirm if consent is in place or underway for all disclosures of confidential information, if you have Section 251 exemption, or any other legal basis that you require for the project.\n\nFor England and Wales, please specify if Section 251 exemption is currently being sought and if so, please provide a Confidentiality Advisory group reference code.\n\nIn Scotland applications are required for the consented and unconsented use of data.\n",
                 "options" => [
@@ -1159,6 +1178,7 @@ class QuestionBankTest extends TestCase
                 "allow_guidance_override" => true,
                 "is_child" => 0,
                 "question_type" => "STANDARD",
+                'all_custodians' => true,
                 "title" => "Please provide the legal basis to process confidential information",
                 "guidance" => "Please confirm if consent is in place or underway for all disclosures of confidential information, if you have Section 251 exemption, or any other legal basis that you require for the project.\n\nFor England and Wales, please specify if Section 251 exemption is currently being sought and if so, please provide a Confidentiality Advisory group reference code.\n\nIn Scotland applications are required for the consented and unconsented use of data.\n",
                 "options" => [
@@ -1251,6 +1271,7 @@ class QuestionBankTest extends TestCase
                     "no"
                 ],
                 "component" => "RadioGroup",
+                'all_custodians' => true,
                 "validations" => [],
                 "section_id" => 1,
                 "title" => "Testing that updating a child fails",
@@ -1289,6 +1310,7 @@ class QuestionBankTest extends TestCase
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'options' => [],
+                'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
                     [
@@ -1391,6 +1413,7 @@ class QuestionBankTest extends TestCase
                 "allow_guidance_override" => true,
                 "is_child" => 0,
                 "question_type" => "STANDARD",
+                'all_custodians' => true,
                 "title" => "Please provide the legal basis to process confidential information",
                 "guidance" => "Please confirm if consent is in place or underway for all disclosures of confidential information, if you have Section 251 exemption, or any other legal basis that you require for the project.\n\nFor England and Wales, please specify if Section 251 exemption is currently being sought and if so, please provide a Confidentiality Advisory group reference code.\n\nIn Scotland applications are required for the consented and unconsented use of data.\n",
                 "options" => [
@@ -1643,10 +1666,11 @@ class QuestionBankTest extends TestCase
             [
                 'section_id' => 1,
                 'user_id' => 1,
-                'team_id' => [1],
+                'team_ids' => [1],
                 'force_required' => 0,
                 'allow_guidance_override' => 1,
                 'question_type' => 'CUSTOM',
+                'all_custodians' => false,
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
- Correct the inaccurate field foreign key for QuestionHasTeam. 
- Allow use of 'all_custodians' field rather than 'question_type' in Controller to make life easier in FE form. 
- Fix seeder so all Qs are originally STANDARD with no associated teams.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5759

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Seeder will need to be run again:
`php artisan db:seed --class=QuestionBankSeeder`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
