### PR TITLE
GAT-6254 :: Pioneer Data Collection has 46-48 Duplicate Datasets

### DIFF
--- a/app/Console/Commands/CleanupCollectionsGat6254.php
+++ b/app/Console/Commands/CleanupCollectionsGat6254.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use Illuminate\Console\Command;
+use App\Models\CollectionHasDatasetVersion;
+
+class CleanupCollectionsGat6254 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cleanup-collections-gat6254 {collId?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'GAT-6254 :: The command that removes duplicates for the relationship between collections and dataset_versions';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $collId = $this->argument('collId');
+        $collections = null;
+
+        if ($collId) {
+            $this->info('collection id: ' . $collId);
+            $collections = CollectionHasDatasetVersion::where('collection_id', $collId)->select('collection_id')->get()->toArray();
+        } else {
+            $this->info('all collections');
+            $collections = CollectionHasDatasetVersion::select('collection_id')->get()->toArray();
+        }
+
+        if (count($collections) === 0) {
+            $this->error('No collection found for ' . $collId . '!');
+            return Command::FAILURE;
+        }
+
+        $collectionIds = array_unique(convertArrayToArrayWithKeyName($collections, 'collection_id'));
+
+        foreach ($collectionIds as $collectionId) {
+            $collectionDatasetVersions = CollectionHasDatasetVersion::where('collection_id', $collectionId)->select('dataset_version_id')->get()->toArray();
+            $collectionDatasetVersionIds = array_unique(convertArrayToArrayWithKeyName($collectionDatasetVersions, 'dataset_version_id'));
+
+            foreach ($collectionDatasetVersionIds as $collectionDatasetVersionId) {
+                // checking if dataset_versions.id exists in the dataset_versions table
+                $datasetVersion = DatasetVersion::where('id', $collectionDatasetVersionId)->select('dataset_id')->first();
+                if (is_null($datasetVersion)) {
+                    CollectionHasDatasetVersion::where([
+                        'collection_id' => $collectionId,
+                        'dataset_version_id' => $collectionDatasetVersionId,
+                    ])->delete();
+                    $this->warn('1. delete collection_id = ' . $collectionId . ' &  dataset_version_id = ' . $collectionDatasetVersionId);
+                    continue;
+                }
+
+                // checking if datasets.id based on dataset_versions.id exists in the datasets table
+                $dataset = Dataset::where('id', $datasetVersion->dataset_id)->select('id')->first();
+                if (is_null($dataset)) {
+                    CollectionHasDatasetVersion::where([
+                        'collection_id' => $collectionId,
+                        'dataset_version_id' => $collectionDatasetVersionId,
+                    ])->delete();
+                    $this->warn('2. delete collection_id = ' . $collectionId . ' &  dataset_version_id = ' . $collectionDatasetVersionId);
+                    continue;
+                }
+
+                $latestDatasetVersionId = Dataset::where('id', (int) $dataset->id)->select('id')->first()->latestVersion()->id;
+                if ((int) $latestDatasetVersionId === (int) $collectionDatasetVersionId) {
+                    continue;
+                }
+
+                if ((int) $latestDatasetVersionId !== (int) $collectionDatasetVersionId) {
+                    $checkCollectionHasDatasetVersion = CollectionHasDatasetVersion::where([
+                        'collection_id' => $collectionId,
+                        'dataset_version_id' => $latestDatasetVersionId,
+                    ])->first();
+
+                    if (!is_null($checkCollectionHasDatasetVersion)) {
+                        $this->addRelationWithLatestDatasetVersion($collectionId, $collectionDatasetVersionId, $latestDatasetVersionId);
+                        $this->warn('3. delete collection_id = ' . $collectionId . ' &  dataset_version_id = ' . $collectionDatasetVersionId);
+                        continue;
+                    }
+
+                    if (is_null($checkCollectionHasDatasetVersion)) {
+                        $this->addRelationWithLatestDatasetVersion($collectionId, $collectionDatasetVersionId, $latestDatasetVersionId);
+                        $this->warn('4. create collection_id = ' . $collectionId . ' &  dataset_version_id = ' . $collectionDatasetVersionId);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        $this->info('Command completed successfully.');
+        return Command::SUCCESS;
+    }
+
+    public function addRelationWithLatestDatasetVersion($collectionId, $collectionDatasetVersionId, $latestDatasetVersionId)
+    {
+        $getCollectionHasDatasetVersion = CollectionHasDatasetVersion::where([
+            'collection_id' => $collectionId,
+            'dataset_version_id' => $collectionDatasetVersionId,
+        ])->first();
+
+        CollectionHasDatasetVersion::create([
+            'collection_id' => $collectionId,
+            'dataset_version_id' => $latestDatasetVersionId,
+            'user_id' => $getCollectionHasDatasetVersion->user_id,
+        ]);
+
+        CollectionHasDatasetVersion::create([
+            'collection_id' => $collectionId,
+            'dataset_version_id' => $collectionDatasetVersionId,
+        ])->delete();
+    }
+}

--- a/app/Console/Commands/CleanupCollectionsGat6254.php
+++ b/app/Console/Commands/CleanupCollectionsGat6254.php
@@ -85,7 +85,10 @@ class CleanupCollectionsGat6254 extends Command
                     ])->first();
 
                     if (!is_null($checkCollectionHasDatasetVersion)) {
-                        $this->addRelationWithLatestDatasetVersion($collectionId, $collectionDatasetVersionId, $latestDatasetVersionId);
+                        CollectionHasDatasetVersion::where([
+                            'collection_id' => $collectionId,
+                            'dataset_version_id' => $collectionDatasetVersionId,
+                        ])->delete();
                         $this->warn('3. delete collection_id = ' . $collectionId . ' &  dataset_version_id = ' . $collectionDatasetVersionId);
                         continue;
                     }

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1250,7 +1250,7 @@ class CollectionController extends Controller
     private function checkDatasets(int $collectionId, array $inDatasets, int $userId = null)
     {
         $collectionHastDatasetVersions = CollectionHasDatasetVersion::withTrashed()
-                                            ->where(['collection_id' => $collectionId])
+                                            ->where('collection_id', $collectionId)
                                             ->select('dataset_version_id')
                                             ->get()
                                             ->toArray();

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1261,7 +1261,7 @@ class CollectionController extends Controller
         }
 
         foreach ($inDatasets as $dataset) {
-            $datasetVersionId = Dataset::where('id', (int) $dataset['id'])->select('id')->first()->latestVersion()->id;
+            $datasetVersionLatestId = Dataset::where('id', (int) $dataset['id'])->select('id')->first()->latestVersion()->id;
 
             $datasetVersions = DatasetVersion::where('dataset_id', (int) $dataset['id'])->select('id')->get()->toArray();
 
@@ -1269,12 +1269,12 @@ class CollectionController extends Controller
             $commonDatasetVersionIds = array_intersect($collectionHastDatasetVersionIds, $datasetVersionIds);
 
             if (count($commonDatasetVersionIds) === 0) {
-                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionId, $userId);
+                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionLatestId, $userId);
                 continue;
             }
 
-            if (!in_array($datasetVersionId, $commonDatasetVersionIds)) {
-                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionId, $userId);
+            if (!in_array($datasetVersionLatestId, $commonDatasetVersionIds)) {
+                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionLatestId, $userId);
                 foreach ($commonDatasetVersionIds as $commonDatasetVersionId) {
                     CollectionHasDatasetVersion::where([
                         'collection_id' => $collectionId,
@@ -1284,9 +1284,9 @@ class CollectionController extends Controller
                 continue;
             }
 
-            if (in_array($datasetVersionId, $commonDatasetVersionIds)) {
+            if (in_array($datasetVersionLatestId, $commonDatasetVersionIds)) {
                 foreach ($commonDatasetVersionIds as $commonDatasetVersionId) {
-                    if ((int) $datasetVersionId === (int) $commonDatasetVersionId) {
+                    if ((int) $datasetVersionLatestId === (int) $commonDatasetVersionId) {
                         $checkCollectionWithLatestDatasetVersionActive = CollectionHasDatasetVersion::where([
                             'collection_id' => $collectionId,
                             'dataset_version_id' => $commonDatasetVersionId,
@@ -1352,7 +1352,7 @@ class CollectionController extends Controller
                 $arrCreate['updated_at'] = $dataset['updated_at'];
             }
 
-            return CollectionHasDatasetVersion::withTrashed()->updateOrCreate($searchArray, $arrCreate);
+            return CollectionHasDatasetVersion::create($arrCreate);
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$arrCreate['user_id'],

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1352,7 +1352,13 @@ class CollectionController extends Controller
                 $arrCreate['updated_at'] = $dataset['updated_at'];
             }
 
-            return CollectionHasDatasetVersion::create($arrCreate);
+            $checkRow = CollectionHasDatasetVersion::where($searchArray)->first();
+            if (is_null($checkRow)) {
+                return CollectionHasDatasetVersion::create($arrCreate);
+            } else {
+                return $checkRow;
+            }
+
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$arrCreate['user_id'],

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1255,7 +1255,7 @@ class CollectionController extends Controller
                                             ->get()
                                             ->toArray();
 
-        $collectionHastDatasetVersions = [];
+        $collectionHastDatasetVersionIds = [];
         if (count($collectionHastDatasetVersions)) {
             $collectionHastDatasetVersionIds = array_unique(convertArrayToArrayWithKeyName($collectionHastDatasetVersions, 'dataset_version_id'));
         }

--- a/app/Http/Traits/CollectionsV2Helpers.php
+++ b/app/Http/Traits/CollectionsV2Helpers.php
@@ -121,29 +121,74 @@ trait CollectionsV2Helpers
     // datasets
     private function checkDatasets(int $collectionId, array $inDatasets, int $userId = null)
     {
-        $cols = CollectionHasDatasetVersion::where(['collection_id' => $collectionId])->get();
-        foreach ($cols as $col) {
-            $datasetId = DatasetVersion::where('id', $col->dataset_version_id)->select('dataset_id')->get();
-            if (count($datasetId) > 0) {
-                if (!in_array($datasetId[0]['dataset_id'], $this->extractInputIdToArray($inDatasets))) {
-                    $this->deleteCollectionHasDatasetVersions($collectionId, $col->dataset_version_id);
-                }
-            }
+        $collectionHastDatasetVersions = CollectionHasDatasetVersion::withTrashed()
+                                            ->where('collection_id', $collectionId)
+                                            ->select('dataset_version_id')
+                                            ->get()
+                                            ->toArray();
+
+        $collectionHastDatasetVersionIds = [];
+        if (count($collectionHastDatasetVersions)) {
+            $collectionHastDatasetVersionIds = array_unique(convertArrayToArrayWithKeyName($collectionHastDatasetVersions, 'dataset_version_id'));
         }
 
-        // LS - This is superflous.
         foreach ($inDatasets as $dataset) {
-            $datasetVersionId = Dataset::where('id', (int) $dataset['id'])->first()->latestVersion()->id;
-            $checking = $this->checkInCollectionHasDatasetVersions($collectionId, $datasetVersionId);
+            $datasetVersionLatestId = Dataset::where('id', (int) $dataset['id'])->select('id')->first()->latestVersion()->id;
 
-            if (!$checking) {
-                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionId, $userId);
-            } else {
-                if ($checking['deleted_at']) {
-                    CollectionHasDatasetVersion::withTrashed()->where([
+            $datasetVersions = DatasetVersion::where('dataset_id', (int) $dataset['id'])->select('id')->get()->toArray();
+
+            $datasetVersionIds = convertArrayToArrayWithKeyName($datasetVersions, 'id');
+            $commonDatasetVersionIds = array_intersect($collectionHastDatasetVersionIds, $datasetVersionIds);
+
+            if (count($commonDatasetVersionIds) === 0) {
+                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionLatestId, $userId);
+                continue;
+            }
+
+            if (!in_array($datasetVersionLatestId, $commonDatasetVersionIds)) {
+                $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionLatestId, $userId);
+                foreach ($commonDatasetVersionIds as $commonDatasetVersionId) {
+                    CollectionHasDatasetVersion::where([
                         'collection_id' => $collectionId,
-                        'dataset_version_id' => $datasetVersionId,
-                    ])->update(['deleted_at' => null]);
+                        'dataset_version_id' => $commonDatasetVersionId,
+                    ])->delete();
+                }
+                continue;
+            }
+
+            if (in_array($datasetVersionLatestId, $commonDatasetVersionIds)) {
+                foreach ($commonDatasetVersionIds as $commonDatasetVersionId) {
+                    if ((int) $datasetVersionLatestId === (int) $commonDatasetVersionId) {
+                        $checkCollectionWithLatestDatasetVersionActive = CollectionHasDatasetVersion::where([
+                            'collection_id' => $collectionId,
+                            'dataset_version_id' => $commonDatasetVersionId,
+                        ])->first();
+
+                        if (!is_null($checkCollectionWithLatestDatasetVersionActive)) {
+                            continue;
+                        }
+
+                        $checkCollectionWithLatestDatasetVersionDeleted = CollectionHasDatasetVersion::onlyTrashed()
+                            ->where([
+                                'collection_id' => $collectionId,
+                                'dataset_version_id' => $commonDatasetVersionId,
+                            ])->first();
+
+                        if (!is_null($checkCollectionWithLatestDatasetVersionDeleted)) {
+                            CollectionHasDatasetVersion::withTrashed()->where([
+                                'collection_id' => $collectionId,
+                                'dataset_version_id' => $commonDatasetVersionId,
+                            ])
+                            ->limit(1)
+                            ->update(['deleted_at' => null]);
+                            continue;
+                        }
+                    } else {
+                        CollectionHasDatasetVersion::where([
+                            'collection_id' => $collectionId,
+                            'dataset_version_id' => $commonDatasetVersionId,
+                        ])->delete();
+                    }
                 }
             }
         }

--- a/app/Http/Traits/CollectionsV2Helpers.php
+++ b/app/Http/Traits/CollectionsV2Helpers.php
@@ -224,7 +224,12 @@ trait CollectionsV2Helpers
                 $arrCreate['updated_at'] = $dataset['updated_at'];
             }
 
-            return CollectionHasDatasetVersion::withTrashed()->updateOrCreate($searchArray, $arrCreate);
+            $checkRow = CollectionHasDatasetVersion::where($searchArray)->first();
+            if (is_null($checkRow)) {
+                return CollectionHasDatasetVersion::create($arrCreate);
+            } else {
+                return $checkRow;
+            }
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$arrCreate['user_id'],

--- a/tests/Feature/CollectionTeamTest.php
+++ b/tests/Feature/CollectionTeamTest.php
@@ -48,7 +48,7 @@ class CollectionTeamTest extends TestCase
         setUp as commonSetUp;
     }
 
-    private function test_url(int $teamId)
+    private function testUrl(int $teamId)
     {
         return '/api/v1/teams/' . $teamId . '/collections/';
     }
@@ -225,7 +225,7 @@ class CollectionTeamTest extends TestCase
         // create a Collection as that user in the selected team
         $response = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockData,
             $this->headerNonAdmin
         );
@@ -278,14 +278,13 @@ class CollectionTeamTest extends TestCase
         // create a Collection as that user in the selected team
         $response = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockData,
             $this->headerNonAdmin
         );
 
         $countAfter = Collection::count();
         $countNewRow = $countAfter - $countBefore;
-
         $response->assertStatus(201);
         $this->assertTrue((bool) $countNewRow, 'Response was successful');
 
@@ -332,7 +331,7 @@ class CollectionTeamTest extends TestCase
 
         $response = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIn,
             $this->headerNonAdmin
         );
@@ -361,7 +360,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIn,
+            $this->testUrl($team->id) . $idIn,
             $mockDataUpdate,
             $this->headerNonAdmin
         );
@@ -388,7 +387,7 @@ class CollectionTeamTest extends TestCase
 
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIn,
+            $this->testUrl($team->id) . $idIn,
             $mockDataUpdate,
             $headerNonAdmin2
         );
@@ -429,7 +428,7 @@ class CollectionTeamTest extends TestCase
 
         $responseIn = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIns,
             $this->headerNonAdmin
         );
@@ -471,7 +470,7 @@ class CollectionTeamTest extends TestCase
 
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIn,
+            $this->testUrl($team->id) . $idIn,
             $mockDataUpdate,
             $headerNonAdmin2
         );
@@ -509,7 +508,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseIn = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIn,
             $this->headerNonAdmin
         );
@@ -534,7 +533,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIn,
+            $this->testUrl($team->id) . $idIn,
             $mockDataUpdate,
             $this->headerNonAdmin
         );
@@ -571,11 +570,10 @@ class CollectionTeamTest extends TestCase
         ];
         $responseIns = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIns,
             $this->headerNonAdmin
         );
-
         $responseIns->assertStatus(201);
         $idIns = (int) $responseIns['data'];
 
@@ -595,7 +593,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIns,
+            $this->testUrl($team->id) . $idIns,
             $mockDataUpdate,
             $this->headerNonAdmin
         );
@@ -614,7 +612,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseEdit1 = $this->json(
             'PATCH',
-            $this->test_url($team->id) . $idIns,
+            $this->testUrl($team->id) . $idIns,
             $mockDataEdit1,
             $this->headerNonAdmin
         );
@@ -644,7 +642,7 @@ class CollectionTeamTest extends TestCase
 
         $responseEdit2 = $this->json(
             'PATCH',
-            $this->test_url($team->id) . $idIns,
+            $this->testUrl($team->id) . $idIns,
             $mockDataEdit2,
             $headerNonAdmin2
         );
@@ -684,7 +682,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseIns = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIns,
             $this->headerNonAdmin
         );
@@ -708,7 +706,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseUpdate = $this->json(
             'PUT',
-            $this->test_url($team->id) . $idIns,
+            $this->testUrl($team->id) . $idIns,
             $mockDataUpdate,
             $this->headerNonAdmin
         );
@@ -745,7 +743,7 @@ class CollectionTeamTest extends TestCase
 
         $responseEdit1 = $this->json(
             'PATCH',
-            $this->test_url($team->id) . $idIns,
+            $this->testUrl($team->id) . $idIns,
             $mockDataEdit1,
             $headerNonAdmin2
         );
@@ -787,7 +785,7 @@ class CollectionTeamTest extends TestCase
         ];
         $responseIn = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIn,
             $this->headerNonAdmin
         );
@@ -815,7 +813,7 @@ class CollectionTeamTest extends TestCase
         }
 
         // try to delete collection when not in the correct team - this will fail
-        $response = $this->json('DELETE', $this->test_url($team->id) . $idIn, [], $headerNonAdmin2);
+        $response = $this->json('DELETE', $this->testUrl($team->id) . $idIn, [], $headerNonAdmin2);
         $response->assertStatus(401);
 
         $countAfter = Collection::count();
@@ -826,7 +824,7 @@ class CollectionTeamTest extends TestCase
 
 
         // delete collection when authorised
-        $response = $this->json('DELETE', $this->test_url($team->id) . $idIn, [], $this->headerNonAdmin);
+        $response = $this->json('DELETE', $this->testUrl($team->id) . $idIn, [], $this->headerNonAdmin);
         $response->assertStatus(200);
 
         $countAfter = Collection::count();
@@ -837,7 +835,7 @@ class CollectionTeamTest extends TestCase
 
         $response = $this->json(
             'PATCH',
-            $this->test_url($team->id) . $idIn . '?unarchive',
+            $this->testUrl($team->id) . $idIn . '?unarchive',
             ['status' => 'ACTIVE'],
             $this->headerNonAdmin
         );
@@ -883,14 +881,14 @@ class CollectionTeamTest extends TestCase
         ];
         $responseIn = $this->json(
             'POST',
-            $this->test_url($team->id),
+            $this->testUrl($team->id),
             $mockDataIn,
             $this->headerNonAdmin
         );
         $responseIn->assertStatus(201);
         $idIn = (int) $responseIn['data'];
 
-        $response = $this->json('DELETE', $this->test_url($team->id) . $idIn, [], $this->headerNonAdmin);
+        $response = $this->json('DELETE', $this->testUrl($team->id) . $idIn, [], $this->headerNonAdmin);
         $response->assertStatus(200);
     }
 
@@ -998,6 +996,7 @@ class CollectionTeamTest extends TestCase
             'message'
         ]);
         $firstResponsePost->assertStatus(201);
+
         return [
             "nonAdminUser" => $nonAdminUser,
             "team" => $team

--- a/tests/Feature/CollectionTeamTest.php
+++ b/tests/Feature/CollectionTeamTest.php
@@ -335,7 +335,6 @@ class CollectionTeamTest extends TestCase
             $mockDataIn,
             $this->headerNonAdmin
         );
-
         $response->assertStatus(201);
         $idIn = (int) $response['data'];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Pioneer Data Collection has 46-48 Duplicate Datasets

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6254

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run command for one collection
```
php artisan app:cleanup-collections-gat6254 {collectionId}
```
or 
run command for all collections
```
php artisan app:cleanup-collections-gat6254
```

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
