### PR TITLE
GAT-6275 :: Timeout when searching for publications

### DIFF
--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -507,8 +507,8 @@ trait IndexElastic
                 $latestVersionID = Dataset::where(['id' => $dataset['id']])->first()->latestVersion()->id;
                 $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
                 $linkType = PublicationHasDatasetVersion::where([
-                    ['publication_id', '=', (int)$id],
-                    ['dataset_version_id', '=', (int)$latestVersionID]
+                    'publication_id' => (int)$id,
+                    'dataset_version_id' => (int)$latestVersionID
                 ])->first()->link_type ?? 'UNKNOWN';
                 $datasetLinkTypes[] =  array_key_exists($linkType, $linkTypeMappings) ? $linkTypeMappings[$linkType] : 'Unknown';
             }


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-01-28 at 16 23 04](https://github.com/user-attachments/assets/51ffe57a-9428-4b9d-90a9-89d9e5d89edc)

## Describe your changes
Timeout when searching for publications using the "Publication & dataset relationship" filter.

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6275

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
- delete publication entity from elastic search with elastic search server
- create publication entity in elastic search with search service server
- run reindex publications

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
