### PR TITLE
feat(GAT-6224): Add permissions to dar/applications endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
@@ -237,6 +237,10 @@ class DataAccessApplicationController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
+            $application = DataAccessApplication::findOrFail($id);
+            if ($application->submission_status === 'DRAFT') {
+                throw new Exception('Files associated with a data access request cannot be viewed when the request is still a draft.');
+            }
             $uploads = Upload::where('entity_id', $id)->get();
 
             if ($uploads) {
@@ -320,6 +324,10 @@ class DataAccessApplicationController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
+            $application = DataAccessApplication::findOrFail($id);
+            if ($application->submission_status === 'DRAFT') {
+                throw new Exception('Files associated with a data access request cannot be downloaded when the request is still a draft.');
+            }
             $file = Upload::where('id', $fileId)->first();
 
             if ($file) {

--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -6,11 +6,14 @@ use Auditor;
 use Config;
 use Exception;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Storage;
 use App\Exceptions\UnauthorizedException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\DataAccessApplication\CreateUserDataAccessApplicationAnswer;
 use App\Http\Requests\DataAccessApplication\EditUserDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\DeleteUserDataAccessApplicationFile;
 use App\Http\Requests\DataAccessApplication\GetUserDataAccessApplication;
+use App\Http\Requests\DataAccessApplication\GetUserDataAccessApplicationFile;
 use App\Http\Requests\DataAccessApplication\UpdateUserDataAccessApplication;
 use App\Http\Traits\DataAccessApplicationHelpers;
 use App\Jobs\SendEmailJob;
@@ -23,7 +26,9 @@ use App\Models\Role;
 use App\Models\Team;
 use App\Models\TeamHasUser;
 use App\Models\TeamUserHasRole;
+use App\Models\Upload;
 use App\Models\User;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class UserDataAccessApplicationController extends Controller
 {
@@ -212,6 +217,202 @@ class UserDataAccessApplicationController extends Controller
             return response()->json([
                 'message' => $e->getMessage(),
             ], Config::get('statuscodes.STATUS_UNAUTHORIZED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/users/{userId}/dar/applications/{id}/files",
+     *      summary="Return a list of files associated with a DAR application",
+     *      description="Return a list of files associated with a DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@showFiles",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\Parameter(
+     *         name="userId",
+     *         in="path",
+     *         description="User id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="User id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="filename", type="string"),
+     *                  @OA\Property(property="file_location", type="string"),
+     *                  @OA\Property(property="user_id", type="string"),
+     *                  @OA\Property(property="status", type="string"),
+     *                  @OA\Property(property="application_id", type="integer"),
+     *                  @OA\Property(property="question_id", type="integer"),
+     *                  @OA\Property(property="error", type="string")
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function showFiles(GetUserDataAccessApplication $request, int $userId, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $application = DataAccessApplication::findOrFail($id);
+            if (($jwtUser['id'] != $userId) || ($jwtUser['id'] != $application->applicant_id)) {
+                throw new UnauthorizedException('User does not have permission to use this endpoint to view these files.');
+            }
+            $uploads = Upload::where('entity_id', $id)->get();
+
+            if ($uploads) {
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'GET',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataAccessApplication list files ' . $id,
+                ]);
+
+                return response()->json([
+                    'message' => Config::get('statuscodes.STATUS_OK.message'),
+                    'data' => $uploads,
+                ], Config::get('statuscodes.STATUS_OK.code'));
+            }
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')
+            ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/users/{userId}/dar/applications/{id}/files/{fileId}/download",
+     *      summary="Download a file associated with a DAR application",
+     *      description="Download a file associated with a DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@downloadFile",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\Parameter(
+     *         name="userId",
+     *         in="path",
+     *         description="User id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="User id",
+     *         ),
+     *      ),
+     *      @OA\Parameter(
+     *         name="fileId",
+     *         in="path",
+     *         description="File id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="File id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\MediaType(
+     *              mediaType="file"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function downloadFile(GetUserDataAccessApplicationFile $request, int $userId, int $id, int $fileId): StreamedResponse | JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $application = DataAccessApplication::findOrFail($id);
+            if (($jwtUser['id'] != $userId) || ($jwtUser['id'] != $application->applicant_id)) {
+                throw new UnauthorizedException('User does not have permission to use this endpoint to download this files.');
+            }
+            $file = Upload::where('id', $fileId)->first();
+
+            if ($file) {
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'GET',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataAccessApplication ' . $id . ' download file ' . $fileId,
+                ]);
+
+                return Storage::disk(env('SCANNING_FILESYSTEM_DISK', 'local_scan') . '.scanned')
+                    ->download($file->file_location);
+            }
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')
+            ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -548,6 +749,114 @@ class UserDataAccessApplicationController extends Controller
             return response()->json([
                 'message' => $e->getMessage(),
             ], Config::get('statuscodes.STATUS_UNAUTHORIZED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v1/users/{userId}/dar/applications/{id}/files/{fileId}",
+     *      summary="Delete a file associated with a DAR application",
+     *      description="Delete a file associated with a DAR application",
+     *      tags={"DataAccessApplication"},
+     *      summary="DataAccessApplication@destroyFile",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DAR application id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DAR application id",
+     *         ),
+     *      ),
+     *      @OA\Parameter(
+     *         name="userId",
+     *         in="path",
+     *         description="User id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="User id",
+     *         ),
+     *      ),
+     *      @OA\Parameter(
+     *         name="fileId",
+     *         in="path",
+     *         description="File id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="File id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroyFile(DeleteUserDataAccessApplicationFile $request, int $userId, int $id, int $fileId): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $application = DataAccessApplication::findOrFail($id);
+            if (($jwtUser['id'] != $userId) || ($jwtUser['id'] != $application->applicant_id)) {
+                throw new UnauthorizedException('User does not have permission to use this endpoint to delete this file.');
+            }
+            if ($application->submission_status !== 'DRAFT') {
+                throw new Exception('Files cannot be deleted after a data access request has been submitted.');
+            }
+
+            $file = Upload::where('id', $fileId)->first();
+
+            Storage::disk(env('SCANNING_FILESYSTEM_DISK', 'local_scan') . '.scanned')
+                ->delete($file->file_location);
+
+            $file->delete();
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication ' . $id . ' file ' . $fileId . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Requests/DataAccessApplication/DeleteUserDataAccessApplicationFile.php
+++ b/app/Http/Requests/DataAccessApplication/DeleteUserDataAccessApplicationFile.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class DeleteUserDataAccessApplicationFile extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+            'fileId' => [
+                'int',
+                'required',
+                'exists:uploads,id',
+            ],
+            'userId' => [
+                'int',
+                'required',
+                'exists:users,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'id' => $this->route('id'),
+            'fileId' => $this->route('fileId'),
+            'userId' => $this->route('userId'),
+        ]);
+    }
+}

--- a/app/Http/Requests/DataAccessApplication/GetUserDataAccessApplicationFile.php
+++ b/app/Http/Requests/DataAccessApplication/GetUserDataAccessApplicationFile.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\DataAccessApplication;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetUserDataAccessApplicationFile extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'int',
+                'required',
+                'exists:dar_applications,id',
+            ],
+            'fileId' => [
+                'int',
+                'required',
+                'exists:uploads,id',
+            ],
+            'userId' => [
+                'int',
+                'required',
+                'exists:users,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'id' => $this->route('id'),
+            'fileId' => $this->route('fileId'),
+            'userId' => $this->route('userId'),
+        ]);
+    }
+}

--- a/app/Models/DataAccessApplication.php
+++ b/app/Models/DataAccessApplication.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/app/Models/DataAccessApplication.php
+++ b/app/Models/DataAccessApplication.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+#[ObservedBy([DataAccessApplicationObserver::class])]
 class DataAccessApplication extends Model
 {
     use HasFactory;

--- a/app/Models/DataAccessApplication.php
+++ b/app/Models/DataAccessApplication.php
@@ -8,13 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-#[ObservedBy([DataAccessApplicationObserver::class])]
 class DataAccessApplication extends Model
 {
     use HasFactory;

--- a/config/routes.php
+++ b/config/routes.php
@@ -3888,6 +3888,35 @@ return [
     [
         'name' => 'dar/applications',
         'method' => 'get',
+        'path' => 'users/{userId}/dar/applications/{id}/files',
+        'methodController' => 'UserDataAccessApplicationController@showFiles',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+            'userId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => '/users/{userId}/dar/applications/{id}/files/{fileId}/download',
+        'methodController' => 'UserDataAccessApplicationController@downloadFile',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+            'fileId' => '[0-9]+',
+            'userId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
         'path' => '/dar/applications/{id}/answers',
         'methodController' => 'DataAccessApplicationController@showAnswers',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
@@ -4041,6 +4070,21 @@ return [
         'constraint' => [
             'id' => '[0-9]+',
             'fileId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'delete',
+        'path' => '/users/{userId}/dar/applications/{id}/files/{fileId}',
+        'methodController' => 'UserDataAccessApplicationController@destroyFile',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+            'fileId' => '[0-9]+',
+            'userId' => '[0-9]+',
         ],
     ],
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -3824,6 +3824,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
         ],
         'constraint' => [],
     ],
@@ -3835,6 +3836,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3862,6 +3864,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3875,6 +3878,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3889,6 +3893,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3916,6 +3921,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.status.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3957,6 +3963,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'check.access:permissions,data-access-applications.provider.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3986,6 +3993,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'check.access:permissions,data-access-applications.provider.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4014,6 +4022,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4027,6 +4036,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4043,6 +4053,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.review.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4056,6 +4067,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.review.create',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4070,6 +4082,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,data-access-applications.review.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4085,6 +4098,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Added permissions to the `dar/applications` endpoints. Also added new endpoints for applicant to access/manage files they upload as part of a data access request.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6224

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
