### PR TITLE
fix(GAT-6223): check if team id is numeric

### DIFF
--- a/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
@@ -567,17 +567,18 @@ class DataAccessApplicationController extends Controller
 
                 $gatewayId = $metadata['metadata']['summary']['publisher']['gatewayId'];
                 // check for primary key or pid match...
-                $team = Team::where('id', $gatewayId)->first();
-                if (!$team) {
+                if (is_numeric($gatewayId)) {
+                    $team = Team::where('id', $gatewayId)->first();
+                } else {
                     $team = Team::where('pid', $gatewayId)->first();
-                    if (!$team) {
-                        CloudLogger::write([
-                            'action_type' => 'CREATE',
-                            'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                            'description' => 'Unable to create data access application for dataset with id ' . $d . ', no matching team found.',
-                        ]);
-                        continue;
-                    }
+                }
+                if (!$team) {
+                    CloudLogger::write([
+                        'action_type' => 'CREATE',
+                        'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                        'description' => 'Unable to create data access application for dataset with id ' . $d . ', no matching team found.',
+                    ]);
+                    continue;
                 }
                 $teams[] = $team;
             }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Changing the logic in template merging.  Previously when the team id in the metadata was a `pid` starting with a number it could mistakenly match to the `id` of a different team e.g. 
```
> $teamId = '4cc3dcd6-2928-4c7d-aa47-99f53ce9ab20';
> $team = Team::where('pid', $teamId)->first();
> $team->id // returns team 1 - this is the correct team

> $team = Team::where('id', $teamId)->first(); // try to match on id 
> $team->id // returns team 4 - a match on the wrong team!
```
Now the code checks if the team id in the metadata is numeric. If true, it looks for matches on id; if false it looks for matches on pid.

I did not add a test because I couldn't recreate the issue in the test environment (MySQL vs SQLite issue maybe?) but I tested that this fixed the issue using my local set up.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
