### PR TITLE
GAT-6300 :: Random ordering in search does not behave as expected under pagination

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -258,9 +258,6 @@ class SearchController extends Controller
                 return Excel::download(new DatasetTableExport($datasetsArray), 'datasets.csv');
             }
 
-            // return response()->json([
-            //     $datasetsArray, $sortField, $sortDirection,
-            // ], 200);
             $datasetsArray = $this->sortSearchResult($datasetsArray, $sortField, $sortDirection);
 
             $perPage = request('perPage', Config::get('constants.per_page'));

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -258,6 +258,9 @@ class SearchController extends Controller
                 return Excel::download(new DatasetTableExport($datasetsArray), 'datasets.csv');
             }
 
+            // return response()->json([
+            //     $datasetsArray, $sortField, $sortDirection,
+            // ], 200);
             $datasetsArray = $this->sortSearchResult($datasetsArray, $sortField, $sortDirection);
 
             $perPage = request('perPage', Config::get('constants.per_page'));
@@ -1746,7 +1749,11 @@ class SearchController extends Controller
             usort(
                 $resultArray,
                 function ($a, $b) use ($sortField) {
-                    return -1 * ($a['_source'][$sortField] <=> $b['_source'][$sortField]);
+                    if (is_string($b['_source'][$sortField])) {
+                        return strtoupper($b['_source'][$sortField]) <=> strtoupper($a['_source'][$sortField]);
+                    } else {
+                        return $b['_source'][$sortField] <=> $a['_source'][$sortField];
+                    }
                 }
             );
         }

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -267,6 +267,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => $response['aggregations'],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);
@@ -578,6 +579,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => $response['aggregations'],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);
@@ -735,6 +737,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => $response['aggregations'],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);
@@ -918,6 +921,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => $response['aggregations'],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);
@@ -1166,6 +1170,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => isset($response['aggregations']) ? $response['aggregations'] : [],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);
@@ -1660,6 +1665,7 @@ class SearchController extends Controller
             $aggs = collect([
                 'aggregations' => $response['aggregations'],
                 'elastic_total' => $totalResults,
+                'ids' => $matchedIds,
             ]);
 
             $final = $aggs->merge($paginatedData);

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1067,6 +1067,7 @@ class SearchController extends Controller
 
             $source = !is_null($input['source']) ? $input['source'] : 'GAT';
 
+            $matchedIds = null;
             if ($source === 'GAT') {
                 $aggs = Filter::where('type', 'paper')->get()->toArray();
                 $input['aggs'] = $aggs;
@@ -1167,11 +1168,14 @@ class SearchController extends Controller
             $paginatedData = $this->paginateArray($request, $pubArray, $perPage);
             unset($pubArray);
 
-            $aggs = collect([
+            $arrAggs = [
                 'aggregations' => isset($response['aggregations']) ? $response['aggregations'] : [],
                 'elastic_total' => $totalResults,
-                'ids' => $matchedIds,
-            ]);
+            ];
+            if  ($matchedIds) {
+                $arrAggs['ids'] = $matchedIds;
+            }
+            $aggs = collect($arrAggs);
 
             $final = $aggs->merge($paginatedData);
 


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-02-11 at 10 27 58](https://github.com/user-attachments/assets/dfa8561b-0dbc-4075-a24d-4d6df2d10463)

![Screenshot 2025-02-11 at 10 29 00](https://github.com/user-attachments/assets/c48c40f4-5c72-4a9f-b8d4-5c341fb73340)


## Describe your changes
Random ordering in search does not behave as expected under pagination

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6300

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
