### PR TITLE
feat(GAT-5909): Set up teams/dars endpoint for custodian dashboard

### DIFF
--- a/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessApplicationController.php
@@ -30,6 +30,7 @@ use App\Models\DataAccessTemplate;
 use App\Models\Dataset;
 use App\Models\EmailTemplate;
 use App\Models\Team;
+use App\Models\TeamHasDataAccessApplication;
 use App\Models\Upload;
 use App\Models\User;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -581,6 +582,11 @@ class DataAccessApplicationController extends Controller
                     continue;
                 }
                 $teams[] = $team;
+
+                TeamHasDataAccessApplication::create([
+                    'dar_application_id' => $application->id,
+                    'team_id' => $team->id,
+                ]);
             }
 
             // compile questions from each teams template

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Auditor;
+use Carbon\Carbon;
+use Config;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Http\Traits\RequestTransformation;
+use App\Models\DataAccessApplication;
+use App\Models\DataAccessApplicationReview;
+use App\Models\DataAccessApplicationStatus;
+use App\Models\Dataset;
+use App\Models\Team;
+use App\Models\TeamHasDataAccessApplication;
+
+class TeamDataAccessApplicationController extends Controller
+{
+    use RequestTransformation;
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/teams/{teamId}/dar/applications",
+     *      summary="List of dar applications belonging to a team",
+     *      description="List of dar applications belonging to a team",
+     *      tags={"TeamDataAccessApplication"},
+     *      summary="TeamDataAccessApplication@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="applicant_id", type="integer", example="1"),
+     *                      @OA\Property(property="submission_status", type="string", example="SUBMITTED"),
+     *                      @OA\Property(property="approval_status", type="string", example="APPORVED"),
+     *                      @OA\Property(property="project_title", type="string", example="A project"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(Request $request, int $teamId): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $applicationIds = TeamHasDataAccessApplication::where('team_id', $teamId)
+                ->select('dar_application_id')
+                ->pluck('dar_application_id');
+
+            $filterTitle = $request->query('project_title', null);
+            $filterApproval = $request->query('approval_status', null);
+            $filterSubmission = $request->query('submission_status', null);
+            $filterAction = isset($input['action_required']) ?
+                $request->boolean('action_required', null) : null;
+
+            $applications = DataAccessApplication::whereIn('id', $applicationIds)
+                ->when($filterTitle, function ($query) use ($filterTitle) {
+                    return $query->where('project_title', 'LIKE', "%{$filterTitle}%");
+                })
+                ->when($filterApproval, function ($query) use ($filterApproval) {
+                    return $query->where('approval_status', '=', $filterApproval);
+                })
+                ->when($filterSubmission, function ($query) use ($filterSubmission) {
+                    return $query->where('submission_status', '=', $filterSubmission);
+                })
+                ->select(['id'])->get();
+
+            $matches = [];
+            foreach ($applications as $a) {
+                $matches[] = $a->id;
+            }
+
+            if (!is_null($filterAction)) {
+                $actionMatches = [];
+                foreach ($matches as $m) {
+                    $reviews = DataAccessApplicationReview::where('application_id', $m)
+                        ->select(['resolved'])->pluck('resolved')->toArray();
+                    $resolved = in_array(false, $reviews) ? false : true;
+
+                    if ((bool) $filterAction === $resolved) {
+                        $actionMatches[] = $m;
+                    }
+                }
+                $matches = array_intersect($matches, $actionMatches);
+            }
+
+            $applications = DataAccessApplication::whereIn('id', $matches)
+                ->with(['user:id,name,organisation','datasets'])
+                ->applySorting()
+                ->paginate(
+                    Config::get('constants.per_page'),
+                    ['*'],
+                    'page'
+                );
+
+            foreach ($applications as $app) {
+                foreach ($app['datasets'] as $d) {
+                    $dataset = Dataset::where('id', $d['dataset_id'])->first();
+                    $title = $dataset->getTitle();
+                    $custodian = Team::where('id', $dataset->team_id)->select(['id','name'])->first();
+                    $d['dataset_title'] = $title;
+                    $d['custodian'] = $custodian;
+                }
+
+                $submissionAudit = DataAccessApplicationStatus::where([
+                    'application_id' => $app->id,
+                    'submission_status' => 'SUBMITTED',
+                ])->first();
+                if ($submissionAudit) {
+                    $app['days_since_submission'] = $submissionAudit
+                        ->updated_at
+                        ->diffInDays(Carbon::today());
+                } else {
+                    $app['days_since_submission'] = null;
+                }
+            }
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataAccessApplication get all by team',
+            ]);
+
+            return response()->json(
+                $applications
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *    path="/api/v1/teams/{teamId}/dar/applications/count/{field}",
+     *    operationId="count_unique_fields_dar_applications",
+     *    tags={"TeamDataAccessApplications"},
+     *    summary="TeamDataAccessApplicationController@count",
+     *    description="Get Counts for distinct entries of a field in the model",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\Parameter(
+     *       name="field",
+     *       in="path",
+     *       description="name of the field to perform a count on",
+     *       required=true,
+     *       example="approval_status",
+     *       @OA\Schema(
+     *          type="string",
+     *          description="approval status field",
+     *       ),
+     *    ),
+     *    @OA\Response(
+     *       response="200",
+     *       description="Success response",
+     *       @OA\JsonContent(
+     *          @OA\Property(
+     *             property="data",
+     *             type="object",
+     *          )
+     *       )
+     *    )
+     * )
+     */
+    public function count(Request $request, int $teamId, string $field): JsonResponse
+    {
+        try {
+            $applicationIds = TeamHasDataAccessApplication::where('team_id', $teamId)
+                ->select('dar_application_id')
+                ->pluck('dar_application_id');
+
+            $counts = DataAccessApplication::whereIn('id', $applicationIds)
+                ->select($field)
+                ->get()
+                ->groupBy($field)
+                ->map->count();
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => "Team DAR application count",
+            ]);
+
+            return response()->json([
+                "data" => $counts
+            ]);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+}

--- a/app/Models/DataAccessApplication.php
+++ b/app/Models/DataAccessApplication.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Observers\DataAccessApplicationObserver;
 
+use App\Models\Traits\SortManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
@@ -18,6 +19,7 @@ class DataAccessApplication extends Model
     use HasFactory;
     use Notifiable;
     use SoftDeletes;
+    use SortManager;
     use Prunable;
 
     /**
@@ -38,6 +40,11 @@ class DataAccessApplication extends Model
         'project_title',
     ];
 
+    protected static array $sortableColumns = [
+        'project_title',
+        'updated_at',
+    ];
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'applicant_id');
@@ -52,4 +59,10 @@ class DataAccessApplication extends Model
     {
         return $this->hasMany(DataAccessApplicationAnswer::class, 'application_id');
     }
+
+    public function datasets(): HasMany
+    {
+        return $this->hasMany(DataAccessApplicationHasDataset::class, 'dar_application_id');
+    }
+
 }

--- a/app/Models/DataAccessApplicationStatus.php
+++ b/app/Models/DataAccessApplicationStatus.php
@@ -23,6 +23,7 @@ class DataAccessApplicationStatus extends Model
     protected $fillable = [
         'application_id',
         'approval_status',
+        'submission_status',
     ];
 
 }

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -179,6 +179,20 @@ class Dataset extends Model
     }
 
     /**
+     * Helper function to grab dataset title from latest metadata.
+     */
+    public function getTitle(): string
+    {
+        $version = DatasetVersion::where('dataset_id', $this->id)
+            ->select(['version','id'])
+            ->orderBy('version', 'desc')
+            ->first()
+            ->id;
+        $datasetVersion = DatasetVersion::findOrFail($version)->toArray();
+        return $datasetVersion['metadata']['metadata']['summary']['title'];
+    }
+
+    /**
      * Order by raw metadata extract
      */
     public function scopeOrderByMetadata(Builder $query, string $field, string $direction): Builder

--- a/app/Models/TeamHasDataAccessApplication.php
+++ b/app/Models/TeamHasDataAccessApplication.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamHasDataAccessApplication extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id', 'dar_application_id',
+    ];
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'team_has_dar_applications';
+}

--- a/app/Observers/DataAccessApplicationObserver.php
+++ b/app/Observers/DataAccessApplicationObserver.php
@@ -18,5 +18,12 @@ class DataAccessApplicationObserver
                 'approval_status' => $application->approval_status,
             ]);
         }
+
+        if ($application->wasChanged('submission_status')) {
+            DataAccessApplicationStatus::create([
+                'application_id' => $application->id,
+                'submission_status' => $application->submission_status,
+            ]);
+        }
     }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -3846,6 +3846,30 @@ return [
     [
         'name' => 'dar/applications',
         'method' => 'get',
+        'path' => 'teams/{teamId}/dar/applications',
+        'methodController' => 'TeamDataAccessApplicationController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => 'teams/{teamId}/dar/applications/count/{field}',
+        'methodController' => 'TeamDataAccessApplicationController@count',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
         'path' => '/dar/applications/{id}',
         'methodController' => 'DataAccessApplicationController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',

--- a/database/migrations/2025_02_17_134506_create_team_has_data_access_applications_table.php
+++ b/database/migrations/2025_02_17_134506_create_team_has_data_access_applications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('team_has_dar_applications', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->bigInteger('dar_application_id')->unsigned();
+            $table->bigInteger('team_id')->unsigned();
+
+            $table->foreign('dar_application_id')->references('id')->on('dar_applications');
+            $table->foreign('team_id')->references('id')->on('teams');
+
+            $table->unique(['dar_application_id', 'team_id']);
+            $table->index('dar_application_id');
+            $table->index('team_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('team_has_dar_applications');
+    }
+};

--- a/database/migrations/2025_02_19_084134_update_dar_application_statuses_table.php
+++ b/database/migrations/2025_02_19_084134_update_dar_application_statuses_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dar_application_statuses', function (Blueprint $table) {
+            $table->string('submission_status')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dar_application_statuses', function (Blueprint $table) {
+            $table->dropIfExists('submission_status');
+        });
+    }
+};

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -876,6 +876,221 @@ class DataAccessApplicationTest extends TestCase
     }
 
     /**
+     * Lists dar applications by team
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_dar_applications_by_team()
+    {
+        // Create team with a dataset and a dar template containing known question
+        $teamId = $this->createTeam();
+        $questionId = $this->createQuestion('Test Question One');
+
+        // Create template and datasets owned by teams
+        $team = Team::where('id', $teamId)->first();
+
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/templates',
+            [
+                'team_id' => $teamId,
+                'published' => true,
+                'locked' => false,
+                'questions' => [
+                    0 => [
+                        'id' => $questionId,
+                        'required' => true,
+                        'guidance' => 'Question One Guidance',
+                        'order' => 1,
+                    ],
+                ]
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        $metadata = $this->getMetadata();
+        $metadata['metadata']['summary']['publisher'] = [
+            'name' => $team->name,
+            'gatewayId' => $team->id
+        ];
+        $responseDataset = $this->json(
+            'POST',
+            'api/v1/datasets',
+            [
+                'team_id' => $teamId,
+                'user_id' => 1,
+                'metadata' => $metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status' => Dataset::STATUS_ACTIVE,
+            ],
+            $this->header,
+        );
+        $responseDataset->assertStatus(201);
+        $datasetId = $responseDataset['data'];
+
+        // Create first DAR application for that dataset
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'DRAFT',
+                'project_title' => 'First test DAR',
+                'dataset_ids' => [$datasetId],
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+        $applicationIdOne = $response->decodeResponseJson()['data'];
+
+        // Create second DAR application for that dataset
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications',
+            [
+                'applicant_id' => 1,
+                'submission_status' => 'SUBMITTED',
+                'project_title' => 'Second test DAR',
+                'dataset_ids' => [$datasetId],
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+        $applicationIdTwo = $response->decodeResponseJson()['data'];
+
+        // Update approval status of application two
+        $response = $this->json(
+            'PATCH',
+            'api/v1/dar/applications/' . $applicationIdTwo,
+            [
+                'approval_status' => 'APPROVED_COMMENTS',
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        // Add a review to second DAR application
+        $response = $this->json(
+            'POST',
+            'api/v1/dar/applications/' . $applicationIdTwo . '/questions/' . $questionId . '/reviews',
+            [
+                'comment' => 'A test review comment',
+                'team_id' => $teamId
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data'
+            ]);
+
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'applicant_id',
+                        'submission_status',
+                        'project_title',
+                        'approval_status',
+                        'days_since_submission',
+                        'user' => [
+                            'id',
+                            'name',
+                            'organisation'
+                        ],
+                        'datasets' => [
+                            0 => [
+                                'dataset_id',
+                                'dataset_title',
+                                'custodian' => [
+                                    'id',
+                                    'name'
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications?sort=project_title:desc',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($applicationIdTwo, $content['data'][0]['id']);
+
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications?submission_status=SUBMITTED',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(1, count($content['data']));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications?approval_status=APPROVED_COMMENTS',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(1, count($content['data']));
+
+        // action required = false should return the dar with a review that is
+        // waiting for a response from the applicant
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications?action_required=false',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($applicationIdTwo, $content['data'][0]['id']);
+        $this->assertEquals(1, count($content['data']));
+    }
+
+    /**
      * Creates a new dar application with merged template
      *
      * @return void

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -1088,6 +1088,20 @@ class DataAccessApplicationTest extends TestCase
         $content = $response->decodeResponseJson();
         $this->assertEquals($applicationIdTwo, $content['data'][0]['id']);
         $this->assertEquals(1, count($content['data']));
+
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications/count/submission_status',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'SUBMITTED',
+                    'DRAFT',
+                ]
+            ]);
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Create /teams/{id}/dar/applications endpoint to populate custodian DAR dashboard. Includes sorting, filtering and dataset/custodian information.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5909

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
