### PR TITLE
fix(GAT-6215): correct the handling of urls with spaces

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'fix/gat-6215-2'
+      - 'dev'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/gat-6215-2
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/gat-6215-2
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - 'fix/gat-6215-2'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/gat-6215-2
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/gat-6215-2
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -1183,7 +1183,7 @@ class CollectionController extends Controller
 
         if ($collection) {
             $collection->image_link = trim($collection->image_link);
-            if ($collection->image_link && !filter_var($collection->image_link, FILTER_VALIDATE_URL)) {
+            if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
                 $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
             }
 

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -193,7 +193,7 @@ class CollectionController extends Controller
             $collections->getCollection()->transform(function ($collection) {
                 $collection->image_link = trim($collection->image_link);
                 if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                    $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
+                    $collection->image_link = urlencode(Config::get('services.media.base_url') . $collection->image_link);
                 }
 
                 return $collection;
@@ -1184,7 +1184,7 @@ class CollectionController extends Controller
         if ($collection) {
             $collection->image_link = trim($collection->image_link);
             if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
+                $collection->image_link = urlencode(Config::get('services.media.base_url') . $collection->image_link);
             }
 
             if($collection->users) {

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -192,7 +192,7 @@ class CollectionController extends Controller
 
             $collections->getCollection()->transform(function ($collection) {
                 $collection->image_link = trim($collection->image_link);
-                if ($collection->image_link && !filter_var($collection->image_link, FILTER_VALIDATE_URL)) {
+                if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
                     $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
                 }
 

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -192,8 +192,8 @@ class CollectionController extends Controller
 
             $collections->getCollection()->transform(function ($collection) {
                 $collection->image_link = trim($collection->image_link);
-                if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                    $collection->image_link = urlencode(Config::get('services.media.base_url') . $collection->image_link);
+                if ($collection->image_link && !preg_match('/^https?:\/\//', $collection->image_link)) {
+                    $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
                 }
 
                 return $collection;
@@ -1183,8 +1183,8 @@ class CollectionController extends Controller
 
         if ($collection) {
             $collection->image_link = trim($collection->image_link);
-            if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                $collection->image_link = urlencode(Config::get('services.media.base_url') . $collection->image_link);
+            if ($collection->image_link && !preg_match('/^https?:\/\//', $collection->image_link)) {
+                $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
             }
 
             if($collection->users) {

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -193,7 +193,7 @@ class CollectionController extends Controller
             $collections->getCollection()->transform(function ($collection) {
                 $collection->image_link = trim($collection->image_link);
                 if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                    $collection->image_link = Config::get('services.media.base_url') . '/' .  $collection->image_link;
+                    $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
                 }
 
                 return $collection;
@@ -1184,7 +1184,7 @@ class CollectionController extends Controller
         if ($collection) {
             $collection->image_link = trim($collection->image_link);
             if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                $collection->image_link = Config::get('services.media.base_url') . '/' . $collection->image_link;
+                $collection->image_link = Config::get('services.media.base_url') . $collection->image_link;
             }
 
             if($collection->users) {

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -193,7 +193,7 @@ class CollectionController extends Controller
             $collections->getCollection()->transform(function ($collection) {
                 $collection->image_link = trim($collection->image_link);
                 if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                    $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
+                    $collection->image_link = Config::get('services.media.base_url') . '/' .  $collection->image_link;
                 }
 
                 return $collection;
@@ -1184,7 +1184,7 @@ class CollectionController extends Controller
         if ($collection) {
             $collection->image_link = trim($collection->image_link);
             if ($collection->image_link && !filter_var(urlencode($collection->image_link), FILTER_VALIDATE_URL)) {
-                $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
+                $collection->image_link = Config::get('services.media.base_url') . '/' . $collection->image_link;
             }
 
             if($collection->users) {

--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -77,7 +77,7 @@ class DataProviderCollController extends Controller
                 ])->where('enabled', 1)
                 ->paginate((int) $perPage, ['*'], 'page')
                 ->through(function ($item) use ($mediaBaseUrl) {
-                    $item->img_url = (is_null($item->img_url) || strlen(trim($item->img_url)) === 0) ? null : (filter_var($item->img_url, FILTER_VALIDATE_URL) ? $item->img_url : $mediaBaseUrl . $item->img_url);
+                    $item->img_url = (is_null($item->img_url) || strlen(trim($item->img_url)) === 0) ? null : (preg_match('/^https?:\/\//', $item->img_url) ? $item->img_url : $mediaBaseUrl . $item->img_url);
                     return $item;
                 });
 
@@ -155,7 +155,7 @@ class DataProviderCollController extends Controller
                 ])->where('id', $id)->firstOrFail();
 
             $mediaBaseUrl = Config::get('services.media.base_url');
-            $dpc->img_url = (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? null : (filter_var($dpc->img_url, FILTER_VALIDATE_URL) ? $dpc->img_url : $mediaBaseUrl . $dpc->img_url);
+            $dpc->img_url = (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? null : (preg_match('/^https?:\/\//', $dpc->img_url) ? $dpc->img_url : $mediaBaseUrl . $dpc->img_url);
 
             Auditor::log([
                 'action_type' => 'GET',
@@ -291,7 +291,7 @@ class DataProviderCollController extends Controller
                 'updated_at'
             )->whereIn('id', $this->collections)->where('status', 'ACTIVE')->get()->toArray();
             $collections = array_map(function ($collection) {
-                if ($collection['image_link'] && !filter_var($collection['image_link'], FILTER_VALIDATE_URL)) {
+                if ($collection['image_link'] && !preg_match('/^https?:\/\//', $collection->image_link)) {
                     $collection['image_link'] = Config::get('services.media.base_url') . $collection['image_link'];
                 }
                 return $collection;
@@ -302,7 +302,7 @@ class DataProviderCollController extends Controller
             $result = [
                 'id' => $dpc->id,
                 'name' => $dpc->name,
-                'img_url' => (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? '' : (filter_var($dpc->img_url, FILTER_VALIDATE_URL) ? $dpc->img_url : Config::get('services.media.base_url') . $dpc->img_url),
+                'img_url' => (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? '' : (preg_match('/^https?:\/\//', $dpc->img_url) ? $dpc->img_url : Config::get('services.media.base_url') . $dpc->img_url),
                 'summary' => $dpc->summary,
                 'enabled' => $dpc->enabled,
                 'url' => $dpc->url,

--- a/app/Http/Controllers/Api/V1/FormHydrationController.php
+++ b/app/Http/Controllers/Api/V1/FormHydrationController.php
@@ -156,7 +156,7 @@ class FormHydrationController extends Controller
         $defaultValues = array();
         $defaultValues['identifier'] = $team['id'];
         $defaultValues['Name of data provider'] = $team['name'];
-        $defaultValues['Organisation Logo'] = (is_null($team['team_logo']) || strlen(trim($team['team_logo'])) === 0) ? null : (filter_var($team['team_logo'], FILTER_VALIDATE_URL) ? $team['team_logo'] : Config::get('services.media.base_url') . $team['team_logo']);
+        $defaultValues['Organisation Logo'] = (is_null($team['team_logo']) || strlen(trim($team['team_logo'])) === 0) ? null : (preg_match('/^https?:\/\//', $team['team_logo']) ? $team['team_logo'] : Config::get('services.media.base_url') . $team['team_logo']);
         $defaultValues['Organisation Description'] = $team['name'];
         $defaultValues['contact point'] = $team['contact_point']; //warning - this is `summary.dataCustodian.contact_point`, not `summary.contact_point` which is called "Contact point"
         $defaultValues['Organisation Membership'] = $team['memberOf'];

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -715,7 +715,7 @@ class SearchController extends Controller
                         $collectionArray[$i]['dataProviderColl'] = $this->getDataProviderColl($model->toArray());
                         $collectionArray[$i]['image_link'] = (is_null($model['image_link']) || strlen(trim($model['image_link'])) === 0
                                                              ? null
-                                                             : ((filter_var($model['image_link'], FILTER_VALIDATE_URL))
+                                                             : (preg_match('/^https?:\/\//', $model['image_link'])
                                                              ? $model['image_link']
                                                              : Config::get('services.media.base_url') . $model['image_link']));
                         $foundFlag = true;
@@ -1480,7 +1480,7 @@ class SearchController extends Controller
                         $dataProviderCollArray[$i]['id'] = $model['id'];
                         $dataProviderCollArray[$i]['_source']['updated_at'] = $model['updated_at'];
                         $dataProviderCollArray[$i]['name'] = $model['name'];
-                        $dataProviderCollArray[$i]['img_url'] =  (is_null($model['img_url']) || strlen(trim($model['img_url'])) === 0 || (filter_var($model['img_url'], FILTER_VALIDATE_URL)) ? null : Config::get('services.media.base_url') . $model['img_url']);
+                        $dataProviderCollArray[$i]['img_url'] =  (is_null($model['img_url']) || strlen(trim($model['img_url'])) === 0 || (preg_match('/^https?:\/\//', $model['img_url'])) ? null : Config::get('services.media.base_url') . $model['img_url']);
                         $dataProviderCollArray[$i]['datasetTitles'] = $this->dataProviderDatasetTitles($model);
                         $dataProviderCollArray[$i]['geographicLocations'] = $this->dataProviderLocations($model);
                         $foundFlag = true;
@@ -1640,7 +1640,7 @@ class SearchController extends Controller
                     if ((int)$dp['_id'] === $model['id']) {
                         $dataProviderArray[$i]['_source']['updated_at'] = $model['updated_at'];
                         $dataProviderArray[$i]['name'] = $model['name'];
-                        $dataProviderArray[$i]['team_logo'] = (is_null($model['team_logo']) || strlen(trim($model['team_logo'])) === 0) ? '' : (filter_var($model['team_logo'], FILTER_VALIDATE_URL) ? $model['team_logo'] : Config::get('services.media.base_url') . $model['team_logo']);
+                        $dataProviderArray[$i]['team_logo'] = (is_null($model['team_logo']) || strlen(trim($model['team_logo'])) === 0) ? '' : (preg_match('/^https?:\/\//', $model['team_logo']) ? $model['team_logo'] : Config::get('services.media.base_url') . $model['team_logo']);
                         $foundFlag = true;
                         break;
                     }

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -486,7 +486,7 @@ class TeamController extends Controller
                 ->toArray();
 
             $collections = array_map(function ($collection) {
-                if ($collection['image_link'] && !filter_var($collection['image_link'], FILTER_VALIDATE_URL)) {
+                if ($collection['image_link'] && !preg_match('/^https?:\/\//', $collection->image_link)) {
                     $collection['image_link'] = Config::get('services.media.base_url') . $collection['image_link'];
                 }
                 return $collection;
@@ -509,7 +509,7 @@ class TeamController extends Controller
                 'data' => [
                     'id' => $dp->id,
                     'is_provider' => $dp->is_provider,
-                    'team_logo' => (is_null($dp->team_logo) || strlen(trim($dp->team_logo)) === 0) ? '' : (filter_var($dp->team_logo, FILTER_VALIDATE_URL) ? $dp->team_logo : Config::get('services.media.base_url') . $dp->team_logo),
+                    'team_logo' => (is_null($dp->team_logo) || strlen(trim($dp->team_logo)) === 0) ? '' : (preg_match('/^https?:\/\//', $dp->team_logo) ? $dp->team_logo : Config::get('services.media.base_url') . $dp->team_logo),
                     'url' => $dp->url,
                     'service' => empty($service) ? null : $service,
                     'name' => $dp->name,

--- a/app/Http/Controllers/Api/V2/CollectionController.php
+++ b/app/Http/Controllers/Api/V2/CollectionController.php
@@ -989,7 +989,7 @@ class CollectionController extends Controller
         ->first();
 
         if ($collection) {
-            if ($collection->image_link && !filter_var($collection->image_link, FILTER_VALIDATE_URL)) {
+            if ($collection->image_link && !preg_match('/^https?:\/\//', $collection->image_link)) {
                 $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
             }
 

--- a/app/Http/Traits/CollectionsV2Helpers.php
+++ b/app/Http/Traits/CollectionsV2Helpers.php
@@ -85,7 +85,7 @@ trait CollectionsV2Helpers
         ->first();
 
         if ($collection) {
-            if ($collection->image_link && !filter_var($collection->image_link, FILTER_VALIDATE_URL)) {
+            if ($collection->image_link && !preg_match('/^https?:\/\//', $collection->image_link)) {
                 $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
             }
 
@@ -671,7 +671,7 @@ trait CollectionsV2Helpers
 
     public function prependUrl($collection)
     {
-        if ($collection->image_link && !filter_var($collection->image_link, FILTER_VALIDATE_URL)) {
+        if ($collection->image_link && !preg_match('/^https?:\/\//', $collection->image_link)) {
             $collection->image_link = Config::get('services.media.base_url') .  $collection->image_link;
         }
 

--- a/app/Http/Traits/TeamTransformation.php
+++ b/app/Http/Traits/TeamTransformation.php
@@ -45,7 +45,7 @@ trait TeamTransformation
                 'url' => $team['url'],
                 'introduction' => $team['introduction'],
                 'dar_modal_content' => $team['dar_modal_content'],
-                'team_logo' => (is_null($team['team_logo']) || strlen(trim($team['team_logo'])) === 0) ? '' : (filter_var($team['team_logo'], FILTER_VALIDATE_URL) ? $team['team_logo'] : Config::get('services.media.base_url') . $team['team_logo']),
+                'team_logo' => (is_null($team['team_logo']) || strlen(trim($team['team_logo'])) === 0) ? '' : (preg_match('/^https?:\/\//', $team['team_logo']) ? $team['team_logo'] : Config::get('services.media.base_url') . $team['team_logo']),
                 'service' => $team['service'],
             ];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Media files that are uploaded with spaces in their filenames later trigger incorrect behaviour when tested with `filter_var(x, FILTER_VALIDATE_URL)` as they fail that test.

This PR changes that behaviour in all places it occurs, to use `preg_match` instead. This can handle spaces, which the FE can also naturally handle.

H/T @JamieByrneHDRUK  for his help

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6215

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
