### PR TITLE
fix!(GAT-6495): allow specifying input schema for dataset integrations

### DIFF
--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -291,7 +291,7 @@ class DataProviderCollController extends Controller
                 'updated_at'
             )->whereIn('id', $this->collections)->where('status', 'ACTIVE')->get()->toArray();
             $collections = array_map(function ($collection) {
-                if ($collection['image_link'] && !preg_match('/^https?:\/\//', $collection->image_link)) {
+                if ($collection['image_link'] && !preg_match('/^https?:\/\//', $collection['image_link'])) {
                     $collection['image_link'] = Config::get('services.media.base_url') . $collection['image_link'];
                 }
                 return $collection;

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -727,8 +727,10 @@ class DatasetController extends Controller
                 "publisherName" => $team['name']
             ];
 
-            $inputSchema = isset($input['metadata']['schemaModel']) ? $input['metadata']['schemaModel'] : null;
-            $inputVersion = isset($input['metadata']['schemaVersion']) ? $input['metadata']['schemaVersion'] : null;
+            $inputSchema = isset($input['metadata']['schemaModel']) ?
+                $input['metadata']['schemaModel'] : $request->query('input_schema', null);
+            $inputVersion = isset($input['metadata']['schemaVersion']) ?
+                $input['metadata']['schemaVersion'] : $request->query('input_version', null);
 
             $submittedMetadata = ($input['metadata']['metadata'] ?? $input['metadata']);
             $gwdmMetadata = null;

--- a/app/Http/Controllers/Api/V1/IntegrationDatasetController.php
+++ b/app/Http/Controllers/Api/V1/IntegrationDatasetController.php
@@ -426,6 +426,20 @@ class IntegrationDatasetController extends Controller
      *          )
      *       )
      *    ),
+     *    @OA\Parameter(
+     *       name="input_schema",
+     *       in="query",
+     *       description="Input schema model.",
+     *       example="HDRUK",
+     *       @OA\Schema(type="string")
+     *    ),
+     *    @OA\Parameter(
+     *       name="input_version",
+     *       in="query",
+     *       description="Input schema version.",
+     *       example="3.0.0",
+     *       @OA\Schema(type="string")
+     *     ),
      *      @OA\Response(
      *          response=201,
      *          description="Created",
@@ -466,11 +480,14 @@ class IntegrationDatasetController extends Controller
 
             $input['metadata'] = $this->extractMetadata($input);
 
+            $inputSchema = $request->query('input_schema', null);
+            $inputVersion = $request->query('input_version', null);
+
             //send the payload to traser
             // - traser will return the input unchanged if the data is
             //   already in the GWDM with GWDM_CURRENT_VERSION
             // - if it is not, traser will try to work out what the metadata is
-            //   and translate it into the GWDM
+            //   and translate it into the GWDM (unless input schema and version are specified)
             // - otherwise traser will return a non-200 error
 
             $payload = $input['metadata'];
@@ -486,6 +503,8 @@ class IntegrationDatasetController extends Controller
                 json_encode($payload),
                 Config::get('metadata.GWDM.name'),
                 Config::get('metadata.GWDM.version'),
+                $inputSchema,
+                $inputVersion,
             );
 
             if ($traserResponse['wasTranslated']) {
@@ -663,6 +682,20 @@ class IntegrationDatasetController extends Controller
      *          description="dataset id",
      *       ),
      *    ),
+     *    @OA\Parameter(
+     *       name="input_schema",
+     *       in="query",
+     *       description="Input schema model.",
+     *       example="HDRUK",
+     *       @OA\Schema(type="string")
+     *    ),
+     *    @OA\Parameter(
+     *       name="input_version",
+     *       in="query",
+     *       description="Input schema version.",
+     *       example="3.0.0",
+     *       @OA\Schema(type="string")
+     *    ),
      *    @OA\RequestBody(
      *       required=true,
      *       description="Pass user credentials",
@@ -726,6 +759,9 @@ class IntegrationDatasetController extends Controller
 
             $input['metadata'] = $this->extractMetadata($input);
 
+            $inputSchema = $request->query('input_schema', null);
+            $inputVersion = $request->query('input_version', null);
+
             $payload = $input['metadata'];
             $payload['extra'] = [
                 'id' => $id,
@@ -738,7 +774,9 @@ class IntegrationDatasetController extends Controller
             $traserResponse = MMC::translateDataModelType(
                 json_encode($payload),
                 Config::get('metadata.GWDM.name'),
-                Config::get('metadata.GWDM.version')
+                Config::get('metadata.GWDM.version'),
+                $inputSchema,
+                $inputVersion,
             );
 
             if ($traserResponse['wasTranslated']) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adding query parameters `input_schema` and `input_model` to the POST/PUT methods in the IntegrationDatasetController to combat "unknown schema" errors from traser.  These query parameters are used in the equivalent methods in the DatasetController, so the change partly brings the integrations methods back into alignment with the main controller, since they have diverged.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6495

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
