### PR TITLE
feat(GAT-6362): Fix observer action in patch

### DIFF
--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -682,11 +682,12 @@ class UserDataAccessApplicationController extends Controller
             $newStatus = $input['submission_status'] ?? null;
 
             if (($newStatus === 'SUBMITTED') && ($originalStatus != 'SUBMITTED')) {
-                TeamHasDataAccessApplication::where([
+                $thd = TeamHasDataAccessApplication::where([
                     'dar_application_id' => $id
-                ])->first()->update([
-                    'submission_status' => $newStatus
-                ]);
+                ])->get();
+                foreach ($thd as $t) {
+                    $t->update(['submission_status' => $newStatus]);
+                }
                 $this->emailSubmissionNotification($id, $userId, $application);
             }
 
@@ -921,11 +922,12 @@ class UserDataAccessApplicationController extends Controller
             $newStatus = $input['submission_status'] ?? null;
 
             if (($newStatus === 'SUBMITTED') && ($status != 'SUBMITTED')) {
-                TeamHasDataAccessApplication::where([
+                $thd = TeamHasDataAccessApplication::where([
                     'dar_application_id' => $id
-                ])->update([
-                    'submission_status' => $newStatus
-                ]);
+                ])->get();
+                foreach ($thd as $t) {
+                    $t->update(['submission_status' => $newStatus]);
+                }
                 $this->emailSubmissionNotification($id, $userId, $application);
             }
 

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -1840,6 +1840,26 @@ class DataAccessApplicationTest extends TestCase
 
         $response = $this->json(
             'PATCH',
+            'api/v1/users/1/dar/applications/' . $applicationId,
+            [
+                'submission_status' => 'SUBMITTED',
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($content['data']['teams'][0]['submission_status'], 'SUBMITTED');
+
+        // Clear test queue
+        Queue::fake();
+
+        $response = $this->json(
+            'PATCH',
             'api/v1/teams/' . $teamId . '/dar/applications/' . $applicationId,
             [
                 'approval_status' => 'APPROVED',
@@ -1871,7 +1891,8 @@ class DataAccessApplicationTest extends TestCase
 
         $statusCountNew = count($responseStatus->decodeResponseJson()['data']);
 
-        $this->assertEquals($statusCountNew, $statusCountInit + 1);
+        // Check for 2 new status entries - submission and approval
+        $this->assertEquals($statusCountNew, $statusCountInit + 2);
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Observer wasn't being triggered to update the status log in users PATCH endpoint. Added a test for that scenario.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6362

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
