### PR TITLE
fix!(GAT-5832): Issue with Peter Harrison's account returning a 500 error when querying library

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -1044,6 +1044,12 @@ class TeamController extends Controller
         try {
             $team = Team::findOrFail($teamId);
             if ($team) {
+                $existsDatasets = Dataset::where('team_id', $teamId)->select('id')->first();
+
+                if (!is_null($existsDatasets)) {
+                    throw new Exception('The team cannot be deleted as there are datasets currently assigned to it.');
+                }
+
                 TeamHasNotification::where('team_id', $teamId)->delete();
 
                 $deletePermanently = false;

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -502,22 +502,6 @@ class DatasetTest extends TestCase
         $responseDeleteDataset->assertJsonStructure([
             'message'
         ]);
-
-        for ($i = 1; $i <= 2; $i++) {
-            // delete team
-            $responseDeleteTeam = $this->json(
-                'DELETE',
-                self::TEST_URL_TEAM . '/' . ${'teamId' . $i} . '?deletePermanently=true',
-                [],
-                $this->header
-            );
-
-            $responseDeleteTeam->assertJsonStructure([
-                'message'
-            ]);
-            $responseDeleteTeam->assertStatus(200);
-        }
-
     }
 
 

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -504,10 +504,6 @@ class DatasetTest extends TestCase
         ]);
     }
 
-
-
-
-
     /**
      * Get Dataset by Id with success
      *

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -474,19 +474,34 @@ class DatasetTest extends TestCase
         );
         $response->assertStatus(400);
 
-
-        for ($i = 1; $i <= 3; $i++) {
-            // delete dataset
-            $responseDeleteDataset = $this->json(
-                'DELETE',
-                self::TEST_URL_DATASET . '/' . ${'datasetId' . $i} . '?deletePermanently=true',
-                [],
-                $this->header
-            );
-            $responseDeleteDataset->assertJsonStructure([
-                'message'
-            ]);
-        }
+        // delete datasets
+        $responseDeleteDataset = $this->json(
+            'DELETE',
+            self::TEST_URL_DATASET . '/' . $datasetId1 . '?deletePermanently=true',
+            [],
+            $this->header
+        );
+        $responseDeleteDataset->assertJsonStructure([
+            'message'
+        ]);
+        $responseDeleteDataset = $this->json(
+            'DELETE',
+            self::TEST_URL_DATASET . '/' . $datasetId2 . '?deletePermanently=true',
+            [],
+            $this->header
+        );
+        $responseDeleteDataset->assertJsonStructure([
+            'message'
+        ]);
+        $responseDeleteDataset = $this->json(
+            'DELETE',
+            self::TEST_URL_DATASET . '/' . $datasetId3 . '?deletePermanently=true',
+            [],
+            $this->header
+        );
+        $responseDeleteDataset->assertJsonStructure([
+            'message'
+        ]);
 
         for ($i = 1; $i <= 2; $i++) {
             // delete team

--- a/tests/Feature/Observers/TeamObserverTest.php
+++ b/tests/Feature/Observers/TeamObserverTest.php
@@ -278,10 +278,19 @@ class TeamObserverTest extends TestCase
             [],
             $this->header
         );
+        $existsDatasets = Dataset::where('team_id', $teamId)->select('id')->first();
 
-        $responseDelete->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
-        ->assertJsonStructure([
-            'message',
-        ]);
+        if (!is_null($existsDatasets)) {
+            $responseDelete->assertStatus(500)
+                ->assertJsonStructure([
+                    'message',
+                ]);
+        } else {
+            $responseDelete->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+                ->assertJsonStructure([
+                    'message',
+                ]);
+        }
+
     }
 }

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -446,10 +446,20 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $responseDelete->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
-        ->assertJsonStructure([
-            'message',
-        ]);
+        $existsDatasets = Dataset::where('team_id', $teamId)->select('id')->first();
+
+        if (!is_null($existsDatasets)) {
+            $responseDelete->assertStatus(500)
+                    ->assertJsonStructure([
+                        'message',
+                    ]);
+        } else {
+            $responseDelete->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+                ->assertJsonStructure([
+                    'message',
+                ]);
+        }
+
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Issue with Peter Harrison's account returning a 500 error when querying /library

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5832

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no
delete from `libraries` table

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
