### PR TITLE
fix(GAT-6430): patch to update question_json fields

### DIFF
--- a/app/Console/Commands/QuestionBankValidationObjects.php
+++ b/app/Console/Commands/QuestionBankValidationObjects.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class QuestionBankValidationObjects extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:question-bank-validation-objects';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Convert question bank validations from arrays to objects.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        try {
+            DB::table('question_bank_versions')->chunkById(100, function ($questions) {
+                foreach ($questions as $question) {
+                    $questionJson = json_decode($question->question_json, true);
+                    $validations = $questionJson['field']['validations'];
+                    if (empty($validations)) {
+                        $questionJson['field']['validations'] = null;
+                    } else {
+                        $validationObj = [];
+                        foreach ($validations as $val) {
+                            foreach ($val as $k => $v) {
+                                $validationObj[$k] = $v;
+                            }
+                        }
+                        $questionJson['field']['validations'] = $validationObj;
+                    }
+                    DB::table('question_bank_versions')
+                        ->where('id', $question->id)
+                        ->update(['question_json' => $questionJson]);
+                }
+            });
+
+        } catch (Exception $exception) {
+            throw new Exception($exception->getMessage());
+        }
+    }
+}

--- a/app/Http/Traits/QuestionBankHelpers.php
+++ b/app/Http/Traits/QuestionBankHelpers.php
@@ -83,7 +83,7 @@ trait QuestionBankHelpers
                         );
                     }
                     if (isset($toAdd['field']['validations'])) {
-                        $toAdd['validations'] = $toAdd['field']['validations'] ?? [];
+                        $toAdd['validations'] = $toAdd['field']['validations'] ?? null;
                     }
                     unset($toAdd['field']);
                 }
@@ -134,7 +134,7 @@ trait QuestionBankHelpers
 
         // Move 2 entries up to the root
         $questionVersion['component'] = $questionVersion['field']['component'];
-        $questionVersion['validations'] = $questionVersion['field']['validations'] ?? [];
+        $questionVersion['validations'] = $questionVersion['field']['validations'] ?? null;
         unset($questionVersion['field']);
 
         // And, because we're really returning a modified form of the QuestionVersion in response

--- a/tests/Feature/QuestionBankTest.php
+++ b/tests/Feature/QuestionBankTest.php
@@ -295,10 +295,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -385,10 +383,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -463,10 +459,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -537,10 +531,8 @@ class QuestionBankTest extends TestCase
                 'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -614,10 +606,8 @@ class QuestionBankTest extends TestCase
                 'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -656,10 +646,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -925,10 +913,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'all_custodians' => true,
@@ -973,10 +959,8 @@ class QuestionBankTest extends TestCase
                 'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -1006,10 +990,8 @@ class QuestionBankTest extends TestCase
                 'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Updated test question',
                 'guidance' => 'Something helpful',
@@ -1314,10 +1296,8 @@ class QuestionBankTest extends TestCase
                 'all_custodians' => true,
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',
@@ -1389,6 +1369,30 @@ class QuestionBankTest extends TestCase
             ->first();
         // Test latest version is still 1
         $this->assertEquals($version['version'], 1);
+
+        $response = $this->json(
+            'PATCH',
+            'api/v1/questions/' . $questionId,
+            [
+                'validations' => [
+                    'min' => 3
+                ]
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $version = QuestionBank::where('id', $questionId)
+            ->first()
+            ->latestVersion()
+            ->first();
+        $this->assertEquals($version['question_json']['field']['validations']['min'], 3);
+
     }
 
     /**
@@ -1675,10 +1679,8 @@ class QuestionBankTest extends TestCase
                 'options' => [],
                 'component' => 'TextArea',
                 'validations' => [
-                    [
-                        'min' => 1,
-                        'message' => 'Please enter a value'
-                    ]
+                    'min' => 1,
+                    'message' => 'Please enter a value'
                 ],
                 'title' => 'Test question',
                 'guidance' => 'Something helpful',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Update question bank patch to edit question json fields. Also a console command to convert validations to expected format.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6430

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

```
php artisan app:question-bank-validation-objects
```

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
