### PR TITLE
fix(GAT-6430): Check for array in validations

### DIFF
--- a/app/Console/Commands/QuestionBankValidationObjects.php
+++ b/app/Console/Commands/QuestionBankValidationObjects.php
@@ -37,8 +37,12 @@ class QuestionBankValidationObjects extends Command
                     } else {
                         $validationObj = [];
                         foreach ($validations as $val) {
-                            foreach ($val as $k => $v) {
-                                $validationObj[$k] = $v;
+                            if (is_array($val)) {
+                                foreach ($val as $k => $v) {
+                                    $validationObj[$k] = $v;
+                                }
+                            } else {
+                                continue;
                             }
                         }
                         $questionJson['field']['validations'] = $validationObj;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Check that validations are arrays of arrays when converting to objects.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
