### PR TITLE
feat(GAT-6528): add dar count endpoints with all counts

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -174,7 +174,7 @@ class TeamDataAccessApplicationController extends Controller
                 ->get();
 
             if ($field === 'action_required') {
-                $counts = $this->actionRequiredCounts(array_column($applications->toArray(), 'id'));
+                $counts = $this->actionRequiredCounts($applications);
             } else {
                 $counts = array();
                 foreach ($applications as $app) {
@@ -198,6 +198,70 @@ class TeamDataAccessApplicationController extends Controller
 
             return response()->json([
                 "data" => $counts
+            ]);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *    path="/api/v1/teams/{teamId}/dar/applications/count",
+     *    tags={"TeamDataAccessApplications"},
+     *    summary="TeamDataAccessApplicationController@allCounts",
+     *    description="Get Counts for all status fields in the model",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\Response(
+     *       response="200",
+     *       description="Success response",
+     *       @OA\JsonContent(
+     *          @OA\Property(
+     *             property="data",
+     *             type="object",
+     *          )
+     *       )
+     *    )
+     * )
+     */
+    public function allCounts(Request $request, int $teamId): JsonResponse
+    {
+        try {
+            $applicationIds = TeamHasDataAccessApplication::where('team_id', $teamId)
+                ->whereNot('submission_status', 'DRAFT')
+                ->select('dar_application_id')
+                ->pluck('dar_application_id');
+
+            $applications = DataAccessApplication::whereIn('id', $applicationIds)
+                ->with('teams')
+                ->get();
+
+            $fields = ['submission_status', 'approval_status'];
+            $counts = array();
+            foreach ($applications as $app) {
+                foreach ($fields as $field) {
+                    foreach ($app['teams'] as $t) {
+                        if ($t->team_id === $teamId) {
+                            if (array_key_exists($t[$field], $counts)) {
+                                $counts[$t[$field]] += 1;
+                            } else {
+                                $counts[$t[$field]] = 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            $actionCounts = $this->actionRequiredCounts($applications);
+            $counts = array_merge($counts, $actionCounts);
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => "Team DAR application count",
+            ]);
+
+            return response()->json([
+                'data' => $counts
             ]);
         } catch (Exception $e) {
             throw new Exception($e->getMessage());

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -174,7 +174,7 @@ class TeamDataAccessApplicationController extends Controller
                 ->get();
 
             if ($field === 'action_required') {
-                $counts = $this->actionRequiredCounts($applications);
+                $counts = $this->actionRequiredCounts($applications, $teamId);
             } else {
                 $counts = array();
                 foreach ($applications as $app) {
@@ -235,24 +235,11 @@ class TeamDataAccessApplicationController extends Controller
                 ->with('teams')
                 ->get();
 
-            $fields = ['submission_status', 'approval_status'];
-            $counts = array();
-            foreach ($applications as $app) {
-                foreach ($fields as $field) {
-                    foreach ($app['teams'] as $t) {
-                        if ($t->team_id === $teamId) {
-                            if (array_key_exists($t[$field], $counts)) {
-                                $counts[$t[$field]] += 1;
-                            } else {
-                                $counts[$t[$field]] = 1;
-                            }
-                        }
-                    }
-                }
-            }
+            $counts = $this->statusCounts($applications, $teamId);
 
-            $actionCounts = $this->actionRequiredCounts($applications);
+            $actionCounts = $this->actionRequiredCounts($applications, $teamId);
             $counts = array_merge($counts, $actionCounts);
+            $counts['ALL'] = count($applicationIds);
 
             Auditor::log([
                 'action_type' => 'GET',

--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -173,7 +173,7 @@ class UserDataAccessApplicationController extends Controller
                 ->get();
 
             if ($field === 'action_required') {
-                $counts = $this->actionRequiredCounts($applications);
+                $counts = $this->actionRequiredCounts($applications, null);
             } else {
                 $counts = array();
                 foreach ($applications as $app) {
@@ -234,36 +234,19 @@ class UserDataAccessApplicationController extends Controller
                 ->with('teams')
                 ->get();
 
-            $counts = array(
-                'DRAFT' => 0,
-                'SUBMITTED' => 0,
-                'FEEDBACK' => 0,
-                'APPROVED' => 0,
-                'REJECTED' => 0,
-                'WITHDRAWN' => 0,
-            );
-            foreach ($applications as $app) {
-                foreach ($app['teams'] as $t) {
-                    if ($t['submission_status'] === 'DRAFT') {
-                        $counts['DRAFT'] += 1;
-                    } elseif (is_null($t['approval_status'])) {
-                        $counts['SUBMITTED'] += 1;
-                    } elseif (str_contains($t['approval_status'], 'APPROVED')) {
-                        $counts['APPROVED'] += 1;
-                    } else {
-                        $counts[$t['approval_status']] += 1;
-                    }
-                }
-            }
+            $counts = $this->statusCounts($applications, null);
 
-            $actionCounts = $this->actionRequiredCounts($applications);
+            $actionCounts = $this->actionRequiredCounts($applications, null);
             $counts = array_merge($counts, $actionCounts);
-            $counts['ALL'] = count($applications);
+            $counts['ALL'] = count(TeamHasDataAccessApplication::whereIn(
+                'dar_application_id',
+                array_column($applications->toArray(), 'id')
+            )->get());
 
             Auditor::log([
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
-                'description' => "Team DAR application count",
+                'description' => "User DAR application count",
             ]);
 
             return response()->json([

--- a/app/Http/Traits/DataAccessApplicationHelpers.php
+++ b/app/Http/Traits/DataAccessApplicationHelpers.php
@@ -263,7 +263,7 @@ trait DataAccessApplicationHelpers
             foreach ($teams as $team) {
                 if (is_null($teamId) || ($team->team_id === $teamId)) {
                     if ($team['approval_status'] === 'FEEDBACK') {
-                        $feedbackApplications[] = $app->id;
+                        $feedbackApplications[] = $app['id'];
                     }
                 }
             }

--- a/config/routes.php
+++ b/config/routes.php
@@ -3889,8 +3889,35 @@ return [
     [
         'name' => 'dar/applications',
         'method' => 'get',
+        'path' => 'teams/{teamId}/dar/applications/count',
+        'methodController' => 'TeamDataAccessApplicationController@allCounts',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,data-access-applications.provider.read',
+        ],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
         'path' => 'users/{userId}/dar/applications/count/{field}',
         'methodController' => 'UserDataAccessApplicationController@count',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+        ],
+        'constraint' => [
+            'userId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'dar/applications',
+        'method' => 'get',
+        'path' => 'users/{userId}/dar/applications/count/',
+        'methodController' => 'UserDataAccessApplicationController@allCounts',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adds new dar/applications/count endpoints to serve the user and team dashboards. Status counts are calculated based on the logic in this table:

![Screenshot 2025-03-13 at 14 46 08](https://github.com/user-attachments/assets/de9b6a7a-e373-43de-88ea-35afa1bc9c6c)

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6528

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
