### PR TITLE
feat(GAT-6396): Add new filter to Datasets table for 'Data Standard'

### DIFF
--- a/app/Console/Commands/UpdateFiltersDatasetGat6396.php
+++ b/app/Console/Commands/UpdateFiltersDatasetGat6396.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Filter;
+use Illuminate\Console\Command;
+
+class UpdateFiltersDatasetGat6396 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-filters-dataset-gat6396';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add new filter to Datasets table for Data Standard';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        Filter::updateOrCreate([
+            'type' => 'dataset',
+            'keys' => 'formatAndStandards',
+        ], [
+            'type' => 'dataset',
+            'keys' => 'formatAndStandards',
+        ]);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-03-18 at 17 14 13](https://github.com/user-attachments/assets/3cb91879-3cef-4575-b55b-c2e1595840d5)

## Describe your changes
Add new filter to Datasets table for 'Data Standard'

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6396

## Environment / Configuration changes (if applicable)
1. remove `dataset` index from elastic search
```
DELETE [ES_SERVER]/dataset
```

2. create index `dataset`
```
POST [SS_SERVER]/mappings/datasets
```

3. reindex datasets
4. run command
```
php artisan app:update-filters-dataset-gat6396
```

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
