### PR TITLE
fix!(GAT-6529): Failing to sort Name and Organisation columns

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -159,6 +159,8 @@ class CohortRequestController extends Controller
             }
 
             $query = CohortRequest::with(['user.teams', 'logs', 'logs.user', 'permissions', 'user.sector'])
+                ->join('users', 'cohort_requests.user_id', '=', 'users.id')
+                ->leftJoin('sectors', 'users.sector_id', '=', 'sectors.id')
                 ->when($email, function ($query) use ($email) {
                     $query->whereHas('user', function ($query) use ($email) {
                         $query->where('email', 'LIKE', '%' . $email . '%')
@@ -196,6 +198,10 @@ class CohortRequestController extends Controller
 
                 if (in_array($key, ['name', 'organisation'])) {
                     $query->orderBy('users.' . $key, strtoupper($value));
+                }
+
+                if (in_array($key, ['sector'])) {
+                    $query->orderBy('sectors.name', strtoupper($value));
                 }
             }
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Failing to sort Name and Organisation columns alphabetically in ascending or descending order on Cohort Discovery Admin dashboard

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6529

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
no

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
