### PR TITLE
feat(GAT-5763): Limit Collections on Data Custodian page to those created by the DataCustodian

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -480,10 +480,8 @@ class TeamController extends Controller
                 $tool['user'] = $user;
             }
 
-            $collections = Collection::whereIn('id', $this->collections)
-                ->where([
-                    'team_id' => $id,
-                ])
+            $collections = Collection::where(['team_id' => $id ])
+                ->whereIn('id', $this->collections)
                 ->select('id', 'name', 'image_link', 'created_at', 'updated_at', 'status', 'public')
                 ->get()
                 ->toArray();

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -481,6 +481,9 @@ class TeamController extends Controller
             }
 
             $collections = Collection::whereIn('id', $this->collections)
+                ->where([
+                    'team_id' => $id,
+                ])
                 ->select('id', 'name', 'image_link', 'created_at', 'updated_at', 'status', 'public')
                 ->get()
                 ->toArray();


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Limit Collections on Data Custodian page to those created by the DataCustodian

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5763

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
