### PR TITLE
feat(GAT-6577): Add submission stats to endpoints and allow nulling approval_status

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -315,6 +315,9 @@ class TeamDataAccessApplicationController extends Controller
 
             $this->getApplicationWithQuestions($application);
 
+            $submissions = $this->submissionAudit($id);
+            $application = array_merge($application->toArray(), $submissions);
+
             if ($application) {
                 Auditor::log([
                     'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -344,6 +344,9 @@ class UserDataAccessApplicationController extends Controller
                 $application['templates'] = $templates;
             }
 
+            $submissions = $this->submissionAudit($id);
+            $application = array_merge($application->toArray(), $submissions);
+
             if ($application) {
                 Auditor::log([
                     'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Requests/DataAccessApplication/EditDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/EditDataAccessApplication.php
@@ -37,6 +37,7 @@ class EditDataAccessApplication extends BaseFormRequest
             ],
             'approval_status' => [
                 'string',
+                'nullable',
                 'in:APPROVED,APPROVED_COMMENTS,FEEDBACK,REJECTED',
             ],
         ];

--- a/app/Http/Requests/DataAccessApplication/UpdateDataAccessApplication.php
+++ b/app/Http/Requests/DataAccessApplication/UpdateDataAccessApplication.php
@@ -40,6 +40,7 @@ class UpdateDataAccessApplication extends BaseFormRequest
             ],
             'approval_status' => [
                 'string',
+                'nullable',
                 'in:APPROVED,APPROVED_COMMENTS,FEEDBACK,REJECTED',
             ],
         ];

--- a/app/Http/Traits/DataAccessApplicationHelpers.php
+++ b/app/Http/Traits/DataAccessApplicationHelpers.php
@@ -210,21 +210,31 @@ trait DataAccessApplicationHelpers
                 $d['custodian'] = $custodian;
             }
 
-            $submissionAudit = DataAccessApplicationStatus::where([
-                'application_id' => $app->id,
-                'submission_status' => 'SUBMITTED',
-            ])->first();
-            if ($submissionAudit) {
-                $app['days_since_submission'] = $submissionAudit
-                    ->updated_at
-                    ->diffInDays(Carbon::today());
-            } else {
-                $app['days_since_submission'] = null;
-            }
-
+            $app['days_since_submission'] = $this->submissionAudit($app->id)['days_since_submission'];
             $app['primary_applicant'] = $this->getPrimaryApplicantInfo($app->id);
         }
         return $applications;
+    }
+
+    public function submissionAudit(int $applicationId): array
+    {
+        $submissions = array(
+            'days_since_submission' => null,
+            'submission_date' => null,
+        );
+        $submissionAudit = DataAccessApplicationStatus::where([
+            'application_id' => $applicationId,
+            'submission_status' => 'SUBMITTED',
+        ])->first();
+        if ($submissionAudit) {
+            $submissions['days_since_submission'] = $submissionAudit
+                ->updated_at
+                ->diffInDays(Carbon::today());
+            $submissions['submission_date'] = $submissionAudit->updated_at;
+            return $submissions;
+        } else {
+            return $submissions;
+        }
     }
 
     public function statusCounts(Collection $applications, ?int $teamId): array

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -330,7 +330,9 @@ class DataAccessApplicationTest extends TestCase
                             'submission_status',
                             'approval_status',
                         ]
-                    ]
+                    ],
+                    'days_since_submission',
+                    'submission_date',
                 ],
             ]);
 
@@ -351,7 +353,9 @@ class DataAccessApplicationTest extends TestCase
                             'submission_status',
                             'approval_status',
                         ]
-                    ]
+                    ],
+                    'days_since_submission',
+                    'submission_date',
                 ],
             ]);
     }
@@ -2209,6 +2213,26 @@ class DataAccessApplicationTest extends TestCase
 
         // Check for 2 new status entries - submission and approval
         $this->assertEquals($statusCountNew, $statusCountInit + 2);
+
+        // Test team can push application back to DRAFT and null approval status
+        $response = $this->json(
+            'PATCH',
+            'api/v1/teams/' . $teamId . '/dar/applications/' . $applicationId,
+            [
+                'submission_status' => 'DRAFT',
+                'approval_status' => null,
+            ],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals($content['data']['teams'][0]['submission_status'], 'DRAFT');
+        $this->assertEquals($content['data']['teams'][0]['approval_status'], null);
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6577

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
