### PR TITLE
feat(GAT-5771): Sector ID is Null in database for newly created accounts

### DIFF
--- a/app/Console/Commands/UpdateSectorIdGat5771.php
+++ b/app/Console/Commands/UpdateSectorIdGat5771.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class UpdateSectorIdGat5771 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-sector-id-gat5771';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sector ID is Null in database for newly created accounts';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        User::whereNull('sector_id')->update(['sector_id' => 6]);
+
+        $this->info('done');
+    }
+}

--- a/database/migrations/2025_03_25_171115_update_sector_id_from_users_table.php
+++ b/database/migrations/2025_03_25_171115_update_sector_id_from_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->bigInteger('sector_id')->nullable()->default(6)->unsigned()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->bigInteger('sector_id')->nullable()->default(null)->unsigned()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Sector ID is Null in database for newly created accounts

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5771

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run next commands:
```
php artisan migrate
php artisan app:update-sector-id-gat5771
```

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
