### PR TITLE
feat(GAT-6005): add SDE concierge and redirect enquiries

### DIFF
--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -7,6 +7,7 @@ use Auditor;
 use Exception;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\DataProviderColl;
 use App\Models\Dataset;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -246,14 +247,45 @@ class EnquiryThreadController extends Controller
             }
             $payload['thread']['dataCustodians'] = array_unique($dataCustodians);
 
+            list($conciergeId, $conciergeName) = $this->getNetworkConcierge();
+            $sdeNetwork = DataProviderColl::where('name', 'LIKE', '%SDE%')
+                ->with('teams')
+                ->first();
+            $sdeTeamIds = $sdeNetwork ? array_column($sdeNetwork['teams']->toArray(), 'id') : [];
+
             // For each dataset we need to determine if teams are responsible for the data providing
             // if not, then a separate enquiry thread and message are created for that team also.
             $teamIds = [];
             $teamNames = [];
-            foreach ($payload['thread']['datasets'] as $d) {
-                $team = Team::where('id', $d['team_id'])->first();
-                $teamIds[] = $team->id;
-                $teamNames[] = $team->name;
+            if ($input['is_general_enquiry']) {
+                foreach ($payload['thread']['datasets'] as $d) {
+                    $team = Team::where('id', $d['team_id'])->first();
+                    if (in_array($team->id, $sdeTeamIds) && (count($payload['thread']['datasets']) > 1)) {
+                        $teamIds[] = $conciergeId;
+                        $teamNames[] = $conciergeName;
+                    } else {
+                        $teamIds[] = $team->id;
+                        $teamNames[] = $team->name;
+                    }
+                }
+            } elseif (($input['is_feasibility_enquiry']) || ($input['is_dar_dialogue'])) {
+                foreach ($payload['thread']['datasets'] as $d) {
+                    $dataset = Dataset::findOrFail($d['dataset_id']);
+                    $metadata = $dataset->latestMetadata()->first();
+                    $gatewayId = $metadata->metadata['metadata']['summary']['publisher']['gatewayId'];
+                    if (is_numeric($gatewayId)) {
+                        $team = Team::where('id', $gatewayId)->first();
+                    } else {
+                        $team = Team::where('pid', $gatewayId)->first();
+                    }
+                    if (in_array($team->id, $sdeTeamIds) && (count($payload['thread']['datasets']) > 1)) {
+                        $teamIds[] = $conciergeId;
+                        $teamNames[] = $conciergeName;
+                    } else {
+                        $teamIds[] = $team->id;
+                        $teamNames[] = $team->name;
+                    }
+                }
             }
 
             $payload['thread']['team_ids'] = array_unique($teamIds);
@@ -341,5 +373,14 @@ class EnquiryThreadController extends Controller
         }
 
         return $arr;
+    }
+
+    private function getNetworkConcierge(): array
+    {
+        $team = Team::where('name', 'LIKE', '%SDE Network%')->first();
+        if ($team) {
+            return array($team->id, $team->name);
+        }
+        return array(null, null);
     }
 }

--- a/database/seeders/SDENetworkConciergeSeeder.php
+++ b/database/seeders/SDENetworkConciergeSeeder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\TeamHasUser;
+use App\Models\TeamUserHasRole;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class SDENetworkConciergeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     * This Seeder creates a team and user for the SDE Network Concierge
+     */
+    public function run(): void
+    {
+        // Create team
+        $team = Team::create([
+            'name' => 'SDE Network Concierge',
+            'pid' => (string) Str::uuid(),
+            'allows_messaging' => 1,
+            'workflow_enabled' =>  1,
+            'access_requests_management' => 1,
+            'uses_5_safes' => 1,
+            'is_admin' => 0,
+            'member_of' => 'OTHER',
+            'contact_point' => 'data.healthresearch@nhs.net',
+            'enabled' => 1,
+        ]);
+
+        // Create user
+        $user = User::create([
+            'name' => 'SDE Network Concierge',
+            'firstname' => 'SDE',
+            'lastname' => 'Network Concierge',
+            'email' => 'data.healthresearch@nhs.net',
+            'provider' => 'service',
+            'password' => '$2y$10$5yALZeLgi0AutXiu5qnLoe6QpapTV4tZR5At3cigVXDZi06lV.Vr6',
+            'is_admin' => 0,
+        ]);
+
+        // Add user and superadmin to team
+        $thuId = TeamHasUser::create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+        ]);
+
+        $superAdminIds = User::where('is_admin', true)->pluck('id');
+        foreach ($superAdminIds as $adminId) {
+            TeamHasUser::create([
+                'team_id' => $team->id,
+                'user_id' => $adminId
+            ]);
+        }
+
+        // Make the user the dar admin for the team
+        $r = Role::where('name', 'custodian.dar.manager')->first();
+
+        TeamUserHasRole::create([
+            'team_has_user_id' => $thuId->id,
+            'role_id' => $r->id,
+        ]);
+    }
+}

--- a/tests/Feature/EnquiryThreadTest.php
+++ b/tests/Feature/EnquiryThreadTest.php
@@ -3,14 +3,17 @@
 namespace Tests\Feature;
 
 use App\Http\Enums\TeamMemberOf;
+use App\Jobs\SendEmailJob;
 use App\Models\Dataset;
 use App\Models\EnquiryThread;
 use App\Models\Team;
 use Database\Seeders\EmailTemplateSeeder;
 use Database\Seeders\EnquiryThreadSeeder;
 use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\SDENetworkConciergeSeeder;
 use Database\Seeders\SpatialCoverageSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 use Tests\Traits\MockExternalApis;
 
@@ -40,6 +43,7 @@ class EnquiryThreadTest extends TestCase
             SpatialCoverageSeeder::class,
             EmailTemplateSeeder::class,
             EnquiryThreadSeeder::class,
+            SDENetworkConciergeSeeder::class,
         ]);
 
         $this->metadata = $this->getMetadata();
@@ -166,6 +170,7 @@ class EnquiryThreadTest extends TestCase
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];
+        $team = Team::findOrFail($teamId);
 
         // assign roles to user
         $url = '/api/v1/teams/' . $teamId . '/users';
@@ -182,14 +187,18 @@ class EnquiryThreadTest extends TestCase
         );
         $responseUserRole->assertStatus(201);
 
-        // Create dataset belonging to the team
+        $metadata = $this->getMetadata();
+        $metadata['metadata']['summary']['publisher'] = [
+            'name' => $team->name,
+            'gatewayId' => $team->id
+        ];
         $responseCreateDataset = $this->json(
             'POST',
             'api/v1/datasets',
             [
                 'team_id' => $teamId,
-                'user_id' => $uniqueUserId,
-                'metadata' => $this->metadata,
+                'user_id' => 1,
+                'metadata' => $metadata,
                 'create_origin' => Dataset::ORIGIN_MANUAL,
                 'status' => Dataset::STATUS_ACTIVE,
             ],
@@ -328,5 +337,241 @@ class EnquiryThreadTest extends TestCase
         $numThreadsAfter = EnquiryThread::count();
 
         $this->assertEquals($numThreadsAfter, $numThreadsBefore + 1);
+    }
+
+    /**
+     * Create an enquiry with SDE datasets
+     *
+     * @return void
+     */
+    public function test_add_new_sde_enquiry_thread_with_success(): void
+    {
+        $uniqueUserId = $this->createUser();
+        $teamId = $this->createTeam([$uniqueUserId]);
+        $team = Team::findOrFail($teamId);
+
+        // assign roles to user
+        $url = '/api/v1/teams/' . $teamId . '/users';
+        $responseUserRole = $this->json(
+            'POST',
+            $url,
+            [
+                'userId' => $uniqueUserId,
+                'roles' => [
+                    'custodian.dar.manager'
+                ]
+            ],
+            $this->header
+        );
+        $responseUserRole->assertStatus(201);
+
+        // Add the team to the SDE network
+        $response = $this->json(
+            'POST',
+            '/api/v1/data_provider_colls',
+            [
+                'name' => 'SDE Network Test',
+                'summary' => 'SDE Network Test',
+                'img_url' => 'https://doesntexist.com/img.jpeg',
+                'enabled' => 1,
+                'team_ids' => [$teamId],
+            ],
+            $this->header,
+        );
+        $response->assertStatus(201);
+
+        $responseCreateDataset = $this->json(
+            'POST',
+            'api/v1/datasets',
+            [
+                'team_id' => $teamId,
+                'user_id' => 1,
+                'metadata' => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status' => Dataset::STATUS_ACTIVE,
+            ],
+            $this->header,
+        );
+        $responseCreateDataset->assertStatus(201);
+        $datasetId = $responseCreateDataset['data'];
+
+        // Create second team and a dataset for them
+        $teamIdTwo = $this->createTeam([$uniqueUserId]);
+        $url = '/api/v1/teams/' . $teamIdTwo . '/users';
+        $responseUserRole = $this->json(
+            'POST',
+            $url,
+            [
+                'userId' => $uniqueUserId,
+                'roles' => [
+                    'custodian.dar.manager'
+                ]
+            ],
+            $this->header
+        );
+        $responseUserRole->assertStatus(201);
+
+        // Create dataset belonging to the team
+        $responseCreateDatasetTwo = $this->json(
+            'POST',
+            'api/v1/datasets',
+            [
+                'team_id' => $teamIdTwo,
+                'user_id' => $uniqueUserId,
+                'metadata' => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status' => Dataset::STATUS_ACTIVE,
+            ],
+            $this->header,
+        );
+        $responseCreateDatasetTwo->assertStatus(201);
+        $datasetIdTwo = $responseCreateDatasetTwo['data'];
+
+        Queue::fake();
+        $numThreadsBefore = EnquiryThread::count();
+
+        // Multi-dataset enquiry directs to concierge
+        $body = [
+            'project_title' => 'Test Enquiry',
+            'from' => 'example.test@hdruk.ac.uk',
+            'contact_number' => '000111444',
+            'is_dar_dialogue' => false,
+            'is_dar_status' => false,
+            'is_feasibility_enquiry' => false,
+            'is_general_enquiry' => true,
+            'datasets' => [
+                0 => [
+                    'dataset_id' => $datasetId,
+                    'interest_type' => 'PRIMARY'
+                ],
+                1 => [
+                    'dataset_id' => $datasetIdTwo,
+                    'interest_type' => 'PRIMARY'
+                ],
+            ],
+            'message' => 'What should I enter for this question?'
+        ];
+        $response = $this->json(
+            'POST',
+            self::TEST_URL . '/',
+            $body,
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $numThreadsAfter = EnquiryThread::count();
+
+        // Test that an email was sent to the network concierge
+        Queue::assertPushed(function (SendEmailJob $email) {
+            return $email->to['to']['name'] === 'SDE Network Concierge';
+        });
+
+        $this->assertEquals($numThreadsAfter, $numThreadsBefore + 1);
+
+        Queue::fake();
+
+        // Single dataset enquiry directs to the dar manager
+        $body = [
+            'project_title' => 'Test Enquiry - single SDE',
+            'from' => 'example.test@hdruk.ac.uk',
+            'contact_number' => '000111444',
+            'is_dar_dialogue' => false,
+            'is_dar_status' => false,
+            'is_feasibility_enquiry' => false,
+            'is_general_enquiry' => true,
+            'datasets' => [
+                0 => [
+                    'dataset_id' => $datasetId,
+                    'interest_type' => 'PRIMARY'
+                ],
+            ],
+            'message' => 'What should I enter for this question?'
+        ];
+        $response = $this->json(
+            'POST',
+            self::TEST_URL . '/',
+            $body,
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $numThreadsAfter = EnquiryThread::count();
+
+        // Test that an email was NOT sent to the network concierge
+        Queue::assertPushed(function (SendEmailJob $email) {
+            return $email->to['to']['name'] !== 'SDE Network Concierge';
+        });
+    }
+
+    private function createUser(): int
+    {
+        $responseCreateUser = $this->json(
+            'POST',
+            '/api/v1/users',
+            [
+                'firstname' => 'XXXXXXXXXX',
+                'lastname' => 'XXXXXXXXXX',
+                'email' => 'just.test.123456789@test.com',
+                'password' => 'Passw@rd1!',
+                'sector_id' => 1,
+                'contact_feedback' => 1,
+                'contact_news' => 1,
+                'organisation' => 'Test Organisation',
+                'bio' => 'Test Biography',
+                'domain' => 'https://testdomain.com',
+                'link' => 'https://testlink.com/link',
+                'orcid' => "https://orcid.org/12345678",
+                'mongo_id' => 1234567,
+                'mongo_object_id' => "12345abcde",
+            ],
+            $this->header
+        );
+        $responseCreateUser->assertStatus(201);
+        $uniqueUserId = $responseCreateUser->decodeResponseJson()['data'];
+        return $uniqueUserId;
+    }
+
+    private function createTeam(array $users = []): int
+    {
+        $responseTeam = $this->json(
+            'POST',
+            'api/v1/teams',
+            [
+                'name' => 'Team Test ' . fake()->regexify('[A-Z]{5}[0-4]{1}'),
+                'enabled' => 1,
+                'allows_messaging' => 1,
+                'workflow_enabled' => 1,
+                'access_requests_management' => 1,
+                'uses_5_safes' => 1,
+                'is_admin' => 1,
+                'member_of' => TeamMemberOf::HUB,
+                'contact_point' => 'dinos345@mail.com',
+                'application_form_updated_by' => 'Someone Somewhere',
+                'application_form_updated_on' => '2023-04-06 15:44:41',
+                'is_question_bank' => 1,
+                'users' => $users,
+                'notifications' => [],
+                'url' => 'https://fakeimg.pl/350x200/ff0000/000',
+                'introduction' => fake()->sentence(),
+                'dar_modal_content' => fake()->sentence(),
+                'service' => 'https://service.local/test',
+            ],
+            $this->header
+        );
+        $responseTeam->assertStatus(200);
+
+        $content = $responseTeam->decodeResponseJson();
+        $teamId = $content['data'];
+        return $teamId;
     }
 }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6005

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

Requires a seeder
```
php artisan db:seed --class=SDENetworkConciergeSeeder
```

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
