### PR TITLE
fix(GAT-6714): Add dar_modal_content as a htmlDecodedField

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -71,6 +71,7 @@ class Team extends Model
 
     protected static $htmlDecodedFields = [
         'introduction',
+        'dar_modal_content'
     ];
 
     /**


### PR DESCRIPTION
## Describe your changes
Add dar_modal_content as a htmlDecodedField, in order for it to be used with the WYSIWYG FE component

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6714

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
