### PR TITLE
feat(GAT-5446): Unit testing for CRUD permission error for Analysis Scripts & Software

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -657,7 +657,7 @@ class TeamController extends Controller
             return response()->json([
                 'message' => 'success',
                 'data' => $team->id,
-            ], 200);
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Controllers/Api/V1/ToolController.php
+++ b/app/Http/Controllers/Api/V1/ToolController.php
@@ -137,7 +137,6 @@ class ToolController extends Controller
     public function index(Request $request): JsonResponse
     {
         try {
-            $matches = [];
             $mongoId = $request->query('mongo_id', null);
             $teamId = $request->query('team_id', null);
             $userId = $request->query('user_id', null);
@@ -1348,7 +1347,7 @@ class ToolController extends Controller
     }
 
     // publications
-    private function checkPublications(int $toolId, array $inPublications, int $userId = null)
+    private function checkPublications(int $toolId, array $inPublications, ?int $userId = null)
     {
         $pubs = PublicationHasTool::where(['tool_id' => $toolId])->get();
         foreach ($pubs as $pub) {
@@ -1366,7 +1365,7 @@ class ToolController extends Controller
         }
     }
 
-    private function addPublicationHasTool(int $toolId, array $publication, int $userId = null)
+    private function addPublicationHasTool(int $toolId, array $publication, ?int $userId = null)
     {
         try {
             $arrCreate = [
@@ -1444,7 +1443,7 @@ class ToolController extends Controller
     }
 
     // collections
-    private function checkCollections(int $toolId, array $inCollections, int $userId = null)
+    private function checkCollections(int $toolId, array $inCollections, ?int $userId = null)
     {
         $colls = CollectionHasTool::where(['tool_id' => $toolId])->get();
         foreach ($colls as $coll) {
@@ -1462,7 +1461,7 @@ class ToolController extends Controller
         }
     }
 
-    private function addCollectionHasTool(int $toolId, array $collection, int $userId = null)
+    private function addCollectionHasTool(int $toolId, array $collection, ?int $userId = null)
     {
         try {
             $arrCreate = [

--- a/app/Http/Traits/CheckAccess.php
+++ b/app/Http/Traits/CheckAccess.php
@@ -19,9 +19,9 @@ trait CheckAccess
      */
     public function checkAccess(
         array $input = [],
-        int $dbTeamId = null,
-        int $dbUserId = null,
-        string $checkType = null
+        ?int $dbTeamId = null,
+        ?int $dbUserId = null,
+        ?string $checkType = null
     ) {
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
         if (!count($jwtUser)) {
@@ -58,7 +58,7 @@ trait CheckAccess
      */
     public function checkAccessCollaborators(
         array $input = [],
-        array $dbUserIds = null
+        ?array $dbUserIds = null
     ) {
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
         if (!count($jwtUser)) {
@@ -117,8 +117,6 @@ trait CheckAccess
             return true;
         }
     }
-
-
 
     private function checkAccessUser($jwtUserId, $dbUserId)
     {

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -2708,7 +2708,7 @@ class DataAccessApplicationTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -840,7 +840,7 @@ class DataAccessTemplateTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];

--- a/tests/Feature/DatasetIntegrationTest.php
+++ b/tests/Feature/DatasetIntegrationTest.php
@@ -173,7 +173,7 @@ class DatasetIntegrationTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -322,7 +322,7 @@ class DatasetIntegrationTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -131,7 +131,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -557,7 +557,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -807,7 +807,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -991,7 +991,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -1146,7 +1146,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -1284,7 +1284,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -1530,7 +1530,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -168,7 +168,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/DatasetVersionTest.php
+++ b/tests/Feature/DatasetVersionTest.php
@@ -94,7 +94,7 @@ class DatasetVersionTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -222,7 +222,7 @@ class DatasetVersionTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/DatasetVersionTest.php
+++ b/tests/Feature/DatasetVersionTest.php
@@ -34,6 +34,8 @@ class DatasetVersionTest extends TestCase
     public const TEST_URL_NOTIFICATION = '/api/v1/notifications';
     public const TEST_URL_USER = '/api/v1/users';
 
+    public $metadata;
+
     public function setUp(): void
     {
         $this->commonSetUp();

--- a/tests/Feature/DurTest.php
+++ b/tests/Feature/DurTest.php
@@ -743,7 +743,7 @@ class DurTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/EnquiryThreadTest.php
+++ b/tests/Feature/EnquiryThreadTest.php
@@ -264,7 +264,7 @@ class EnquiryThreadTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeamTwo->decodeResponseJson();
         $teamIdTwo = $content['data'];

--- a/tests/Feature/EnquiryThreadTest.php
+++ b/tests/Feature/EnquiryThreadTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Config;
 use App\Http\Enums\TeamMemberOf;
 use App\Jobs\SendEmailJob;
 use App\Models\Dataset;
@@ -166,7 +167,7 @@ class EnquiryThreadTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];
@@ -568,7 +569,7 @@ class EnquiryThreadTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];

--- a/tests/Feature/FederationTest.php
+++ b/tests/Feature/FederationTest.php
@@ -87,7 +87,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -229,7 +229,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -359,7 +359,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -508,7 +508,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -706,7 +706,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -955,7 +955,7 @@ class FederationTest extends TestCase
             $this->header,
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/FormHydrationTest.php
+++ b/tests/Feature/FormHydrationTest.php
@@ -205,7 +205,7 @@ class FormHydrationTest extends TestCase
             $this->header
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',

--- a/tests/Feature/Observers/TeamObserverTest.php
+++ b/tests/Feature/Observers/TeamObserverTest.php
@@ -89,7 +89,7 @@ class TeamObserverTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',
@@ -197,7 +197,7 @@ class TeamObserverTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',

--- a/tests/Feature/TeamNotificationTest.php
+++ b/tests/Feature/TeamNotificationTest.php
@@ -52,7 +52,7 @@ class TeamNotificationTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -131,7 +131,7 @@ class TeamNotificationTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -133,7 +133,7 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',
@@ -275,7 +275,7 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',
@@ -357,7 +357,7 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',
@@ -518,7 +518,7 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $responseCreate->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreate->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -680,7 +680,7 @@ class TeamTest extends TestCase
             $this->header
         );
 
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
             ->assertJsonStructure([
                 'message',
                 'data',

--- a/tests/Feature/TeamUserTest.php
+++ b/tests/Feature/TeamUserTest.php
@@ -703,7 +703,7 @@ class TeamUserTest extends TestCase
         ]);
     }
 
-    private function createUser(string $email = null)
+    private function createUser(?string $email = null)
     {
         $responseNewUser = $this->json(
             'POST',

--- a/tests/Feature/TeamUserTest.php
+++ b/tests/Feature/TeamUserTest.php
@@ -684,7 +684,7 @@ class TeamUserTest extends TestCase
             $this->header,
         );
 
-        $responseNewTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $responseNewTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         return $responseNewTeam['data'];
     }

--- a/tests/Feature/ToolTest.php
+++ b/tests/Feature/ToolTest.php
@@ -327,7 +327,7 @@ class ToolTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -364,7 +364,7 @@ class ToolTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',
@@ -1628,6 +1628,8 @@ class ToolTest extends TestCase
             'PUT',
             '/api/v1/tools/' . $toolId,
             [
+                'name' => 'Tool A',
+                'user_id' => $idUserAOne,
                 'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
                 'dataset' => $this->generateDatasets($datasets),
                 'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
@@ -1736,6 +1738,8 @@ class ToolTest extends TestCase
             'PUT',
             '/api/v1/tools/' . $toolId,
             [
+                'name' => 'Tool A',
+                'user_id' => $idUserATwo,
                 'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
                 'dataset' => $this->generateDatasets($datasets),
                 'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
@@ -1847,6 +1851,8 @@ class ToolTest extends TestCase
             'PUT',
             '/api/v1/tools/' . $toolId,
             [
+                'name' => 'Tool A',
+                'user_id' => $idUserBOne,
                 'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
                 'dataset' => $this->generateDatasets($datasets),
                 'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),

--- a/tests/Feature/ToolTest.php
+++ b/tests/Feature/ToolTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature;
 
 use Config;
 use Exception;
+use App\Models\Tag;
 use Tests\TestCase;
 use App\Models\Tool;
+use App\Models\User;
 use ReflectionClass;
 use App\Models\Dataset;
 use App\Models\License;
@@ -13,6 +15,7 @@ use App\Models\Collection;
 use App\Models\DurHasTool;
 use App\Models\ToolHasTag;
 use App\Models\Publication;
+use Illuminate\Support\Str;
 use Database\Seeders\DurSeeder;
 use Database\Seeders\TagSeeder;
 use Tests\Traits\Authorization;
@@ -36,6 +39,7 @@ use Database\Seeders\MinimalUserSeeder;
 use Database\Seeders\PublicationSeeder;
 use Database\Seeders\TypeCategorySeeder;
 use App\Models\ToolHasProgrammingPackage;
+use Database\Seeders\EmailTemplateSeeder;
 use App\Models\ToolHasProgrammingLanguage;
 use Database\Seeders\DatasetVersionSeeder;
 use Database\Seeders\CollectionHasToolSeeder;
@@ -44,6 +48,11 @@ use Database\Seeders\DurHasPublicationSeeder;
 use Database\Seeders\ProgrammingPackageSeeder;
 use Database\Seeders\PublicationHasToolSeeder;
 use App\Http\Controllers\Api\V1\ToolController;
+use App\Models\Category;
+use App\Models\Dur;
+use App\Models\ProgrammingLanguage;
+use App\Models\ProgrammingPackage;
+use App\Models\TypeCategory;
 use Database\Seeders\ProgrammingLanguageSeeder;
 use Database\Seeders\DatasetVersionHasToolSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -97,6 +106,7 @@ class ToolTest extends TestCase
             CollectionHasToolSeeder::class,
             DatasetVersionHasToolSeeder::class,
             CollectionHasUserSeeder::class,
+            EmailTemplateSeeder::class,
         ]);
     }
 
@@ -105,7 +115,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_get_all_tools_with_success(): void
+    public function test_v1_get_all_tools_with_success(): void
     {
         $countTool = Tool::where('enabled', 1)->count();
         $response = $this->json('GET', self::TEST_URL, [], $this->header);
@@ -161,7 +171,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_get_tool_by_id_with_success(): void
+    public function test_v1_get_tool_by_id_with_success(): void
     {
         $toolId = Tool::where('enabled', 1)->get()->random()->id;
         $response = $this->json('GET', self::TEST_URL . '/' . $toolId, [], $this->header);
@@ -204,7 +214,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_add_new_tool_with_success(): void
+    public function test_v1_add_new_tool_with_success(): void
     {
         ECC::shouldReceive("indexDocument")
             ->times(1);
@@ -268,7 +278,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_get_all_team_tools_with_success(): void
+    public function test_v1_get_all_team_tools_with_success(): void
     {
         // First create a notification to be used by the new team
         $responseNotification = $this->json(
@@ -583,15 +593,12 @@ class ToolTest extends TestCase
         $responseDeleteUser->assertStatus(200);
     }
 
-
-
-
     /**
      * Insert data into tool_has_tags table with success
      *
      * @return void
      */
-    public function test_insert_data_in_tool_has_tags(): void
+    public function test_v1_insert_data_in_tool_has_tags(): void
     {
         ToolHasTag::truncate();
 
@@ -622,7 +629,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_update_tool_with_success(): void
+    public function test_v1_update_tool_with_success(): void
     {
 
         ECC::shouldReceive("indexDocument")
@@ -777,7 +784,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_edit_tool_with_success(): void
+    public function test_v1_edit_tool_with_success(): void
     {
         $licenseId = License::where('valid_until', null)->get()->random()->id;
         // insert
@@ -927,7 +934,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_create_archive_unarchive_tool_with_success(): void
+    public function test_v1_create_archive_unarchive_tool_with_success(): void
     {
         $licenseId = License::where('valid_until', null)->get()->random()->id;
 
@@ -1012,7 +1019,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_update_tool_and_generate_exception(): void
+    public function test_v1_update_tool_and_generate_exception(): void
     {
         $licenseId = License::where('valid_until', null)->get()->random()->id;
         $mockData = array(
@@ -1058,7 +1065,7 @@ class ToolTest extends TestCase
      *
      * @return void
      */
-    public function test_soft_delete_tool_with_success(): void
+    public function test_v1_soft_delete_tool_with_success(): void
     {
         $tools = Tool::first();
         $countBefore = Tool::onlyTrashed()->count();
@@ -1072,6 +1079,926 @@ class ToolTest extends TestCase
             $countAfter,
             "actual value is equals to expected"
         );
+    }
+
+    public function test_v1_create_tool_A_with_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => 'Test Tool A Description',
+                'results_insights' => 'mazing insights',
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+    }
+
+    public function test_v1_create_tool_A_with_no_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // create Team B
+        $idTeamB = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            self::TEST_URL,
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamB,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // no success
+        $responseCreateTool->assertStatus(401);
+    }
+
+    public function test_v1_edit_tool_A_same_user_with_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // edit tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseEdit = $this->json(
+            'PATCH',
+            '/api/v1/tools/' . $toolId,
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => 1,
+                'user_id' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => "DRAFT"
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseEdit->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+    }
+
+    public function test_v1_edit_tool_A_by_another_user_from_same_team_with_no_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // create User a.two@test.com
+        $idUserATwo = $this->createTestUser('a.two@test.com');
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["custodian.team.admin"];
+        $this->assignUserToTeam($idTeamA, $idUserATwo, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserATwo = $this->getTestUserAuthorization('a.two@test.com');
+
+        // edit tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+
+        $responseEdit = $this->json(
+            'PATCH',
+            '/api/v1/tools/' . $toolId,
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => 1,
+                'user_id' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => "DRAFT"
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserATwo,
+            ]
+        );
+
+        // error
+        $responseEdit->assertStatus(401);
+    }
+
+    public function test_v1_edit_tool_A_by_another_user_from_another_team_with_no_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // create User b.one@test.com
+        $idUserBOne = $this->createTestUser('b.one@test.com');
+
+        // create Team A
+        $idTeamB = $this->createTestTeam();
+
+        // assign User b.one@test.com to Team B
+        $permissions = ["custodian.team.admin"];
+        $this->assignUserToTeam($idTeamB, $idUserBOne, $permissions);
+
+        // generate jwt for user b.one@test.com
+        $jwtUserBOne = $this->getTestUserAuthorization('b.one@test.com');
+
+        // edit tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+
+        $responseEdit = $this->json(
+            'PATCH',
+            '/api/v1/tools/' . $toolId,
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => 1,
+                'user_id' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => "DRAFT"
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserBOne,
+            ]
+        );
+
+        // error
+        $responseEdit->assertStatus(401);
+    }
+
+    public function test_v1_update_tool_A_by_same_user_with_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // update tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseUpdate = $this->json(
+            'PUT',
+            '/api/v1/tools/' . $toolId,
+            [
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => 'ACTIVE',
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseUpdate->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+    }
+
+    public function test_v1_update_tool_A_by_another_user_from_same_team_with_no_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // create User a.two@test.com
+        $idUserATwo = $this->createTestUser('a.two@test.com');
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["custodian.team.admin"];
+        $this->assignUserToTeam($idTeamA, $idUserATwo, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserATwo = $this->getTestUserAuthorization('a.two@test.com');
+
+        // update tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseUpdate = $this->json(
+            'PUT',
+            '/api/v1/tools/' . $toolId,
+            [
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => 'ACTIVE'
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserATwo,
+            ]
+        );
+
+        // error
+        $responseUpdate->assertStatus(401);
+    }
+
+    public function test_v1_update_tool_A_by_another_user_from_another_team_with_no_success()
+    {
+        // create User a.one@test.com
+        $idUserAOne = $this->createTestUser('a.one@test.com');
+
+        // create Team A
+        $idTeamA = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team A
+        $permissions = ["developer", "custodian.dar.manager"];
+        $this->assignUserToTeam($idTeamA, $idUserAOne, $permissions);
+
+        // generate jwt for user a.one@test.com
+        $jwtUserAOne = $this->getTestUserAuthorization('a.one@test.com');
+
+        // user a.one@test.com create Tool AOne with Team A
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseCreateTool = $this->json(
+            'POST',
+            '/api/v1/tools',
+            [
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'name' => 'Tool A',
+                'url' => fake()->url(),
+                'description' => fake()->sentence(),
+                'results_insights' => fake()->sentence(),
+                'license' => $licenseId,
+                'tech_stack' => fake()->words(3, true),
+                'category_id' => $categoryId,
+                'user_id' => $idUserAOne,
+                'team_id' => $idTeamA,
+                'enabled' => 1,
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserAOne,
+            ]
+        );
+
+        // success
+        $responseCreateTool->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $toolId = $responseCreateTool['data'];
+
+        // create User b.one@test.com
+        $idUserBOne = $this->createTestUser('b.one@test.com');
+
+        // create Team B
+        $idTeamB = $this->createTestTeam();
+
+        // assign User a.one@test.com to Team B
+        $permissions = ["custodian.team.admin"];
+        $this->assignUserToTeam($idTeamB, $idUserBOne, $permissions);
+
+        // generate jwt for user b.one@test.com
+        $jwtUserBOne = $this->getTestUserAuthorization('b.one@test.com');
+
+        // update tool
+        $licenseId = License::where('valid_until', null)->get()->random()->id;
+        $categoryId = Category::where('enabled', 1)->get()->random()->id;
+        $tags = Tag::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $datasets = Dataset::where('status', Dataset::STATUS_ACTIVE)->inRandomOrder()->take(3)->select('id')->get()->toArray();
+        $programmingLanguags = ProgrammingLanguage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $programmingPackages = ProgrammingPackage::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $typeCategories = TypeCategory::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $durs = Dur::inRandomOrder()->select('id')->take(2)->get()->toArray();
+        $generatedPublications = $this->generatePublications();
+        $generatedCollections = $this->generateCollections();
+        $responseUpdate = $this->json(
+            'PUT',
+            '/api/v1/tools/' . $toolId,
+            [
+                'tag' => convertArrayToArrayWithKeyName($tags, 'id'),
+                'dataset' => $this->generateDatasets($datasets),
+                'programming_language' => convertArrayToArrayWithKeyName($programmingLanguags, 'id'),
+                'programming_package' => convertArrayToArrayWithKeyName($programmingPackages, 'id'),
+                'type_category' => convertArrayToArrayWithKeyName($typeCategories, 'id'),
+                'enabled' => 1,
+                'publications' => $generatedPublications,
+                'durs' => convertArrayToArrayWithKeyName($durs, 'id'),
+                'collections' => $generatedCollections,
+                'any_dataset' => false,
+                'status' => 'ACTIVE'
+            ],
+            [
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer ' . $jwtUserBOne,
+            ]
+        );
+
+        // error
+        $responseUpdate->assertStatus(401);
+    }
+
+    public function assignUserToTeam(int $teamId, int $userId, array $permissions)
+    {
+        $url = 'api/v1/teams/' . $teamId . '/users';
+        $payload = [
+            "userId" => $userId,
+            "roles" => $permissions,
+        ];
+
+        $response = $this->json('POST', $url, $payload, $this->header);
+        $response->assertStatus(201);
+
+        return;
+    }
+
+    public function createTestTeam()
+    {
+        $userNotificationId = User::all()->random()->id;
+        $responseNotification = $this->json(
+            'POST',
+            'api/v1/notifications',
+            [
+                'notification_type' => 'applicationSubmitted',
+                'message' => fake()->words(3, true),
+                'email' => null,
+                'user_id' => $userNotificationId,
+                'opt_in' => 1,
+                'enabled' => 1,
+            ],
+            $this->header
+        );
+        $responseNotification->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        $responseTeam = $this->json(
+            'POST',
+            'api/v1/teams',
+            [
+                'name' => 'Team Test ' . fake()->regexify('[A-Z]{5}[0-4]{1}'),
+                'enabled' => 1,
+                'allows_messaging' => 1,
+                'workflow_enabled' => 1,
+                'access_requests_management' => 1,
+                'uses_5_safes' => 1,
+                'is_admin' => 1,
+                'member_of' => fake()->randomElement([
+                    TeamMemberOf::ALLIANCE,
+                    TeamMemberOf::HUB,
+                    TeamMemberOf::OTHER,
+                    TeamMemberOf::NCS,
+                ]),
+                'contact_point' => fake()->unique()->safeEmail(),
+                'application_form_updated_by' => fake()->words(3, true),
+                'application_form_updated_on' => '2023-04-06 15:44:41',
+                'notifications' => [$responseNotification['data']],
+                'is_question_bank' => 1,
+                'users' => [],
+                'url' => 'https://fakeimg.pl/350x200/ff0000/000',
+                'introduction' => fake()->sentence(),
+                'dar_modal_content' => fake()->sentence(),
+                'service' => 'https://service.local/test',
+            ],
+            $this->header
+        );
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        return $responseTeam['data'];
+    }
+
+
+    public function createTestUser(string $email)
+    {
+        $password = 'Passw@rd1!';
+        $provider = 'service';
+        $userNotificationId = User::all()->random()->id;
+        $responseNotification = $this->json(
+            'POST',
+            'api/v1/notifications',
+            [
+                'notification_type' => 'applicationSubmitted',
+                'message' => fake()->words(3, true),
+                'email' => null,
+                'user_id' => $userNotificationId,
+                'opt_in' => 1,
+                'enabled' => 1,
+            ],
+            $this->header
+        );
+        $responseNotification->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        $responseUser = $this->json(
+            'POST',
+            '/api/v1/users',
+            [
+                'firstname' => fake()->firstName(),
+                'lastname' => fake()->lastName(),
+                'email' => $email,
+                'secondary_email' => 'just.test.1234567890@test.com',
+                'preferred_email' => 'primary',
+                'password' => $password,
+                'sector_id' => 1,
+                'organisation' => 'Test ' . fake()->regexify('[A-Z]{5}[0-4]{1}'),
+                'provider' => $provider,
+                'providerid' => '123456',
+                'bio' => fake()->words(2, true),
+                'domain' => 'https://testdomain.com',
+                'link' => 'https://testlink.com/link',
+                'orcid' => "https://orcid.org/75697342",
+                'contact_feedback' => 1,
+                'contact_news' => 1,
+                'mongo_id' => fake()->randomNumber(9, true),
+                'mongo_object_id' => strtolower(Str::random(24)),
+                'notifications' => [$responseNotification['data']],
+            ],
+            $this->header
+        );
+        $responseNotification->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        return $responseUser['data'];
+    }
+
+    public function getTestUserAuthorization(string $email)
+    {
+        $password = 'Passw@rd1!';
+        $response = $this->json('POST', '/api/v1/auth', [
+            'email' => $email,
+            'password' => $password,
+        ], [
+            'Accept' => 'application/json'
+        ]);
+
+        return $response['access_token'];
     }
 
     private function generatePublications()
@@ -1103,4 +2030,18 @@ class ToolTest extends TestCase
         // remove duplicate entries - doesn't use array_unique directly as that fails for multi-d arrays.
         return array_map("unserialize", array_unique(array_map("serialize", $return)));
     }
+
+    private function generateDatasets(array $datasets)
+    {
+        $response = [];
+        foreach ($datasets as $dataset) {
+            $response[] = [
+                'id' => $dataset['id'],
+                'link_type' => fake()->randomElement(['Used on', 'Other', 'Used in (Tool)', 'Derived from (Tool)'])
+            ];
+        }
+
+        return $response;
+    }
+
 }

--- a/tests/Feature/V2/CollectionTest.php
+++ b/tests/Feature/V2/CollectionTest.php
@@ -2048,7 +2048,7 @@ class CollectionTest extends TestCase
             ],
             $this->header
         );
-        $responseTeam->assertStatus(200);
+        $responseTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         $content = $responseTeam->decodeResponseJson();
         $teamId = $content['data'];

--- a/tests/Feature/V2/DatasetTest.php
+++ b/tests/Feature/V2/DatasetTest.php
@@ -1073,7 +1073,7 @@ class DatasetTest extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/V2/ToolV2Test.php
+++ b/tests/Feature/V2/ToolV2Test.php
@@ -353,7 +353,7 @@ class ToolV2Test extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',

--- a/tests/Feature/V2/ToolV2Test.php
+++ b/tests/Feature/V2/ToolV2Test.php
@@ -316,7 +316,7 @@ class ToolV2Test extends TestCase
             $this->header,
         );
 
-        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+        $responseCreateTeam->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
         ->assertJsonStructure([
             'message',
             'data',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Unit testing for CRUD permission error for Analysis Scripts & Software

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-5446

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
no

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
