### PR TITLE
fix!(GAT-6679): Organisation sector (optional) and Applicant name(s) (optional) are not rendering on the DUR upload UI

### DIFF
--- a/app/Console/Commands/UpdateDurOrgSectorGat6679.php
+++ b/app/Console/Commands/UpdateDurOrgSectorGat6679.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class UpdateDurOrgSectorGat6679 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-dur-org-sector-gat6679';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        \DB::statement('UPDATE dur SET organisation_sector = NULL WHERE sector_id IS NULL');
+
+        $this->info('Done');
+    }
+}

--- a/app/Imports/DataUsesTemplateImport.php
+++ b/app/Imports/DataUsesTemplateImport.php
@@ -45,7 +45,7 @@ class DataUsesTemplateImport implements ToModel, WithStartRow, WithValidation
             'project_id_text' => $row[0],
             'organisation_name' => $row[1],
             'organisation_id' => $row[2],
-            'organisation_sector' => $row[3] ? $this->mapOrganisationSector($row[3]) : null,
+            'organisation_sector' => $row[3] ?? null,
             'non_gateway_applicants' => explode(",", $row[4]),
             'applicant_id' => $row[5],
             'funders_and_sponsors' => explode(",", $row[6]),
@@ -76,6 +76,7 @@ class DataUsesTemplateImport implements ToModel, WithStartRow, WithValidation
             'enabled' => true,
             'user_id' => $this->data['user_id'],
             'team_id' => $this->data['team_id'],
+            'sector_id' => $row[3] ? $this->mapOrganisationSector($row[3]) : null,
         ]);
 
         $this->durIds[] = (int) $dur->id;


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-04-07 at 15 25 03](https://github.com/user-attachments/assets/7e57e4c0-ddf3-4622-bc22-12bb74d8c103)
![Screenshot 2025-04-07 at 15 25 11](https://github.com/user-attachments/assets/f2c021ec-2e3c-42ca-bee1-f3d4a3c3a9c1)

## Describe your changes
Organisation sector (optional) and Applicant name(s) (optional) are not rendering on the DUR upload UI

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6679

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run command
```
php artisan app:update-dur-org-sector-gat6679
```

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
