### PR TITLE
feat(GAT-6530): Add active_date to the dataset_versions table

### DIFF
--- a/app/Observers/DatasetVersionObserver.php
+++ b/app/Observers/DatasetVersionObserver.php
@@ -62,12 +62,16 @@ class DatasetVersionObserver
             'status' => Dataset::STATUS_ACTIVE,
         ])->select('id', 'status')->first();
 
+        if (!is_null($dataset) && $dataset->status === Dataset::STATUS_ACTIVE && $datasetVersion->active_date === null) {
+            $datasetVersion->active_date = now();
+            $datasetVersion->save();
+        }
+
         if (!is_null($dataset) && $dataset->status === Dataset::STATUS_ACTIVE) {
             $this->reindexElastic($dataset->id);
             if ($dataset->team_id) {
                 $this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');
             }
-
         }
     }
 }

--- a/database/migrations/2025_04_07_153827_add_active_date_to_dataset_versions_table.php
+++ b/database/migrations/2025_04_07_153827_add_active_date_to_dataset_versions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->dateTime('active_date')->nullable()->after('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->dropColumn('active_date');
+        });
+    }
+};


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-04-07 at 17 09 46](https://github.com/user-attachments/assets/6acfe855-a6da-427f-aa6a-cab31f871ea1)

## Describe your changes
Add active_date to the dataset_versions table

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6530

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run migration
```
php artisan migrate
```

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
