### PR TITLE
feat(GAT-6695): Enable user to push application back to draft

### DIFF
--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -1000,7 +1000,7 @@ class UserDataAccessApplicationController extends Controller
                     'dar_application_id' => $id
                 ])->get();
 
-                if (($newStatus === 'SUBMITTED') && ($status != 'SUBMITTED')) {
+                if (($newStatus === 'SUBMITTED') && ($status !== 'SUBMITTED')) {
                     foreach ($thd as $t) {
                         $t->update(['submission_status' => $newStatus]);
                     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6695

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
