### PR TITLE
fix(GAT-6941): Show approved/approved comments in dashboards

### DIFF
--- a/app/Http/Traits/DataAccessApplicationHelpers.php
+++ b/app/Http/Traits/DataAccessApplicationHelpers.php
@@ -157,9 +157,9 @@ trait DataAccessApplicationHelpers
             $approvalMatches = [];
             foreach ($applications as $a) {
                 foreach ($a['teams'] as $t) {
-                    if ((isset($teamId)) && ($t->team_id === $teamId) && ($t->approval_status === $filterApproval)) {
+                    if ((isset($teamId)) && ($t->team_id === $teamId) && (str_contains($t->approval_status, $filterApproval))) {
                         $approvalMatches[] = $a->id;
-                    } elseif ((isset($userId)) && ($t->approval_status === $filterApproval)) {
+                    } elseif ((isset($userId)) && (str_contains($t->approval_status, $filterApproval))) {
                         $approvalMatches[] = $a->id;
                     }
                 }

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -1618,9 +1618,10 @@ class DataAccessApplicationTest extends TestCase
         $content = $response->decodeResponseJson();
         $this->assertEquals(1, count($content['data']));
 
+        // filtering for APPROVED should also return APPROVED_COMMENTS
         $response = $this->json(
             'GET',
-            'api/v1/teams/' . $teamId . '/dar/applications?approval_status=APPROVED_COMMENTS',
+            'api/v1/teams/' . $teamId . '/dar/applications?approval_status=APPROVED',
             [],
             $this->header
         );


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Endpoints `http://localhost:8000/api/v1/users/{id}/dar/applications?approval_status=APPROVED` and `http://localhost:8000/api/v1/teams/{id}/dar/applications?approval_status=APPROVED` will now return applications where `approval_status` is either `APPROVED` or `APPROVED_COMMENTS`

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6941

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
