### PR TITLE
feat(GAT-6959): update data provider network serp with teams

### DIFF
--- a/app/Console/Commands/UpdateDataCustodianNetworkSerp.php
+++ b/app/Console/Commands/UpdateDataCustodianNetworkSerp.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Team;
+use Illuminate\Console\Command;
+use App\Models\DataProviderColl;
+use App\Models\DataProviderCollHasTeam;
+
+class UpdateDataCustodianNetworkSerp extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-data-custodian-network-serp';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'update data custodian network serp';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+
+        // add team_id 19 and 115 to data_provider_coll_id 2
+        // remove team_id 104 from data_provider_coll_id 2
+        $add = [19, 115];
+        $remove = [104];
+        $dataProviderNetworkId = 2;
+
+        foreach ($add as $teamId) {
+            $this->addTeamToDataProviderNetwork($dataProviderNetworkId, $teamId);
+        }
+
+        foreach ($remove as $teamId) {
+            $this->removeTeamToDataProviderNetwork($dataProviderNetworkId, $teamId);
+        }
+
+        $this->info('Completed ...');
+    }
+
+    public function addTeamToDataProviderNetwork($dataProviderNetworkId, $teamId)
+    {
+        $checkDataProviderNetworkId = DataProviderColl::where('id', $dataProviderNetworkId)->first();
+        if (is_null($checkDataProviderNetworkId)) {
+            $this->warn('Data Provider Network not found for id ' . $dataProviderNetworkId);
+            return;
+        }
+
+        $checkTeam = Team::where('id', $teamId)->first();
+        if (is_null($checkTeam)) {
+            $this->warn('Team not found for id ' . $teamId);
+            return;
+        }
+
+        $checkDataProviderCollHasTeam = DataProviderCollHasTeam::where([
+            'data_provider_coll_id' => $dataProviderNetworkId,
+            'team_id' => $teamId,
+        ])->first();
+
+        if (is_null($checkDataProviderCollHasTeam)) {
+            DataProviderCollHasTeam::create([
+                'data_provider_coll_id' => $dataProviderNetworkId,
+                'team_id' => $teamId,
+            ]);
+            $this->info('Data Provider Network ' . $dataProviderNetworkId . ' has been linked to team ' . $teamId);
+        }
+    }
+
+    public function removeTeamToDataProviderNetwork($dataProviderNetworkId, $teamId)
+    {
+        $checkDataProviderNetworkId = DataProviderColl::where('id', $dataProviderNetworkId)->first();
+        if (is_null($checkDataProviderNetworkId)) {
+            $this->warn('Data Provider Network not found for id ' . $dataProviderNetworkId);
+            return;
+        }
+
+        $checkTeam = Team::where('id', $teamId)->first();
+        if (is_null($checkTeam)) {
+            $this->warn('Team not found for id ' . $teamId);
+            return;
+        }
+
+        $checkDataProviderCollHasTeam = DataProviderCollHasTeam::where([
+            'data_provider_coll_id' => $dataProviderNetworkId,
+            'team_id' => $teamId,
+        ])->first();
+
+        if (!is_null($checkDataProviderCollHasTeam)) {
+            DataProviderCollHasTeam::where([
+                'data_provider_coll_id' => $dataProviderNetworkId,
+                'team_id' => $teamId,
+            ])->delete();
+            $this->info('Data Provider Network ' . $dataProviderNetworkId . ' has been unlinked to team ' . $teamId);
+        }
+    }
+
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
update data provider network serp with teams
```
data-custodian-network_id=2
ADD: team_id=19
ADD: team_id=115
REMOVE: team_id=104
```

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6959

## Environment / Configuration changes (if applicable)
run command
```
php artisan app:update-data-custodian-network-serp
```

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
