### PR TITLE
fix(GAT-6869): Data Custodian filter on Collections/Networks search UI has blank option that doesn't function

### DIFF
--- a/app/Console/Commands/ReindexEntities.php
+++ b/app/Console/Commands/ReindexEntities.php
@@ -212,8 +212,9 @@ class ReindexEntities extends Command
             echo "---> Deleted $nDeleted documents from the index \n";
         }
 
-        $nTotal = Collection::count();
+        $nTotal = Collection::whereNotNull('team_id')->where('status', Collection::STATUS_ACTIVE)->count();
         $collectionIds = Collection::where('status', Collection::STATUS_ACTIVE)
+            ->whereNotNull('team_id')
             ->select('id')
             ->pluck('id')
             ->toArray();


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-04-24 at 15 04 14](https://github.com/user-attachments/assets/99012890-7723-4f92-9ae7-dad5d998af9c)

## Describe your changes
[BE] Data Custodian filter on Collections/Networks search UI has blank option that doesn't function

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6869

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run reindex collections

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
