### PR TITLE
fix(GAT-6868): Fix deletion of datasets from Collections

### DIFF
--- a/app/Http/Traits/CollectionsV2Helpers.php
+++ b/app/Http/Traits/CollectionsV2Helpers.php
@@ -121,15 +121,15 @@ trait CollectionsV2Helpers
     // datasets
     private function checkDatasets(int $collectionId, array $inDatasets, int $userId = null)
     {
-        $collectionHastDatasetVersions = CollectionHasDatasetVersion::withTrashed()
+        $collectionHasDatasetVersions = CollectionHasDatasetVersion::withTrashed()
                                             ->where('collection_id', $collectionId)
                                             ->select('dataset_version_id')
                                             ->get()
                                             ->toArray();
 
-        $collectionHastDatasetVersionIds = [];
-        if (count($collectionHastDatasetVersions)) {
-            $collectionHastDatasetVersionIds = array_unique(convertArrayToArrayWithKeyName($collectionHastDatasetVersions, 'dataset_version_id'));
+        $collectionHasDatasetVersionIds = [];
+        if (count($collectionHasDatasetVersions)) {
+            $collectionHasDatasetVersionIds = array_unique(convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'dataset_version_id'));
         }
 
         foreach ($inDatasets as $dataset) {
@@ -138,7 +138,7 @@ trait CollectionsV2Helpers
             $datasetVersions = DatasetVersion::where('dataset_id', (int) $dataset['id'])->select('id')->get()->toArray();
 
             $datasetVersionIds = convertArrayToArrayWithKeyName($datasetVersions, 'id');
-            $commonDatasetVersionIds = array_intersect($collectionHastDatasetVersionIds, $datasetVersionIds);
+            $commonDatasetVersionIds = array_intersect($collectionHasDatasetVersionIds, $datasetVersionIds);
 
             if (count($commonDatasetVersionIds) === 0) {
                 $this->addCollectionHasDatasetVersion($collectionId, $dataset, $datasetVersionLatestId, $userId);


### PR DESCRIPTION
## Screenshots (if relevant)

https://github.com/user-attachments/assets/70e77249-cb61-45d3-bc48-80a0fc81b2eb


## Describe your changes
The helper function was not checking for any dataset versions that had previously been linked but no longer required. We now check for these, and delete them.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6868

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
