### PR TITLE
fix(GAT-6854): Extend linkage extraction job (under apps/jobs) for tools - Its not rendering on the Tools Search UI

### DIFF
--- a/app/Jobs/ExtractToolsFromMetadata.php
+++ b/app/Jobs/ExtractToolsFromMetadata.php
@@ -122,14 +122,19 @@ class ExtractToolsFromMetadata implements ShouldQueue
 
     public function createLinkToolDatasetVersion(int $toolId, int $datasetVersionId, string $type)
     {
-        return DatasetVersionHasTool::updateOrCreate([
-            'tool_id' => $toolId,
-            'dataset_version_id' => $datasetVersionId,
-            'link_type' => $type,
-        ], [
-            'tool_id' => $toolId,
-            'dataset_version_id' => $datasetVersionId,
-            'link_type' => $type,
-        ]);
+        $check = DatasetVersionHasTool::where([
+                'tool_id' => $toolId,
+                'dataset_version_id' => $datasetVersionId,
+                'link_type' => $type,
+            ])
+            ->first();
+
+        if (is_null($check)) {
+            return DatasetVersionHasTool::create([
+                'tool_id' => $toolId,
+                'dataset_version_id' => $datasetVersionId,
+                'link_type' => $type,
+            ]);
+        }
     }
 }

--- a/app/Jobs/ExtractToolsFromMetadata.php
+++ b/app/Jobs/ExtractToolsFromMetadata.php
@@ -120,7 +120,7 @@ class ExtractToolsFromMetadata implements ShouldQueue
         }
     }
 
-    public function createLinkToolDatasetVersion(int $toolId, int $datasetVersionId, string $type)
+    public function createLinkToolDatasetVersion(int $toolId, int $datasetVersionId, string $type): ?DatasetVersionHasTool
     {
         $check = DatasetVersionHasTool::where([
                 'tool_id' => $toolId,
@@ -136,5 +136,7 @@ class ExtractToolsFromMetadata implements ShouldQueue
                 'link_type' => $type,
             ]);
         }
+
+        return null;
     }
 }

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -82,6 +82,56 @@ class Dataset extends Model
         'status',
     ];
 
+    public function getToolsAttribute()
+    {
+        return $this->attributes['tools'] ?? collect();
+    }
+
+    public function getToolsCountAttribute()
+    {
+        return $this->attributes['tools_count'] ?? 0;
+    }
+
+    public function getDursAttribute()
+    {
+        return $this->attributes['durs'] ?? collect();
+    }
+
+    public function getDursCountAttribute()
+    {
+        return $this->attributes['durs_count'] ?? 0;
+    }
+
+    public function getCollectionsAttribute()
+    {
+        return $this->attributes['collections'] ?? collect();
+    }
+
+    public function getCollectionsCountAttribute()
+    {
+        return $this->attributes['collections_count'] ?? 0;
+    }
+
+    public function getPublicationsAttribute()
+    {
+        return $this->attributes['publications'] ?? collect();
+    }
+
+    public function getPublicationsCountAttribute()
+    {
+        return $this->attributes['publications_count'] ?? 0;
+    }
+
+    public function getSpatialCoverageAttribute()
+    {
+        return $this->attributes['spatialCoverage'] ?? 0;
+    }
+
+    public function getNamedEntitiesAttribute()
+    {
+        return $this->attributes['named_entities'] ?? 0;
+    }
+
     /**
      * The version history of metadata that respond to this dataset.
      */

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -120,7 +120,7 @@ class DatasetVersion extends Model
      */
     public function spatialCoverage(): BelongsToMany
     {
-        return $this->belongsToMany(NamedEntities::class, 'dataset_version_has_spatial_coverage');
+        return $this->belongsToMany(SpatialCoverage::class, 'dataset_version_has_spatial_coverage');
     }
 
 
@@ -129,7 +129,7 @@ class DatasetVersion extends Model
      */
     public function tools(): BelongsToMany
     {
-        return $this->belongsToMany(Tool::class, 'dataset_version_has_tool');
+        return $this->belongsToMany(Tool::class, 'dataset_version_has_tool', 'dataset_version_id', 'tool_id');
     }
 
     /**
@@ -154,6 +154,22 @@ class DatasetVersion extends Model
     public function collections(): HasMany
     {
         return $this->hasMany(CollectionHasDatasetVersion::class);
+    }
+
+    /**
+     * The durs that belong to the dataset version.
+     */
+    public function durs(): HasMany
+    {
+        return $this->hasMany(DurHasDatasetVersion::class);
+    }
+
+    /**
+     * The durs that belong to the dataset version.
+     */
+    public function publications(): HasMany
+    {
+        return $this->hasMany(PublicationHasDatasetVersion::class);
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Extend linkage extraction job (under apps/jobs) for tools - Its not rendering on the Tools Search UI

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6854

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
