### PR TITLE
fix(GAT-6984): add message to review when status set to draft by custodian

### DIFF
--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -143,18 +143,20 @@ class CohortUserExpiry extends Command
         }
     }
 
-    private function calculateTrueExpiry($cohort) {
+    private function calculateTrueExpiry($cohort)
+    {
         $request_expire_at = null;
         if (!is_null($cohort->request_expire_at)) {
             $request_expire_at = Carbon::createFromFormat('Y-m-d H:i:s', $cohort->request_expire_at);
         }
 
         return min(
-            array_diff([
-                $cohort->updated_at->addDays((int)Config::get('cohort.cohort_access_expiry_time_in_days')), 
+            array_diff(
+                [
+                $cohort->updated_at->addDays((int)Config::get('cohort.cohort_access_expiry_time_in_days')),
                 $request_expire_at
             ],
-            array(null)
+                array(null)
             )
         );
     }

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -769,12 +769,19 @@ class TeamDataAccessApplicationController extends Controller
                 'dar_application_id' => $id,
             ])->first();
 
+            $submissionStatusUpdate = $input['submission_status'] ?? null;
+
             $reviewId = null;
             if (isset($input['comment'])) {
-                $review = DataAccessApplicationReview::create([
-                    'application_id' => $id,
-                    'resolved' => true,
-                ]);
+                if ($submissionStatusUpdate === 'DRAFT') {
+                    $review = DataAccessApplicationReview::where('application_id', $id)->first();
+                }
+                if (!$review) {
+                    $review = DataAccessApplicationReview::create([
+                        'application_id' => $id,
+                        'resolved' => true,
+                    ]);
+                }
                 $reviewId = $review->id;
 
                 DataAccessApplicationComment::create([

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -772,6 +772,7 @@ class TeamDataAccessApplicationController extends Controller
             $submissionStatusUpdate = $input['submission_status'] ?? null;
 
             $reviewId = null;
+            $review = null;
             if (isset($input['comment'])) {
                 if ($submissionStatusUpdate === 'DRAFT') {
                     $review = DataAccessApplicationReview::where('application_id', $id)->first();

--- a/tests/Feature/DataAccessApplicationTest.php
+++ b/tests/Feature/DataAccessApplicationTest.php
@@ -2443,6 +2443,7 @@ class DataAccessApplicationTest extends TestCase
             [
                 'submission_status' => 'DRAFT',
                 'approval_status' => null,
+                'comment' => 'A comment'
             ],
             $this->header
         );
@@ -2455,6 +2456,46 @@ class DataAccessApplicationTest extends TestCase
         $content = $response->decodeResponseJson();
         $this->assertEquals($content['data']['teams'][0]['submission_status'], 'DRAFT');
         $this->assertEquals($content['data']['teams'][0]['approval_status'], null);
+
+        // Test that a review was created
+        $response = $this->json(
+            'GET',
+            'api/v1/teams/' . $teamId . '/dar/applications/' . $applicationId . '/reviews',
+            [],
+            $this->header
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    0 => [
+                        'id',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'application_id',
+                        'question_id',
+                        'resolved',
+                        'comments' => [
+                            0 => [
+                                'id',
+                                'created_at',
+                                'updated_at',
+                                'deleted_at',
+                                'team_id',
+                                'user_id',
+                                'comment',
+                            ]
+                        ],
+                        'files',
+                    ]
+                ]
+            ]);
+        $content = $response->decodeResponseJson()['data'];
+
+        $this->assertEquals(1, count($content[0]['comments']));
+        $this->assertEquals('A comment', $content[0]['comments'][0]['comment']);
+
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-6984

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
