### PR TITLE
fix(GAT-6962): Data Collections / Networks tab slow

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1834,10 +1834,10 @@ class SearchController extends Controller
             $datasets = Dataset::where([
                 'team_id' => $team['id'],
                 'status' => 'ACTIVE',
-                ])->with('versions')->select(['id'])->get();
+                ])->with(['versions:id,dataset_id,short_title'])->select(['id'])->get();
             foreach ($datasets as $dataset) {
                 $metadata = $dataset['versions'][0];
-                $datasetTitles[] = $metadata['metadata']['metadata']['summary']['shortTitle'];
+                $datasetTitles[] = $metadata['short_title'];
             }
         }
         usort($datasetTitles, 'strcasecmp');


### PR DESCRIPTION
## Screenshots (if relevant)
from
![Screenshot 2025-05-06 at 14 02 54](https://github.com/user-attachments/assets/190d3239-af03-47fe-9942-2668ec972043)

to
![Screenshot 2025-05-06 at 14 02 49](https://github.com/user-attachments/assets/bec01900-8074-4532-ad6c-db4fa8f62056)


## Describe your changes
Data Collections / Networks tab slow

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6962

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
