### PR TITLE
feat(GAT-4070): Add dataProvider to tools filters.

### DIFF
--- a/database/seeders/FilterSeeder.php
+++ b/database/seeders/FilterSeeder.php
@@ -66,6 +66,7 @@ class FilterSeeder extends Seeder
             'license',
             'dataProviderColl',
             'datasetTitles',
+            'dataProvider',
             'typeCategory'
         ];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Adds the missing `dataProvider` filter to tools.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4070

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
requires running `php artisan db:seed  --class=FilterSeeder` - this is non-destructive as it checks for existing rows

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
