### PR TITLE
feat(GAT-4070): Add team name to dataProvider field in tool indexing

### DIFF
--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -729,7 +729,7 @@ trait IndexElastic
                 'tags' => $tags,
                 'datasetTitles' => $datasetTitles,
                 'dataProviderColl' => $dataProviderColl,
-                'dataProvider' => $tool['team']['name'],
+                'dataProvider' => $tool['team']['name'] ?? null,
                 'resultsInsights' => $tool['results_insights']
             ];
 

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -647,6 +647,7 @@ trait IndexElastic
                     'category',
                     'typeCategory',
                     'license',
+                    'team',
                 ])
                 ->first();
 
@@ -728,6 +729,7 @@ trait IndexElastic
                 'tags' => $tags,
                 'datasetTitles' => $datasetTitles,
                 'dataProviderColl' => $dataProviderColl,
+                'dataProvider' => $tool['team']['name'],
                 'resultsInsights' => $tool['results_insights']
             ];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Add team name to dataProvider field in tool indexing

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-4070

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
This requires a reindexing of tools

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
