### PR TITLE
feat(GAT-6422): Search on the dataUses is returning - There has been a server error cURL error 28 ... 

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -49,6 +49,7 @@ use App\Http\Traits\GetValueByPossibleKeys;
 use App\Models\PublicationHasDatasetVersion;
 use Illuminate\Database\Eloquent\Casts\Json;
 use App\Http\Requests\Search\PublicationSearch;
+use Illuminate\Http\Client\ConnectionException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class SearchController extends Controller
@@ -864,13 +865,20 @@ class SearchController extends Controller
         try {
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/dur';
             $response = Http::post($urlString, $input);
-        } catch (Exception $e) {
+        } catch (ConnectionException $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
             throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+            throw new Exception($e->getMessage());
         }
 
         try {

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -477,8 +477,24 @@ class SearchController extends Controller
             $aggs = Filter::where('type', 'tool')->get()->toArray();
             $input['aggs'] = $aggs;
 
-            $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/tools';
-            $response = Http::post($urlString, $input);
+            try {
+                $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/tools';
+                $response = Http::post($urlString, $input);
+            } catch (ConnectionException $e) {
+                Auditor::log([
+                    'action_type' => 'EXCEPTION',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => $e->getMessage(),
+                ]);
+                throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
+            } catch (Exception $e) {
+                Auditor::log([
+                    'action_type' => 'EXCEPTION',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => $e->getMessage(),
+                ]);
+                throw new Exception($e->getMessage());
+            }
 
             $toolsArray = $response['hits']['hits'];
             $totalResults = $response['hits']['total']['value'];
@@ -1087,8 +1103,24 @@ class SearchController extends Controller
                 $aggs = Filter::where('type', 'paper')->get()->toArray();
                 $input['aggs'] = $aggs;
 
-                $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/publications';
-                $response = Http::post($urlString, $input);
+                try {
+                    $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/publications';
+                    $response = Http::post($urlString, $input);
+                } catch (ConnectionException $e) {
+                    Auditor::log([
+                        'action_type' => 'EXCEPTION',
+                        'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                        'description' => $e->getMessage(),
+                    ]);
+                    throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
+                } catch (Exception $e) {
+                    Auditor::log([
+                        'action_type' => 'EXCEPTION',
+                        'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                        'description' => $e->getMessage(),
+                    ]);
+                    throw new Exception($e->getMessage());
+                }
 
                 $pubArray = $response['hits']['hits'];
                 $totalResults = $response['hits']['total']['value'];
@@ -1147,7 +1179,24 @@ class SearchController extends Controller
                     }
                 }
                 $input['field'] = ['TITLE', 'ABSTRACT', 'METHODS'];
-                $response = Http::post($urlString, $input);
+
+                try {
+                    $response = Http::post($urlString, $input);
+                } catch (ConnectionException $e) {
+                    Auditor::log([
+                        'action_type' => 'EXCEPTION',
+                        'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                        'description' => $e->getMessage(),
+                    ]);
+                    throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
+                } catch (Exception $e) {
+                    Auditor::log([
+                        'action_type' => 'EXCEPTION',
+                        'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                        'description' => $e->getMessage(),
+                    ]);
+                    throw new Exception($e->getMessage());
+                }
 
                 $pubArray = $response['resultList']['result'] ?? [];
                 $totalResults = $response['hitCount'];


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-05-08 at 12 18 48](https://github.com/user-attachments/assets/6423012b-a984-494e-aa73-d109c6532918)

## Describe your changes
Search on the dataUses is returning - "There has been a server error cURL error 28: Operation timed out after 30000 milliseconds with 0 bytes received"

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6422

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
