### PR TITLE
fix(GAT-6985): Getting 404 errors when clicking on derived from linked datasets

### DIFF
--- a/app/Console/Commands/UpdateDatasetLinkageGat6985.php
+++ b/app/Console/Commands/UpdateDatasetLinkageGat6985.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dataset;
+use App\Jobs\LinkageExtraction;
+use Illuminate\Console\Command;
+
+class UpdateDatasetLinkageGat6985 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-dataset-linkage-gat6985';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $datasets = Dataset::select(['id', 'status'])->get();
+
+        foreach ($datasets as $dataset) {
+            $this->info("dataset with ID: {$dataset->id} has status: {$dataset->status}");
+            $latestVersion = $dataset->latestVersion();
+            $datasetVersionId = $latestVersion->id;
+            LinkageExtraction::dispatch($dataset->id, $datasetVersionId);
+            $this->info("LinkageExtraction job dispatched for dataset ID: {$dataset->id} and version ID: {$datasetVersionId}");
+
+            $this->info('Done');
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -28,6 +28,7 @@ use App\Http\Requests\Dataset\CreateDataset;
 use App\Http\Requests\Dataset\ExportDataset;
 use App\Http\Requests\Dataset\UpdateDataset;
 use App\Exports\DatasetStructuralMetadataExport;
+use App\Models\DatasetVersionHasDatasetVersion;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -496,6 +497,9 @@ class DatasetController extends Controller
                 return Excel::download(new DatasetStructuralMetadataExport($export), 'dataset-structural-metadata.csv');
             }
 
+            // linkage
+            $dataset->linkages = $this->getLinkages($latestVersionID);
+
             Auditor::log([
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
@@ -516,6 +520,44 @@ class DatasetController extends Controller
 
             throw new Exception($e->getMessage());
         }
+    }
+
+    public function getLinkages($datasetVersionId)
+    {
+        $datasetLinkages = DatasetVersionHasDatasetVersion::where([
+            'dataset_version_source_id' => $datasetVersionId,
+        ])
+        ->get()
+        ->map(function ($linkage) {
+            $dv = DatasetVersion::where([
+                'id' => $linkage->dataset_version_target_id,
+            ])->select(['id', 'dataset_id', 'short_title'])->first();
+
+            if (is_null($dv)) {
+                return null;
+            }
+
+            $d = Dataset::where([
+                'id' => $dv->dataset_id,
+            ])->select(['id', 'status'])->first();
+
+            if (is_null($d)) {
+                return null;
+            }
+
+            if ($d->status !== Dataset::STATUS_ACTIVE) {
+                return null;
+            }
+
+            return [
+                'title' => $dv->short_title,
+                'url' => env('GATEWAY_URL') . '/en/dataset/' . $d->id,
+            ];
+        })
+        ->filter()
+        ->values();
+
+        return $datasetLinkages ?? [];
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -497,14 +497,14 @@ class DatasetController extends Controller
                 return Excel::download(new DatasetStructuralMetadataExport($export), 'dataset-structural-metadata.csv');
             }
 
-            // linkage
-            $dataset->linkages = $this->getLinkages($latestVersionID);
-
             Auditor::log([
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => 'Dataset get ' . $id,
             ]);
+
+            // linkages
+            $dataset->setAttribute('linkages', $this->getLinkages($latestVersionID));
 
             return response()->json([
                 'message' => 'success',
@@ -557,7 +557,7 @@ class DatasetController extends Controller
         ->filter()
         ->values();
 
-        return $datasetLinkages ?? [];
+        return $datasetLinkages;
     }
 
     /**

--- a/tests/Feature/DatasetTest.php
+++ b/tests/Feature/DatasetTest.php
@@ -622,6 +622,7 @@ class DatasetTest extends TestCase
                 'versions',
                 'durs_count',
                 'publications_count',
+                'linkages',
             ]
         ]);
         $responseGetOneActive->assertStatus(200);
@@ -703,6 +704,7 @@ class DatasetTest extends TestCase
                 'versions',
                 'durs_count',
                 'publications_count',
+                'linkages',
             ]
         ]);
         $responseGetOneDraft->assertStatus(200);


### PR DESCRIPTION
## Screenshots (if relevant)
![Screenshot 2025-05-08 at 17 22 10](https://github.com/user-attachments/assets/b116d158-e740-48af-acc5-6ec4bf4e8a87)
 
## Describe your changes
Getting 404 errors when clicking on 'derived from' linked datasets

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6985

## Environment / Configuration changes (if applicable)
run command:
```
php artisan app:update-dataset-linkage-gat6985
```

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
