### PR TITLE
fix(GAT-7113): Emails masked by OpenAthens breaks workflow to user creation on RQuest

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'dev'
-      - 'bugfix/GAT-7113'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -27,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: bugfix/GAT-7113
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -77,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: bugfix/GAT-7113
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'bugfix/GAT-7113'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +27,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: bugfix/GAT-7113
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +77,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: bugfix/GAT-7113
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1135,6 +1135,17 @@ class CohortRequestController extends Controller
                 throw new Exception('Unauthorized for access :: There are not enough permissions allocated for the cohort request');
             }
 
+            $user = User::where([
+                'id' => $userId,
+            ])->first();
+            if (!$user) {
+                throw new Exception('Unauthorized for access :: The user not found');
+            }
+            $email = ($user->provider === 'open-athens' || $user->preferred_email === 'secondary') ? $user->secondary_email : $user->email;
+            if (strlen(trim($email)) === 0 || !$email) {
+                throw new Exception('Unauthorized for access :: The user email not found');
+            }
+
             // oidc
             OauthUser::where('user_id', $userId)->delete();
             session(['cr_uid' => $userId]);

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1145,6 +1145,9 @@ class CohortRequestController extends Controller
             if (strlen(trim($email)) === 0 || !$email) {
                 throw new Exception('Unauthorized for access :: The user email not found');
             }
+            if (filter_var(trim($email), FILTER_VALIDATE_EMAIL) === false) {
+                throw new Exception('Unauthorized for access :: The user email is not valid');
+            }
 
             // oidc
             OauthUser::where('user_id', $userId)->delete();

--- a/app/Http/Controllers/SSO/CustomUserController.php
+++ b/app/Http/Controllers/SSO/CustomUserController.php
@@ -65,7 +65,7 @@ class CustomUserController extends Controller
                 'profile' => $profile,
                 'given_name' => $user->firstname,
                 'family_name' => $user->lastname,
-                'email' => $user->email,
+                'email' => ($user->provider === 'open-athens' || $user->preferred_email === 'secondary') ? $user->secondary_email : $user->email,
                 'rquestroles' => $rRoles,
             ]);
         } catch (Exception $e) {

--- a/app/Http/Traits/CustomAccessTokenTrait.php
+++ b/app/Http/Traits/CustomAccessTokenTrait.php
@@ -90,7 +90,7 @@ trait CustomAccessTokenTrait
             ->withClaim('sid', $sessionState)
             ->withClaim('allowed-origins', $allowedOrigins)
             ->withClaim('email_verified', true)
-            ->withClaim('email', $user->email)
+            ->withClaim('email', ($user->provider === 'open-athens' || $user->preferred_email === 'secondary') ? $user->secondary_email : $user->email)
             ->withClaim('preferred_username', $user->name)
             ->withClaim('name', $user->lastname . ' ' . $user->firstname)
             ->withClaim('given_name', $user->firstname)

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,6 +40,7 @@ Route::get('/email', function (Request $reqest) {
 # bcplatform
 Route::get('/oauth/userinfo', [CustomUserController::class, 'userInfo'])->middleware('auth:api');
 Route::match(['get', 'post'], '/oauth/logmeout', [CustomLogoutController::class, 'rquestLogout']);
+Route::match(['get', 'post'], '/oauth2/logout', [CustomLogoutController::class, 'rquestLogout']);
 
 // stop all all other routes
 Route::any('{path}', function () {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Emails masked by OpenAthens breaks workflow to user creation on RQuest

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7113

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
