### PR TITLE
fix(GAT-7118): Fixes incorrect usage of dataset id, instead of versio…

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -412,7 +412,10 @@ class DatasetController extends Controller
             // objects on this, rather than excessively calling latestDataset()-><relation>.
             $latestVersionID = $dataset->latestVersionID($id);
 
-            $datasetVersion = DatasetVersion::where('dataset_id', $id)
+            // This was incorrectly using the dataset ID, not the version ID. Thus leaving us
+            // at the mercy of the sql optimiser and whatever order it decided to return at
+            // time. Changed to use the version ID to ensure we get the correct 'latest' version.
+            $datasetVersion = DatasetVersion::where('id', $latestVersionID)
                 ->with(['tools', 'spatialCoverage', 'namedEntities', 'collections', 'durs', 'publications'])
                 ->select('id')
                 ->first();


### PR DESCRIPTION
…n id

## Screenshots (if relevant)

## Describe your changes
DatasetController was incorrectly using DatasetVersion.dataset_id when pulling metadata against a record that had multiples of metadata. The version it was pulling just so happened to pull back the first ever for that dataset, thus leading to payload inconsistencies.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7118

## Environment / Configuration changes (if applicable)
N/A

## Requires migrations being run?
N/A

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
