### PR TITLE
feat(GAT-6925): Enable the use of aliases for Data Custodian names

### DIFF
--- a/app/Http/Controllers/Api/V1/AliasController.php
+++ b/app/Http/Controllers/Api/V1/AliasController.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Config;
+use Auditor;
+use Exception;
+use App\Models\Alias;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use App\Http\Requests\Alias\GetAlias;
+use App\Http\Requests\Alias\CreateAlias;
+use App\Http\Requests\Alias\EditAlias;
+use App\Http\Requests\Alias\DeleteAlias;
+use App\Http\Requests\Alias\UpdateAlias;
+use App\Models\TeamHasAlias;
+use App\Http\Controllers\Controller;
+
+class AliasController extends Controller
+{
+    /**
+     * @OA\Get(
+     *    path="/api/v1/aliases",
+     *    summary="List of aliases",
+     *    description="Returns a list of aliases",
+     *    tags={"Alias"},
+     *    operationId="AliasController@index",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\Response(
+     *       response=200,
+     *       description="Success",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string"),
+     *          @OA\Property(property="data", type="array",
+     *             @OA\Items(
+     *                @OA\Property(property="id", type="integer", example="123"),
+     *                @OA\Property(property="name", type="string", example="something"),
+     *             )
+     *          )
+     *       )
+     *    )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $aliases = Alias::paginate(Config::get('constants.per_page'), ['*'], 'page');
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'INDEX',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => "Alias index",
+            ]);
+
+            return response()->json(
+                $aliases
+            );
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v1/aliases/{id}",
+     *      summary="Return a single alias",
+     *      description="Return a single alias",
+     *      tags={"Alias"},
+     *      operationId="AliasController@show",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="alias id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="alias id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="alias", type="string", example="something")
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function show(GetAlias $request, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $alias = Alias::find($id);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'INDEX',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Alias show ' . $id,
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $alias,
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/aliases",
+     *      summary="Create a new alias",
+     *      description="Creates a new alias",
+     *      tags={"Alias"},
+     *      summary="AliasController@store",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Alias definition",
+     *          @OA\JsonContent(
+     *              required={"name"},
+     *              @OA\Property(property="name", type="string", example="something")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="alias", type="string", example="something")
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function store(CreateAlias $request): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $alias = Alias::create([
+                'name' => $input['name'],
+            ]);
+            $aliasId = (int) $alias->id;
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'CREATE',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Alias ' . $aliasId . ' created',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_CREATED.message'),
+                'data' => $aliasId,
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *      path="/api/v1/aliases/{id}",
+     *      summary="Update a alias",
+     *      description="Update a alias",
+     *      tags={"Alias"},
+     *      summary="AliasController@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="alias id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="alias id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Alias definition",
+     *          @OA\JsonContent(
+     *              required={"name"},
+     *              @OA\Property(property="name", type="string", example="something")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="name", type="string", example="xxx")
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function update(UpdateAlias $request, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            Alias::where('id', $id)->update([
+                'name' => $input['name'],
+            ]);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'UPDATE',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Alias ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => Alias::where('id', $id)->first(),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *      path="/api/v1/aliases/{id}",
+     *      summary="Edit a alias",
+     *      description="Edit a alias",
+     *      tags={"Alias"},
+     *      summary="AliasController@edit",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="alias id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="alias id",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Alias definition",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="id", type="integer", example="123"),
+     *              @OA\Property(property="name", type="string", example="something")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="name", type="string", example="something")
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function edit(EditAlias $request, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $input = $request->all();
+
+            Alias::where('id', $id)->update($input['name']);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EDIT',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Alias ' . $id . ' updated',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => Alias::where('id', $id)->first()
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v1/aliases/{id}",
+     *      summary="Delete an alias",
+     *      description="Delete an alias",
+     *      tags={"Alias"},
+     *      summary="AliasController@destroy",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="alias id",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="alias id",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroy(DeleteAlias $request, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $teamHasAlias = TeamHasAlias::where(['alias_id' => $id])->first();
+            if (!is_null($teamHasAlias)) {
+                throw new Exception('I cannot delete this alias, it is used by a team');
+            }
+
+            Alias::where('id', $id)->delete();
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Alias ' . $id . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/AliasController.php
+++ b/app/Http/Controllers/Api/V1/AliasController.php
@@ -362,7 +362,10 @@ class AliasController extends Controller
         try {
             $input = $request->all();
 
-            Alias::where('id', $id)->update($input['name']);
+            Alias::where('id', $id)
+            ->update([
+                    'name' => $input['name'],
+                ]);
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -421,7 +421,7 @@ class CollectionController extends Controller
             Auditor::log([
                 'action_type' => 'SHOW',
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
-                'description' => 'CohortRequest show ' . $id,
+                'description' => 'Collection show ' . $id,
             ]);
 
             return response()->json([

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -2,21 +2,22 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use Auditor;
 use Config;
+use Auditor;
 use Exception;
 use App\Models\User;
 use App\Models\Notification;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
+use App\Exceptions\NotFoundException;
+use App\Http\Traits\TeamTransformation;
+use App\Http\Traits\RequestTransformation;
+use App\Http\Requests\Notification\GetNotification;
 use App\Http\Requests\Notification\EditNotification;
 use App\Http\Requests\Notification\CreateNotification;
 use App\Http\Requests\Notification\DeleteNotification;
 use App\Http\Requests\Notification\UpdateNotification;
-use App\Http\Traits\TeamTransformation;
-use App\Http\Traits\RequestTransformation;
-use App\Http\Requests\Notification\GetNotification;
 
 class NotificationController extends Controller
 {
@@ -311,10 +312,10 @@ class NotificationController extends Controller
      */
     public function update(UpdateNotification $request, int $id): JsonResponse
     {
-        try {
-            $input = $request->all();
-            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
+        try {
             Notification::where('id', $id)->update([
                 'notification_type' => $input['notification_type'],
                 'message' => $input['message'],
@@ -495,10 +496,10 @@ class NotificationController extends Controller
      */
     public function destroy(DeleteNotification $request, int $id): JsonResponse
     {
-        try {
-            $input = $request->all();
-            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
+        try {
             $notification = Notification::findOrFail($id);
             if ($notification) {
                 $notification->delete();

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -1302,7 +1302,6 @@ class TeamController extends Controller
         $this->collections = array_unique(array_merge($this->collections, Arr::pluck($dataset->allCollections, 'id')));
     }
 
-
     private function updateTeamAlias(int $teamId, array $arrayTeamAlias): void
     {
         TeamHasAlias::where('team_id', $teamId)->delete();

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -35,6 +35,7 @@ use App\Http\Traits\TeamTransformation;
 use App\Http\Traits\RequestTransformation;
 use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Traits\CheckAccess;
+use App\Models\TeamHasAlias;
 
 class TeamController extends Controller
 {
@@ -86,15 +87,16 @@ class TeamController extends Controller
      *                    @OA\Property(property="url", type="string", example="https://example/image.jpg"),
      *                    @OA\Property(property="introduction", type="string", example="info about the team"),
      *                    @OA\Property(property="service", type="string", example="https://example"),
+     *                    @OA\Property(property="aliases", type="array", example="[]", @OA\Items()),
      *                ),
      *             ),
-     *             @OA\Property(property="first_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/cohort_requests?page=1"),
+     *             @OA\Property(property="first_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams?page=1"),
      *             @OA\Property(property="from", type="integer", example="1"),
      *             @OA\Property(property="last_page", type="integer", example="1"),
-     *             @OA\Property(property="last_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/cohort_requests?page=1"),
+     *             @OA\Property(property="last_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams?page=1"),
      *             @OA\Property(property="links", type="array", example="[]", @OA\Items(type="array", @OA\Items())),
      *             @OA\Property(property="next_page_url", type="string", example="null"),
-     *             @OA\Property(property="path", type="string", example="http:\/\/localhost:8000\/api\/v1\/cohort_requests"),
+     *             @OA\Property(property="path", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams"),
      *             @OA\Property(property="per_page", type="integer", example="25"),
      *             @OA\Property(property="prev_page_url", type="string", example="null"),
      *             @OA\Property(property="to", type="integer", example="3"),
@@ -230,7 +232,7 @@ class TeamController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
-            $userTeam = Team::where('id', $teamId)->with(['users', 'notifications'])->get()->toArray();
+            $userTeam = Team::where('id', $teamId)->with(['users', 'notifications', 'aliases'])->get()->toArray();
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -578,6 +580,7 @@ class TeamController extends Controller
      *              @OA\Property(property="introduction", type="string", example="info about the team"),
      *              @OA\Property(property="dar_modal_content", type="string", example="dar info"),
      *              @OA\Property(property="service", type="string", example="https://example"),
+     *              @OA\Property(property="aliases", type="array", example="[1, 2]", @OA\Items(type="array", @OA\Items())),
      *          ),
      *      ),
      *      @OA\Response(
@@ -610,7 +613,8 @@ class TeamController extends Controller
         $arrayTeam['name'] = formatCleanInput($input['name']);
         $arrayTeam['pid'] = (string) Str::uuid();
 
-        $arrayTeamNotification = $input['notifications'];
+        $arrayTeamNotification = $input['notifications'] ?? [];
+        $arrayTeamAlias = $input['aliases'] ?? [];
         $arrayTeamUsers = $input['users'];
         $superAdminIds = User::where('is_admin', true)->pluck('id');
         $team = Team::create($arrayTeam);
@@ -623,6 +627,8 @@ class TeamController extends Controller
                         'notification_id' => (int)$value,
                     ]);
                 }
+
+                $arrayTeamAlias && $this->updateTeamAlias((int)$team->id, $arrayTeamAlias);
 
                 //make sure the super admin is added to this team on creation
                 foreach ($superAdminIds as $adminId) {
@@ -805,6 +811,7 @@ class TeamController extends Controller
             Team::where('id', $teamId)->update($array);
 
             $arrayTeamNotification = array_key_exists('notifications', $input) ? $input['notifications'] : [];
+
             TeamHasNotification::where('team_id', $teamId)->delete();
             foreach ($arrayTeamNotification as $value) {
                 TeamHasNotification::updateOrCreate([
@@ -812,6 +819,9 @@ class TeamController extends Controller
                     'notification_id' => (int) $value,
                 ]);
             }
+
+            $arrayTeamAlias = array_key_exists('aliases', $input) ? $input['aliases'] : [];
+            $arrayTeamAlias && $this->updateTeamAlias($teamId, $arrayTeamAlias);
 
             $users = array_key_exists('users', $input) ? $input['users'] : [];
             $this->updateTeamAdminUsers($teamId, $users);
@@ -970,6 +980,9 @@ class TeamController extends Controller
                 ]);
             }
 
+            $arrayTeamAlias = array_key_exists('aliases', $input) ? $input['aliases'] : [];
+            $arrayTeamAlias && $this->updateTeamAlias($teamId, $arrayTeamAlias);
+
             $users = array_key_exists('users', $input) ? $input['users'] : [];
             $this->updateTeamAdminUsers($teamId, $users);
 
@@ -1044,26 +1057,19 @@ class TeamController extends Controller
 
         try {
             $team = Team::findOrFail($teamId);
-            if ($team) {
-                $existsDatasets = Dataset::where('team_id', $teamId)->select('id')->first();
+            $existsDatasets = Dataset::where('team_id', $teamId)->select('id')->first();
 
-                if (!is_null($existsDatasets)) {
-                    throw new Exception('The team cannot be deleted as there are datasets currently assigned to it.');
-                }
-
-                TeamHasNotification::where('team_id', $teamId)->delete();
-
-                $deletePermanently = false;
-                if ($request->has('deletePermanently')) {
-                    $deletePermanently = (bool)$request->query('deletePermanently');
-                }
-
-                $team->delete();
-
-                return response()->json([
-                    'message' => Config::get('statuscodes.STATUS_OK.message'),
-                ], Config::get('statuscodes.STATUS_OK.code'));
+            if (!is_null($existsDatasets)) {
+                throw new Exception('The team cannot be deleted as there are datasets currently assigned to it.');
             }
+
+            TeamHasNotification::where('team_id', $teamId)->delete();
+
+            $team->delete();
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -1294,4 +1300,17 @@ class TeamController extends Controller
         $this->tools = array_unique(array_merge($this->tools, Arr::pluck($dataset->allTools, 'id')));
         $this->collections = array_unique(array_merge($this->collections, Arr::pluck($dataset->allCollections, 'id')));
     }
+
+
+    private function updateTeamAlias(int $teamId, array $arrayTeamAlias): void
+    {
+        TeamHasAlias::where('team_id', $teamId)->delete();
+        foreach ($arrayTeamAlias as $aliasId) {
+            TeamHasAlias::updateOrCreate([
+                'team_id' => (int)$teamId,
+                'alias' => (int)$aliasId,
+            ]);
+        }
+    }
+
 }

--- a/app/Http/Requests/Alias/CreateAlias.php
+++ b/app/Http/Requests/Alias/CreateAlias.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Alias;
+
+use App\Http\Requests\BaseFormRequest;
+
+class CreateAlias extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'unique:aliases,name',
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Alias/DeleteAlias.php
+++ b/app/Http/Requests/Alias/DeleteAlias.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Alias;
+
+use App\Http\Requests\BaseFormRequest;
+
+class DeleteAlias extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                'exists:aliases,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/Alias/EditAlias.php
+++ b/app/Http/Requests/Alias/EditAlias.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Alias;
+
+use App\Http\Requests\BaseFormRequest;
+
+class EditAlias extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                'exists:aliases,id',
+            ],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'unique:aliases,name',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/Alias/GetAlias.php
+++ b/app/Http/Requests/Alias/GetAlias.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Alias;
+
+use App\Http\Requests\BaseFormRequest;
+
+class GetAlias extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                'exists:aliases,id',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Requests/Alias/UpdateAlias.php
+++ b/app/Http/Requests/Alias/UpdateAlias.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Alias;
+
+use App\Http\Requests\BaseFormRequest;
+
+class UpdateAlias extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => [
+                'required',
+                'integer',
+                'exists:aliases,id',
+            ],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                'unique:aliases,name',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['id' => $this->route('id')]);
+    }
+}

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -149,123 +149,123 @@ trait IndexElastic
      */
     public function reindexElasticDataProvider(string $teamId, bool $returnParams = false): null|array
     {
-        // try {
-        $datasets = Dataset::where([
-            'team_id' => $teamId,
-            'status' => Dataset::STATUS_ACTIVE,
-        ]);
+        try {
+            $datasets = Dataset::where([
+                'team_id' => $teamId,
+                'status' => Dataset::STATUS_ACTIVE,
+            ]);
 
-        if (is_null($datasets->first())) {
+            if (is_null($datasets->first())) {
+                return null;
+            }
+
+            $datasets = $datasets->get();
+
+            $datasetTitles = [];
+            $datasetVersionIds = [];
+            $locations = [];
+            $dataTypes = [];
+            $publicationTitles = [];
+            $collectionNames = [];
+            $durTitles = [];
+            $toolNames = [];
+            foreach ($datasets as $dataset) {
+                $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
+                $datasetVersionIds[] = $dataset->latestVersion()->id;
+                $metadata = $dataset->latestVersion()->metadata;
+                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
+                foreach ($types as $t) {
+                    if (!in_array($t, $dataTypes)) {
+                        $dataTypes[] = $t;
+                    }
+                }
+                foreach ($dataset['spatialCoverage'] as $loc) {
+                    if (!in_array($loc['region'], $locations)) {
+                        $locations[] = $loc['region'];
+                    }
+                }
+
+                unset($metadata); // Only because it's potentially massive.
+            }
+            usort($datasetTitles, 'strcasecmp');
+
+            // dur
+            if (count($datasetVersionIds)) {
+                $durHasDatasetVersions = DurHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('dur_id')->get();
+                $durIds = convertArrayToArrayWithKeyName($durHasDatasetVersions, 'dur_id');
+                $durs = Dur::whereIn('id', $durIds)->select('project_title')->get();
+                $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
+                $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
+                $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
+                $durTitles = implode(',', array_unique(array_merge($durTitles, $durByTeamIdTitles)));
+            }
+
+            // tools
+            if (count($datasetVersionIds)) {
+                $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
+                $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
+                $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
+                $toolNames = convertArrayToStringWithKeyName($tools, 'name');
+            }
+
+            // publications
+            if (count($datasetVersionIds)) {
+                $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
+                $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
+                $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
+                $publicationTitles = convertArrayToStringWithKeyName($publications, 'paper_title');
+            }
+
+            // collections
+            if (count($datasetVersionIds)) {
+                $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
+                $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
+                $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
+                $collectionNames = convertArrayToStringWithKeyName($collections, 'name');
+            }
+
+            // aliases
+            $aliases = Team::where('id', $teamId)->with(['aliases'])->select(['id'])->first();
+            $aliases = $aliases->toArray();
+            $aliases = $aliases['aliases'] ?? [];
+            $aliases = array_map(function ($alias) {
+                return $alias['name'];
+            }, $aliases);
+
+            $toIndex = [
+                'name' => Team::findOrFail($teamId)->name,
+                'datasetTitles' => array_values(array_unique($datasetTitles)),
+                'geographicLocation' => $locations,
+                'dataType' => $dataTypes,
+                'durTitles' => $durTitles,
+                'toolNames' => $toolNames,
+                'publicationTitles' => $publicationTitles,
+                'collectionNames' => $collectionNames,
+                'teamAliases' => $aliases,
+            ];
+
+            $params = [
+                'index' => 'dataprovider',
+                'id' => $teamId,
+                'body' => $toIndex,
+                'headers' => 'application/json'
+            ];
+            if ($returnParams) {
+                return $params;
+            }
+
+            ECC::indexDocument($params);
             return null;
+
+        } catch (Exception $e) {
+            \Log::error('Error reindexing ElasticSearch', [
+                'teamId' => $teamId,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            throw new Exception($e->getMessage());
         }
-
-        $datasets = $datasets->get();
-
-        $datasetTitles = [];
-        $datasetVersionIds = [];
-        $locations = [];
-        $dataTypes = [];
-        $publicationTitles = [];
-        $collectionNames = [];
-        $durTitles = [];
-        $toolNames = [];
-        foreach ($datasets as $dataset) {
-            $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
-            $datasetVersionIds[] = $dataset->latestVersion()->id;
-            $metadata = $dataset->latestVersion()->metadata;
-            $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
-            $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
-            foreach ($types as $t) {
-                if (!in_array($t, $dataTypes)) {
-                    $dataTypes[] = $t;
-                }
-            }
-            foreach ($dataset['spatialCoverage'] as $loc) {
-                if (!in_array($loc['region'], $locations)) {
-                    $locations[] = $loc['region'];
-                }
-            }
-
-            unset($metadata); // Only because it's potentially massive.
-        }
-        usort($datasetTitles, 'strcasecmp');
-
-        // dur
-        if (count($datasetVersionIds)) {
-            $durHasDatasetVersions = DurHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('dur_id')->get();
-            $durIds = convertArrayToArrayWithKeyName($durHasDatasetVersions, 'dur_id');
-            $durs = Dur::whereIn('id', $durIds)->select('project_title')->get();
-            $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
-            $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
-            $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
-            $durTitles = implode(',', array_unique(array_merge($durTitles, $durByTeamIdTitles)));
-        }
-
-        // tools
-        if (count($datasetVersionIds)) {
-            $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
-            $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
-            $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
-            $toolNames = convertArrayToStringWithKeyName($tools, 'name');
-        }
-
-        // publications
-        if (count($datasetVersionIds)) {
-            $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
-            $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
-            $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
-            $publicationTitles = convertArrayToStringWithKeyName($publications, 'paper_title');
-        }
-
-        // collections
-        if (count($datasetVersionIds)) {
-            $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
-            $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
-            $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
-            $collectionNames = convertArrayToStringWithKeyName($collections, 'name');
-        }
-
-        // aliases
-        $aliases = Team::where('id', $teamId)->with(['aliases'])->select(['id'])->first();
-        $aliases = $aliases->toArray();
-        $aliases = $aliases['aliases'] ?? [];
-        $aliases = array_map(function ($alias) {
-            return $alias['name'];
-        }, $aliases);
-
-        $toIndex = [
-            'name' => Team::findOrFail($teamId)->name,
-            'datasetTitles' => array_values(array_unique($datasetTitles)),
-            'geographicLocation' => $locations,
-            'dataType' => $dataTypes,
-            'durTitles' => $durTitles,
-            'toolNames' => $toolNames,
-            'publicationTitles' => $publicationTitles,
-            'collectionNames' => $collectionNames,
-            'teamAliases' => $aliases,
-        ];
-
-        $params = [
-            'index' => 'dataprovider',
-            'id' => $teamId,
-            'body' => $toIndex,
-            'headers' => 'application/json'
-        ];
-        if ($returnParams) {
-            return $params;
-        }
-
-        ECC::indexDocument($params);
-        return null;
-
-        // } catch (Exception $e) {
-        //     \Log::error('Error reindexing ElasticSearch', [
-        //         'teamId' => $teamId,
-        //         'message' => $e->getMessage(),
-        //         'trace' => $e->getTraceAsString(),
-        //     ]);
-        //     throw new Exception($e->getMessage());
-        // }
     }
 
     public function reindexElasticDataProviderWithRelations(string $teamId, string $relation = 'undefined')

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -149,114 +149,123 @@ trait IndexElastic
      */
     public function reindexElasticDataProvider(string $teamId, bool $returnParams = false): null|array
     {
-        try {
-            $datasets = Dataset::where([
-                'team_id' => $teamId,
-                'status' => Dataset::STATUS_ACTIVE,
-            ]);
+        // try {
+        $datasets = Dataset::where([
+            'team_id' => $teamId,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
 
-            if (is_null($datasets->first())) {
-                return null;
-            }
-
-            $datasets = $datasets->get();
-
-            $datasetTitles = [];
-            $datasetVersionIds = [];
-            $locations = [];
-            $dataTypes = [];
-            $publicationTitles = [];
-            $collectionNames = [];
-            $durTitles = [];
-            $toolNames = [];
-            foreach ($datasets as $dataset) {
-                $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
-                $datasetVersionIds[] = $dataset->latestVersion()->id;
-                $metadata = $dataset->latestVersion()->metadata;
-                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
-                $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
-                foreach ($types as $t) {
-                    if (!in_array($t, $dataTypes)) {
-                        $dataTypes[] = $t;
-                    }
-                }
-                foreach ($dataset['spatialCoverage'] as $loc) {
-                    if (!in_array($loc['region'], $locations)) {
-                        $locations[] = $loc['region'];
-                    }
-                }
-
-                unset($metadata); // Only because it's potentially massive.
-            }
-            usort($datasetTitles, 'strcasecmp');
-
-            // dur
-            if (count($datasetVersionIds)) {
-                $durHasDatasetVersions = DurHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('dur_id')->get();
-                $durIds = convertArrayToArrayWithKeyName($durHasDatasetVersions, 'dur_id');
-                $durs = Dur::whereIn('id', $durIds)->select('project_title')->get();
-                $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
-                $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
-                $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
-                $durTitles = implode(',', array_unique(array_merge($durTitles, $durByTeamIdTitles)));
-            }
-
-            // tools
-            if (count($datasetVersionIds)) {
-                $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
-                $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
-                $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
-                $toolNames = convertArrayToStringWithKeyName($tools, 'name');
-            }
-
-            // publications
-            if (count($datasetVersionIds)) {
-                $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
-                $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
-                $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
-                $publicationTitles = convertArrayToStringWithKeyName($publications, 'paper_title');
-            }
-
-            // collections
-            if (count($datasetVersionIds)) {
-                $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
-                $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
-                $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
-                $collectionNames = convertArrayToStringWithKeyName($collections, 'name');
-            }
-
-            $toIndex = [
-                'name' => Team::findOrFail($teamId)->name,
-                'datasetTitles' => array_values(array_unique($datasetTitles)),
-                'geographicLocation' => $locations,
-                'dataType' => $dataTypes,
-                'durTitles' => $durTitles,
-                'toolNames' => $toolNames,
-                'publicationTitles' => $publicationTitles,
-                'collectionNames' => $collectionNames,
-            ];
-
-            $params = [
-                'index' => 'dataprovider',
-                'id' => $teamId,
-                'body' => $toIndex,
-                'headers' => 'application/json'
-            ];
-            if ($returnParams) {
-                return $params;
-            }
-
-            ECC::indexDocument($params);
+        if (is_null($datasets->first())) {
             return null;
-
-        } catch (Exception $e) {
-            \Log::error('Error reindexing ElasticSearch', [
-                'teamId' => $teamId,
-                'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-            throw new Exception($e->getMessage());
         }
+
+        $datasets = $datasets->get();
+
+        $datasetTitles = [];
+        $datasetVersionIds = [];
+        $locations = [];
+        $dataTypes = [];
+        $publicationTitles = [];
+        $collectionNames = [];
+        $durTitles = [];
+        $toolNames = [];
+        foreach ($datasets as $dataset) {
+            $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
+            $datasetVersionIds[] = $dataset->latestVersion()->id;
+            $metadata = $dataset->latestVersion()->metadata;
+            $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+            $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
+            foreach ($types as $t) {
+                if (!in_array($t, $dataTypes)) {
+                    $dataTypes[] = $t;
+                }
+            }
+            foreach ($dataset['spatialCoverage'] as $loc) {
+                if (!in_array($loc['region'], $locations)) {
+                    $locations[] = $loc['region'];
+                }
+            }
+
+            unset($metadata); // Only because it's potentially massive.
+        }
+        usort($datasetTitles, 'strcasecmp');
+
+        // dur
+        if (count($datasetVersionIds)) {
+            $durHasDatasetVersions = DurHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('dur_id')->get();
+            $durIds = convertArrayToArrayWithKeyName($durHasDatasetVersions, 'dur_id');
+            $durs = Dur::whereIn('id', $durIds)->select('project_title')->get();
+            $durTitles = convertArrayToArrayWithKeyName($durs, 'project_title');
+            $durByTeamIds = Dur::where('team_id', $teamId)->select('project_title')->get();
+            $durByTeamIdTitles = convertArrayToArrayWithKeyName($durByTeamIds, 'project_title');
+            $durTitles = implode(',', array_unique(array_merge($durTitles, $durByTeamIdTitles)));
+        }
+
+        // tools
+        if (count($datasetVersionIds)) {
+            $datasetVersionHasTools = DatasetVersionHasTool::whereIn('dataset_version_id', $datasetVersionIds)->select('tool_id')->get();
+            $toolIds = convertArrayToArrayWithKeyName($datasetVersionHasTools, 'tool_id');
+            $tools = Tool::whereIn('id', $toolIds)->select('name')->get();
+            $toolNames = convertArrayToStringWithKeyName($tools, 'name');
+        }
+
+        // publications
+        if (count($datasetVersionIds)) {
+            $publicationHasDatasetVersions = PublicationHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('publication_id')->get();
+            $publicationIds = convertArrayToArrayWithKeyName($publicationHasDatasetVersions, 'publication_id');
+            $publications = Publication::whereIn('id', $publicationIds)->select('paper_title')->get();
+            $publicationTitles = convertArrayToStringWithKeyName($publications, 'paper_title');
+        }
+
+        // collections
+        if (count($datasetVersionIds)) {
+            $collectionHasDatasetVersions = CollectionHasDatasetVersion::whereIn('dataset_version_id', $datasetVersionIds)->select('collection_id')->get();
+            $collectionIds = convertArrayToArrayWithKeyName($collectionHasDatasetVersions, 'collection_id');
+            $collections = Collection::whereIn('id', $collectionIds)->where('status', 'active')->select('name')->get();
+            $collectionNames = convertArrayToStringWithKeyName($collections, 'name');
+        }
+
+        // aliases
+        $aliases = Team::where('id', $teamId)->with(['aliases'])->select(['id'])->first();
+        $aliases = $aliases->toArray();
+        $aliases = $aliases['aliases'] ?? [];
+        $aliases = array_map(function ($alias) {
+            return $alias['name'];
+        }, $aliases);
+
+        $toIndex = [
+            'name' => Team::findOrFail($teamId)->name,
+            'datasetTitles' => array_values(array_unique($datasetTitles)),
+            'geographicLocation' => $locations,
+            'dataType' => $dataTypes,
+            'durTitles' => $durTitles,
+            'toolNames' => $toolNames,
+            'publicationTitles' => $publicationTitles,
+            'collectionNames' => $collectionNames,
+            'teamAliases' => $aliases,
+        ];
+
+        $params = [
+            'index' => 'dataprovider',
+            'id' => $teamId,
+            'body' => $toIndex,
+            'headers' => 'application/json'
+        ];
+        if ($returnParams) {
+            return $params;
+        }
+
+        ECC::indexDocument($params);
+        return null;
+
+        // } catch (Exception $e) {
+        //     \Log::error('Error reindexing ElasticSearch', [
+        //         'teamId' => $teamId,
+        //         'message' => $e->getMessage(),
+        //         'trace' => $e->getTraceAsString(),
+        //     ]);
+        //     throw new Exception($e->getMessage());
+        // }
     }
 
     public function reindexElasticDataProviderWithRelations(string $teamId, string $relation = 'undefined')

--- a/app/Http/Traits/TeamTransformation.php
+++ b/app/Http/Traits/TeamTransformation.php
@@ -107,20 +107,14 @@ trait TeamTransformation
             }
             $tmpTeam['notifications'] = $tmpNotification;
 
-            $aliases = TeamHasAlias::where('team_id', $tmpTeam['id'])->get()->toArray();
-            $tmpAlias = [];
-            foreach ($aliases as $value) {
-                $alias = Alias::where('id', $value['alias_id'])->firstOrFail();
-                $tmpAlias[] = $alias;
-            }
-            $tmpTeam['aliases'] = $tmpAlias;
+            $aliasIds = TeamHasAlias::where('team_id', $tmpTeam['id'])->pluck('alias_id');
+            $tmpTeam['aliases'] = Alias::whereIn('id', $aliasIds)->get()->toArray();
 
             $response[] = $tmpTeam;
             unset($tmpTeam);
             unset($tmpUser);
             unset($notifications);
             unset($tmpNotification);
-            unset($tmpAlias);
         }
 
         if (count($response) > 1) {

--- a/app/Http/Traits/TeamTransformation.php
+++ b/app/Http/Traits/TeamTransformation.php
@@ -4,8 +4,10 @@ namespace App\Http\Traits;
 
 use Config;
 use App\Models\User;
+use App\Models\Alias;
 use App\Models\TeamHasUser;
 use App\Models\Notification;
+use App\Models\TeamHasAlias;
 use App\Models\TeamHasNotification;
 use App\Models\TeamUserHasNotification;
 
@@ -105,11 +107,20 @@ trait TeamTransformation
             }
             $tmpTeam['notifications'] = $tmpNotification;
 
+            $aliases = TeamHasAlias::where('team_id', $tmpTeam['id'])->get()->toArray();
+            $tmpAlias = [];
+            foreach ($aliases as $value) {
+                $alias = Alias::where('id', $value['alias_id'])->firstOrFail();
+                $tmpAlias[] = $alias;
+            }
+            $tmpTeam['aliases'] = $tmpAlias;
+
             $response[] = $tmpTeam;
             unset($tmpTeam);
             unset($tmpUser);
             unset($notifications);
             unset($tmpNotification);
+            unset($tmpAlias);
         }
 
         if (count($response) > 1) {

--- a/app/Models/Alias.php
+++ b/app/Models/Alias.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Alias extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    public $table = 'aliases';
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -305,4 +305,9 @@ class Team extends Model
     {
         return $this->belongsToMany(Federation::class, 'team_has_federations');
     }
+
+    public function aliases(): BelongsToMany
+    {
+        return $this->belongsToMany(Alias::class, 'team_has_aliases');
+    }
 }

--- a/app/Models/TeamHasAlias.php
+++ b/app/Models/TeamHasAlias.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeamHasAlias extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $table = 'team_has_aliases';
+
+    protected $fillable = [
+        'team_id',
+        'alias_id',
+    ];
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -4698,7 +4698,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [],
     ],
@@ -4710,7 +4709,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4724,8 +4722,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'sanitize.input',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [],
     ],
@@ -4737,8 +4733,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'sanitize.input',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4752,8 +4746,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'sanitize.input',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -4767,7 +4759,6 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
-            'check.access:roles,hdruk.superadmin',
         ],
         'constraint' => [
             'id' => '[0-9]+',

--- a/config/routes.php
+++ b/config/routes.php
@@ -4688,4 +4688,89 @@ return [
             'id' => '[0-9]+',
         ],
     ],
+
+    // aliases
+    [
+        'name' => 'aliases',
+        'method' => 'get',
+        'path' => '/aliases',
+        'methodController' => 'AliasController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'aliases',
+        'method' => 'get',
+        'path' => '/aliases/{id}',
+        'methodController' => 'AliasController@show',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'aliases',
+        'method' => 'post',
+        'path' => '/aliases',
+        'methodController' => 'AliasController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'aliases',
+        'method' => 'put',
+        'path' => '/aliases/{id}',
+        'methodController' => 'AliasController@update',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'aliases',
+        'method' => 'patch',
+        'path' => '/aliases/{id}',
+        'methodController' => 'AliasController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'aliases',
+        'method' => 'delete',
+        'path' => '/aliases/{id}',
+        'methodController' => 'AliasController@destroy',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
 ];

--- a/database/migrations/2025_05_01_134650_update_team_has_dar_table.php
+++ b/database/migrations/2025_05_01_134650_update_team_has_dar_table.php
@@ -10,9 +10,50 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        Schema::table('team_has_dar_applications', function (Blueprint $table) {
-            $table->dropColumn(['approval_status', 'submission_status', 'review_id']);
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('tmp_team_has_dar_applications', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->bigInteger('dar_application_id')->unsigned();
+            $table->bigInteger('team_id')->unsigned();
         });
+
+        DB::table('tmp_team_has_dar_applications')->insert(
+            DB::table('team_has_dar_applications')
+                ->select('id', 'team_id', 'dar_application_id', 'created_at', 'updated_at')
+                ->get()
+                ->map(function ($row) {
+                    return (array) $row;
+                })
+                ->toArray()
+        );
+
+        Schema::drop('team_has_dar_applications');
+
+        Schema::create('team_has_dar_applications', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->bigInteger('dar_application_id')->unsigned();
+            $table->bigInteger('team_id')->unsigned();
+
+            $table->foreign('dar_application_id')->references('id')->on('dar_applications');
+            $table->foreign('team_id')->references('id')->on('teams');
+        });
+
+        DB::table('team_has_dar_applications')->insert(
+            DB::table('tmp_team_has_dar_applications')
+                ->select('id', 'team_id', 'dar_application_id', 'created_at', 'updated_at')
+                ->get()
+                ->map(function ($row) {
+                    return (array) $row;
+                })
+                ->toArray()
+        );
+
+        Schema::drop('tmp_team_has_dar_applications');
+
+        Schema::enableForeignKeyConstraints();
     }
 
     /**

--- a/database/migrations/2025_05_12_120840_create_aliases_table.php
+++ b/database/migrations/2025_05_12_120840_create_aliases_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('aliases', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable(false)->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('aliases');
+    }
+};

--- a/database/migrations/2025_05_12_121434_create_team_has_aliases_table.php
+++ b/database/migrations/2025_05_12_121434_create_team_has_aliases_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('team_has_aliases', function (Blueprint $table) {
+            $table->bigInteger('team_id')->unsigned();
+            $table->bigInteger('alias_id')->unsigned();
+
+            $table->foreign('team_id', 'team_id_fk')->references('id')->on('teams');
+            $table->foreign('alias_id', 'alias_id_fk')->references('id')->on('aliases');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('team_has_aliases');
+    }
+};

--- a/database/seeders/AliasSeeder.php
+++ b/database/seeders/AliasSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\Alias;
+use App\Models\Team;
+use App\Models\TeamHasAlias;
 use Illuminate\Database\Seeder;
 
 class AliasSeeder extends Seeder
@@ -12,6 +14,7 @@ class AliasSeeder extends Seeder
      */
     public function run(): void
     {
+        // aliases table
         for ($i = 1; $i <= 20; $i++) {
             do {
                 $alias = fake()->unique()->word();
@@ -26,6 +29,25 @@ class AliasSeeder extends Seeder
             Alias::create([
                 'name' => $alias,
             ]);
+        }
+
+        // team_has_aliases table
+        $teams = Team::all();
+        foreach ($teams as $team) {
+            $alias = Alias::inRandomOrder()->first();
+
+            $checkTeamAlias = TeamHasAlias::where([
+                'team_id' => $team->id,
+                'alias_id' => $alias->id,
+            ])->first();
+            if (is_null($checkTeamAlias)) {
+                TeamHasAlias::create([
+                    'team_id' => $team->id,
+                    'alias_id' => $alias->id,
+                ]);
+            } else {
+                continue;
+            }
         }
     }
 }

--- a/database/seeders/AliasSeeder.php
+++ b/database/seeders/AliasSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Alias;
+use Illuminate\Database\Seeder;
+
+class AliasSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        for ($i = 1; $i <= 20; $i++) {
+            do {
+                $alias = fake()->unique()->word();
+            } while (strlen($alias) < 3);
+
+
+            $checkAlias = Alias::where('name', $alias)->first();
+            if (!is_null($checkAlias)) {
+                continue;
+            }
+
+            Alias::create([
+                'name' => $alias,
+            ]);
+        }
+    }
+}

--- a/tests/Feature/AliasTest.php
+++ b/tests/Feature/AliasTest.php
@@ -39,7 +39,6 @@ class AliasTest extends TestCase
     public function test_the_application_can_list_aliases()
     {
         $response = $this->get('api/v1/aliases', $this->header);
-
         $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
             ->assertJsonStructure([
                 'data' => [

--- a/tests/Feature/AliasTest.php
+++ b/tests/Feature/AliasTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Tests\Feature;
+
+use Config;
+use Tests\TestCase;
+use App\Models\Alias;
+use Database\Seeders\AliasSeeder;
+use Tests\Traits\MockExternalApis;
+use Database\Seeders\MinimalUserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class AliasTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const TEST_URL = 'api/v1/aliases';
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->seed([
+            MinimalUserSeeder::class,
+            AliasSeeder::class,
+        ]);
+    }
+
+    /**
+     * List all Aliases
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_aliases()
+    {
+        $response = $this->get('api/v1/aliases', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    0 => [
+                        'id',
+                        'name',
+                    ],
+                ],
+                'current_page',
+                'first_page_url',
+                'from',
+                'last_page',
+                'last_page_url',
+                'links',
+                'next_page_url',
+                'path',
+                'per_page',
+                'prev_page_url',
+                'to',
+                'total',
+            ]);
+    }
+
+    /**
+     * Tests that an activity log can be listed by id
+     *
+     * @return void
+     */
+    public function test_the_application_can_list_a_single_alias()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/aliases',
+            [
+                'name' => $this->getUniqueAlias(),
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+
+        $response = $this->get('api/v1/aliases/' . $content['data'], $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                ],
+            ]);
+    }
+
+    /**
+     * Tests that an activity log can be created
+     *
+     * @return void
+     */
+    public function test_the_application_can_create_an_alias()
+    {
+        $response = $this->json(
+            'POST',
+            'api/v1/aliases',
+            [
+                'name' => $this->getUniqueAlias(),
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(
+            $content['message'],
+            Config::get('statuscodes.STATUS_CREATED.message')
+        );
+    }
+
+    /**
+     * Tests it can update an activity log
+     *
+     * @return void
+     */
+    public function test_the_application_can_update_an_alias()
+    {
+        // Start by creating a new activity log record for updating
+        // within this test case
+        $response = $this->json(
+            'POST',
+            'api/v1/aliases',
+            [
+                'name' => $this->getUniqueAlias(),
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(
+            $content['message'],
+            Config::get('statuscodes.STATUS_CREATED.message')
+        );
+
+        $updateAlias = $this->getUniqueAlias();
+        $response = $this->json(
+            'PUT',
+            'api/v1/aliases/' . $content['data'],
+            [
+                'name' => $updateAlias,
+            ],
+            $this->header,
+        );
+
+        $content = $response->decodeResponseJson();
+
+        $this->assertEquals($content['data']['name'], $updateAlias);
+    }
+
+    /**
+     * Tests it can delete an activity log
+     *
+     * @return void
+     */
+    public function test_it_can_delete_an_alias()
+    {
+        // Start by creating a new activity log record for updating
+        // within this test case
+        $response = $this->json(
+            'POST',
+            'api/v1/aliases',
+            [
+                'name' => $this->getUniqueAlias(),
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure([
+                'message',
+                'data',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(
+            $content['message'],
+            Config::get('statuscodes.STATUS_CREATED.message')
+        );
+
+        // Finally, delete the last entered activity log to
+        // prove functionality
+        $response = $this->json(
+            'DELETE',
+            'api/v1/aliases/' . $content['data'],
+            [],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'message',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals(
+            $content['message'],
+            Config::get('statuscodes.STATUS_OK.message')
+        );
+    }
+
+    private function getUniqueAlias()
+    {
+        do {
+            $alias = fake()->unique()->word();
+            $checkAlias = Alias::where('name', $alias)->first();
+        } while (!is_null($checkAlias));
+
+        return $alias;
+    }
+}

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -232,6 +232,8 @@ class TeamTest extends TestCase
      */
     public function test_the_application_can_create_a_team()
     {
+        $aliasId = Alias::all()->random()->id;
+
         // First create a notification to be used by the new team
         $responseNotification = $this->json(
             'POST',
@@ -277,6 +279,7 @@ class TeamTest extends TestCase
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
                 'service' => 'https://service.local/test',
+                'aliases' => [$aliasId],
             ],
             $this->header
         );
@@ -312,6 +315,7 @@ class TeamTest extends TestCase
     public function test_the_application_can_update_a_team()
     {
         MMC::spy();
+        $aliasId = Alias::all()->random()->id;
 
         // First create a notification to be used by the new team
         $responseNotification = $this->json(
@@ -359,6 +363,7 @@ class TeamTest extends TestCase
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
                 'service' => 'https://service.local/test',
+                'aliases' => [$aliasId],
             ],
             $this->header
         );
@@ -411,6 +416,7 @@ class TeamTest extends TestCase
                 'users' => [],
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
+                'aliases' => [$aliasId],
             ],
             $this->header
         );
@@ -475,6 +481,8 @@ class TeamTest extends TestCase
      */
     public function test_the_application_can_edit_a_team()
     {
+        $aliasId = Alias::all()->random()->id;
+
         // create notification
         $responseNotification = $this->json(
             'POST',
@@ -520,6 +528,7 @@ class TeamTest extends TestCase
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
                 'service' => 'https://service.local/test',
+                'aliases' => [$aliasId],
             ],
             $this->header
         );
@@ -560,6 +569,7 @@ class TeamTest extends TestCase
                 'users' => [],
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
+                'aliases' => [$aliasId],
             ],
             $this->header
         );
@@ -639,6 +649,8 @@ class TeamTest extends TestCase
      */
     public function test_the_application_can_delete_a_team()
     {
+        $aliasId = Alias::all()->random()->id;
+
         // First create a notification to be used by the new team
         $responseNotification = $this->json(
             'POST',
@@ -682,6 +694,7 @@ class TeamTest extends TestCase
                 'users' => [],
                 'url' => 'https://fakeimg.pl/350x200/ff0000/000',
                 'introduction' => fake()->sentence(),
+                'aliases' => [$aliasId],
             ],
             $this->header
         );

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -5,14 +5,16 @@ namespace Tests\Feature;
 // use Illuminate\Foundation\Testing\RefreshDatabase;
 use Config;
 use Tests\TestCase;
-use Tests\Traits\MockExternalApis;
-use App\Http\Enums\TeamMemberOf;
-use App\Models\Dataset;
 use App\Models\Team;
+use App\Models\Alias;
+use App\Models\Dataset;
+use App\Http\Enums\TeamMemberOf;
+use Database\Seeders\AliasSeeder;
+use Tests\Traits\MockExternalApis;
 use Database\Seeders\MinimalUserSeeder;
+use MetadataManagementController as MMC;
 use Database\Seeders\SpatialCoverageSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use MetadataManagementController as MMC;
 
 class TeamTest extends TestCase
 {
@@ -33,6 +35,7 @@ class TeamTest extends TestCase
         $this->seed([
             MinimalUserSeeder::class,
             SpatialCoverageSeeder::class,
+            AliasSeeder::class,
         ]);
 
         $this->metadata = $this->getMetadata();
@@ -84,6 +87,8 @@ class TeamTest extends TestCase
      */
     public function test_the_application_can_show_one_team()
     {
+        $aliasId = Alias::all()->random()->id;
+
         // First create a notification to be used by the new team
         $responseNotification = $this->json(
             'POST',
@@ -129,6 +134,7 @@ class TeamTest extends TestCase
                 'introduction' => fake()->sentence(),
                 'dar_modal_content' => fake()->sentence(),
                 'service' => 'https://service.local/test',
+                'aliases' => [$aliasId],
             ],
             $this->header
         );


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Enable the use of aliases for Data Custodian names

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6925

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
run
```
php artisan migrate
```
reindex data providers

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
