### PR TITLE
fix(GAT-6907): Getting this error message when creating new team

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -218,7 +218,7 @@ class Team extends Model
         $mediaUrl = Config::get('services.media.base_url');
         $escapedMediaUrl = preg_quote($mediaUrl, '/');
         $allowedExtensions = 'jpeg|jpg|png|gif|bmp|webp';
-        $customPattern = "/^(" . $escapedMediaUrl . ")?\/teams\/[a-zA-Z0-9 _-]+\.(?:$allowedExtensions)$/";
+        $customPattern = "/^(" . $escapedMediaUrl . ")?\/teams\/[a-zA-Z0-9 _\-()]+\.(?:$allowedExtensions)$/";
 
         $validator = Validator::make($this->attributes, [
             'team_logo' => [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Getting this error message when creating new team with “The team_logo must be a valid URL or match the required format."

## Issue ticket link
```
https://hdruk.atlassian.net/browse/GAT-6907
```

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
