### PR TITLE
feat(GAT-6925): Enable use of aliases for Data Custodian names for team summary

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -35,6 +35,7 @@ use App\Http\Traits\TeamTransformation;
 use App\Http\Traits\RequestTransformation;
 use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Traits\CheckAccess;
+use App\Models\Alias;
 use App\Models\TeamHasAlias;
 
 class TeamController extends Controller
@@ -502,6 +503,12 @@ class TeamController extends Controller
 
             $service = array_values(array_filter(explode(",", $dp->service)));
 
+            $aliasesIds = TeamHasAlias::where(['team_id' => $id])->pluck('alias_id')->toArray();
+            $aliases = Alias::whereIn('id', $aliasesIds)
+                ->select('id', 'name')
+                ->get()
+                ->toArray();
+
             Auditor::log([
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
@@ -533,6 +540,7 @@ class TeamController extends Controller
                         ->get()
                         ->toArray(),
                     'collections' => $collections,
+                    'aliases' => $aliases,
                 ],
             ]);
         } catch (Exception $e) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Enable use of aliases for Data Custodian names for team summary

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-6925

## Environment / Configuration changes (if applicable)
no

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
