### PR TITLE
feat(GAT-6995): Update Extend linkage extraction job tools from metadata

### DIFF
--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -9,7 +9,6 @@ use App\Models\Dataset;
 use App\Models\Publication;
 use Illuminate\Support\Arr;
 use Illuminate\Bus\Queueable;
-use App\Http\Traits\IndexElastic;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
@@ -23,7 +22,6 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
-    use IndexElastic;
 
     private int $datasetVersionId = 0;
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Extend linkage extraction job (under apps/jobs) for tools - Its not rendering on the Tools Search UI

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-6995

## Environment / Configuration changes (if applicable)
reindex all

## Requires migrations being run?
no

## If not using the pre-push hook. Confirm tests pass:
yes

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
