### PR TITLE
feat(GAT-6927): Temp deadsafe for feature flagging

### DIFF
--- a/app/Providers/FeatureServiceProvider.php
+++ b/app/Providers/FeatureServiceProvider.php
@@ -24,6 +24,8 @@ class FeatureServiceProvider extends ServiceProvider
                 logger()->info('Calling that Bucket');
 
                 try {
+                    // this is the thing that fails, it does not retry and falls over because during a random split second http protocol does not exist...
+                    // this error we are getting is VERY similiar to the reddis connection problems.. they are likely the same underlying issue.
                     $res = Http::timeout(60)
                         ->retry(3, 2000, function ($exception, $requestNumber) use ($url) {
                             logger()->warning('Retrying feature flag fetch', [
@@ -38,7 +40,11 @@ class FeatureServiceProvider extends ServiceProvider
                         'url' => $url,
                         'error' => $e->getMessage(),
                     ]);
-                    return [];
+                    /// this is temp until the new GCS solution JB is in place
+                    return [
+                    'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
+                    'Aliases' => ['enabled' => true],
+                ];
                 }
 
                 if (!$res->successful()) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
This is a temp solution until branch feat/GAT-6927-5 is in which will use the GCS driver and talk directly to the bucket (hopefully not using the HTTP protocol...)
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
