### PR TITLE
fix!(GAT-5504): Changed all perPage in requests to per_page

### DIFF
--- a/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/Http/Controllers/Api/V1/CategoryController.php
@@ -23,6 +23,17 @@ class CategoryController extends Controller
      *      tags={"Category"},
      *      summary="Category@index",
      *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -47,7 +58,7 @@ class CategoryController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $categories = Category::where('enabled', 1)->paginate($perPage);
 
             Auditor::log([

--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -83,6 +83,17 @@ class CollectionController extends Controller
      *       @OA\Schema(type="string"),
      *       description="Filter collections by status (DRAFT, ACTIVE, ARCHIVED)"
      *    ),
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *    @OA\Response(
      *       response=200,
      *       description="Success",
@@ -130,7 +141,7 @@ class CollectionController extends Controller
     public function index(Request $request): JsonResponse
     {
         try {
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
             $name = $request->query('name', null);
             $filterTitle = $request->query('title', null);
             $filterStatus = $request->query('status', null);

--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -40,6 +40,17 @@ class DataProviderCollController extends Controller
      *      tags={"DataProviderColl"},
      *      summary="DataProviderColl@index",
      *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -66,7 +77,7 @@ class DataProviderCollController extends Controller
         try {
             $input = $request->all();
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $mediaBaseUrl = Config::get('services.media.base_url');
 
             $dpc = DataProviderColl::with([

--- a/app/Http/Controllers/Api/V1/DurController.php
+++ b/app/Http/Controllers/Api/V1/DurController.php
@@ -60,6 +60,17 @@ class DurController extends Controller
      *       @OA\Schema(type="string"),
      *       description="Filter tools by project title"
      *    ),
+     *    @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *    @OA\Response(
      *       response=200,
      *       description="Success",
@@ -159,7 +170,7 @@ class DurController extends Controller
             $teamId = $request->query('team_id', null);
             $projectId = $request->query('project_id', null);
             $filterStatus = $request->query('status', null);
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $withRelated = $request->boolean('with_related', true);
             $durs = Dur::when($mongoId, function ($query) use ($mongoId) {
                 return $query->where('mongo_id', '=', $mongoId);

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -27,6 +27,17 @@ class EnquiryThreadController extends Controller
      *      tags={"EnquiryThread"},
      *      summary="EnquiryThread@index",
      *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -51,7 +62,7 @@ class EnquiryThreadController extends Controller
         try {
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
 
             $enquiryThreads = EnquiryThread::paginate($perPage);
 

--- a/app/Http/Controllers/Api/V1/FilterController.php
+++ b/app/Http/Controllers/Api/V1/FilterController.php
@@ -31,6 +31,17 @@ class FilterController extends Controller
      *      tags={"Filter"},
      *      summary="Filter@index",
      *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -91,7 +102,7 @@ class FilterController extends Controller
                 }
             }
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $filters, $perPage);
 
             Auditor::log([

--- a/app/Http/Controllers/Api/V1/IntegrationCollectionController.php
+++ b/app/Http/Controllers/Api/V1/IntegrationCollectionController.php
@@ -51,6 +51,17 @@ class IntegrationCollectionController extends Controller
      *       @OA\Schema(type="string"),
      *       description="Filter collections by name"
      *    ),
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *    @OA\Response(
      *       response=200,
      *       description="Success",
@@ -102,7 +113,7 @@ class IntegrationCollectionController extends Controller
         try {
             $applicationOverrideDefaultValues = $this->injectApplicationDatasetDefaults($request->header());
 
-            $perPage = $request->has('perPage') ? (int) $request->get('perPage') : Config::get('constants.per_page');
+            $perPage = $request->has('per_page') ? (int) $request->get('per_page') : Config::get('constants.per_page');
             $name = $request->query('name', null);
 
             $collections = Collection::when($name, function ($query) use ($name) {

--- a/app/Http/Controllers/Api/V1/IntegrationDurController.php
+++ b/app/Http/Controllers/Api/V1/IntegrationDurController.php
@@ -49,6 +49,17 @@ class IntegrationDurController extends Controller
      *           type="project_title:asc,updated_at:asc"
      *       )
      *    ),
+     *    @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
      *    @OA\Response(
      *       response=200,
      *       description="Success",
@@ -144,7 +155,7 @@ class IntegrationDurController extends Controller
 
             $applicationOverrideDefaultValues = $this->injectApplicationDatasetDefaults($request->header());
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $durs = Dur::where('enabled', 1)
                 ->with([
                     'publications',

--- a/app/Http/Controllers/Api/V1/KeywordController.php
+++ b/app/Http/Controllers/Api/V1/KeywordController.php
@@ -36,7 +36,7 @@ class KeywordController extends Controller
      *      summary="KeywordController@index",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
-     *          name="perPage",
+     *          name="per_page",
      *          in="query",
      *          description="Alternative output schema version.",
      *          @OA\Schema(type="integer")
@@ -76,7 +76,7 @@ class KeywordController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $perPage = (int) request('perPage', Config::get('constants.per_page'));
+            $perPage = (int) request('per_page', Config::get('constants.per_page'));
             $keywords = Keyword::where('enabled', 1)
                 ->paginate(function ($total) use ($perPage) {
                     if ($perPage === -1) {

--- a/app/Http/Controllers/Api/V1/LibraryController.php
+++ b/app/Http/Controllers/Api/V1/LibraryController.php
@@ -32,7 +32,7 @@ class LibraryController extends Controller
      *      description="Returns a paginated list of libraries along with associated datasets and teams.",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
-     *          name="perPage",
+     *          name="per_page",
      *          in="query",
      *          description="Specify the number of libraries per page",
      *          required=false,
@@ -90,7 +90,7 @@ class LibraryController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $perPage = (int) request('perPage', Config::get('constants.per_page'));
+            $perPage = (int) request('per_page', Config::get('constants.per_page'));
 
             $libraries = Library::where('user_id', $jwtUser['id'])
                 ->with(['dataset.team']);

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -59,7 +59,7 @@ class NotificationController extends Controller
             $input = $request->all();
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $notifications = Notification::where('enabled', 1)->paginate($perPage);
 
             Auditor::log([

--- a/app/Http/Controllers/Api/V1/SavedSearchController.php
+++ b/app/Http/Controllers/Api/V1/SavedSearchController.php
@@ -32,7 +32,7 @@ class SavedSearchController extends Controller
      *      summary="SavedSearch@index",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
-     *          name="perPage",
+     *          name="per_page",
      *          in="query",
      *          description="Specify number of results per page",
      *          @OA\Schema(type="integer")
@@ -65,7 +65,7 @@ class SavedSearchController extends Controller
             $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
             $jwtUserIsAdmin = $jwtUser['is_admin'];
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             if ($jwtUserIsAdmin) {
                 $savedSearches = SavedSearch::where('enabled', 1)->with('filters');
             } else {

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -95,6 +95,7 @@ class SearchController extends Controller
      *                  @OA\Property(property="sort", type="string", example="score"),
      *                  @OA\Property(property="direction", type="string", example="desc"),
      *                  @OA\Property(property="filters", type="string", example={"filtersExample": @OA\Schema(ref="#/components/examples/filtersExample")})
+     *                  @OA\Property(property="per_page", type="integer", example=25)
      *              )
      *          )
      *      ),
@@ -259,7 +260,7 @@ class SearchController extends Controller
 
             $datasetsArray = $this->sortSearchResult($datasetsArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $datasetsArray, $perPage);
             unset($datasetsArray);
 
@@ -416,6 +417,7 @@ class SearchController extends Controller
      *              description="Sort direction",
      *          ),
      *      ),
+     * 
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -587,7 +589,7 @@ class SearchController extends Controller
                 return Excel::download(new ToolListExport($toolsArray), 'tools.csv');
             }
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $toolsArray, $perPage);
             unset($toolsArray);
 
@@ -1637,6 +1639,16 @@ class SearchController extends Controller
      *              description="Sort direction",
      *          ),
      *      ),
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="Number of results to return per page",
+     *          example="25",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="Number of results to return per page",
+     *          ),
+     *      ),
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -1727,7 +1739,7 @@ class SearchController extends Controller
 
             $dataProviderArray = $this->sortSearchResult($dataProviderArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $dataProviderArray, $perPage);
             unset($dataProviderArray);
 

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -94,7 +94,7 @@ class SearchController extends Controller
      *                  @OA\Property(property="query", type="string", example="asthma dataset"),
      *                  @OA\Property(property="sort", type="string", example="score"),
      *                  @OA\Property(property="direction", type="string", example="desc"),
-     *                  @OA\Property(property="filters", type="string", example={"filtersExample": @OA\Schema(ref="#/components/examples/filtersExample")})
+     *                  @OA\Property(property="filters", type="string", example={"filtersExample": @OA\Schema(ref="#/components/examples/filtersExample")}),
      *                  @OA\Property(property="per_page", type="integer", example=25)
      *              )
      *          )
@@ -417,7 +417,7 @@ class SearchController extends Controller
      *              description="Sort direction",
      *          ),
      *      ),
-     * 
+     *
      *      @OA\Response(
      *          response=200,
      *          description="Success",
@@ -747,7 +747,7 @@ class SearchController extends Controller
 
             $collectionArray = $this->sortSearchResult($collectionArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $collectionArray, $perPage);
             unset($collectionArray);
 
@@ -947,7 +947,7 @@ class SearchController extends Controller
 
             $durArray = $this->sortSearchResult($durArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $durArray, $perPage);
             unset($durArray);
 
@@ -1230,7 +1230,7 @@ class SearchController extends Controller
 
             $pubArray = $this->sortSearchResult($pubArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $pubArray, $perPage);
             unset($pubArray);
 
@@ -1571,7 +1571,7 @@ class SearchController extends Controller
 
             $dataProviderCollArray = $this->sortSearchResult($dataProviderCollArray, $sortField, $sortDirection);
 
-            $perPage = request('perPage', Config::get('constants.per_page'));
+            $perPage = request('per_page', Config::get('constants.per_page'));
             $paginatedData = $this->paginateArray($request, $dataProviderCollArray, $perPage);
             unset($dataProviderCollArray);
 

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -75,7 +75,7 @@ class UserController extends Controller
     {
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-        $perPage = request('perPage', Config::get('constants.per_page'));
+        $perPage = request('per_page', Config::get('constants.per_page'));
         $mini = $request->has('mini');
         $users = [];
 

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -96,7 +96,7 @@ class SearchTest extends TestCase
      */
     public function test_datasets_search_with_success(): void
     {
-        $response = $this->json('POST', self::TEST_URL_SEARCH . "/datasets?perPage=1", ["query" => "asthma"], ['Accept' => 'application/json']);
+        $response = $this->json('POST', self::TEST_URL_SEARCH . "/datasets?per_page=1", ["query" => "asthma"], ['Accept' => 'application/json']);
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data' => [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

FE PR: https://github.com/HDRUK/gateway-web/pull/1193

Renamed any params that are perPage to per_page. The case for other parameters isn't always consistent, but snake_case seems more used that camelCase. 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-5504

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
