### PR TITLE
feat(GAT-6927): Remove cache (redis) from feature flagging

### DIFF
--- a/app/Http/Controllers/Api/V1/FeatureFlagController.php
+++ b/app/Http/Controllers/Api/V1/FeatureFlagController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Cache;
+// use Illuminate\Support\Facades\Cache;
 use App\Http\Controllers\Controller;
 use Laravel\Pennant\Feature;
 use App\Services\FeatureFlagManager;
@@ -67,8 +67,8 @@ class FeatureFlagController extends Controller
             Log::warning('Invalid API token', ['provided' => $providedToken]);
             return response()->json(['message' => 'Unauthorized: Invalid token.'], 401);
         }
-        Cache::forget('getAllFlags');
-        Cache::forget('feature_flags');
+        // Cache::forget('getAllFlags');
+        // Cache::forget('feature_flags');
 
 
         $url = env('FEATURE_FLAGGING_CONFIG_URL');
@@ -77,14 +77,17 @@ class FeatureFlagController extends Controller
             return response()->json(['message' => 'Feature flagging disabled in this environment.'], 200);
         }
 
-        $res = Http::get($url);
+        // $res = Http::get($url);
 
-        if (!$res->successful()) {
-            Log::error('Failed to fetch feature flags from GitHub', ['url' => $url]);
-            return response()->json(['message' => 'Failed to fetch feature flags.'], 500);
-        }
+        // if (!$res->successful()) {
+        //     Log::error('Failed to fetch feature flags from GitHub', ['url' => $url]);
+        //     return response()->json(['message' => 'Failed to fetch feature flags.'], 500);
+        // }
 
-        $featureFlags = $res->json();
+        $featureFlags = [
+                    'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
+                    'Aliases' => ['enabled' => true],
+        ];
 
 
 

--- a/app/Providers/FeatureServiceProvider.php
+++ b/app/Providers/FeatureServiceProvider.php
@@ -63,12 +63,14 @@ class FeatureServiceProvider extends ServiceProvider
                     'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
                     'Aliases' => ['enabled' => true],
             ];
+            app(FeatureFlagManager::class)->define($featureFlags);
 
-            if (is_array($featureFlags) && !empty($featureFlags)) {
-                app(FeatureFlagManager::class)->define($featureFlags);
-            } else {
-                logger()->warning('No feature flags were defined - empty or failed response.', ['url' => $url]);
-            }
+
+            // if (is_array($featureFlags) && !empty($featureFlags)) {
+            //     app(FeatureFlagManager::class)->define($featureFlags);
+            // } else {
+            //     logger()->warning('No feature flags were defined - empty or failed response.', ['url' => $url]);
+            // }
         });
     }
 

--- a/app/Providers/FeatureServiceProvider.php
+++ b/app/Providers/FeatureServiceProvider.php
@@ -20,44 +20,49 @@ class FeatureServiceProvider extends ServiceProvider
                 return;
             }
 
-            $featureFlags = Cache::remember('feature_flags', now()->addMinutes(10), function () use ($url) {
-                logger()->info('Calling that Bucket');
+            // $featureFlags = Cache::remember('feature_flags', now()->addMinutes(10), function () use ($url) {
+            //     logger()->info('Calling that Bucket');
 
-                try {
-                    // this is the thing that fails, it does not retry and falls over because during a random split second http protocol does not exist...
-                    // this error we are getting is VERY similiar to the reddis connection problems.. they are likely the same underlying issue.
-                    $res = Http::timeout(60)
-                        ->retry(3, 2000, function ($exception, $requestNumber) use ($url) {
-                            logger()->warning('Retrying feature flag fetch', [
-                                'url' => $url,
-                                'attempt' => $requestNumber,
-                                'error' => $exception->getMessage(),
-                            ]);
-                        })
-                        ->get($url);
-                } catch (ConnectionException $e) {
-                    logger()->error('ConnectionException when fetching feature flags', [
-                        'url' => $url,
-                        'error' => $e->getMessage(),
-                    ]);
-                    /// this is temp until the new GCS solution JB is in place
-                    return [
+            //     try {
+            //         // this is the thing that fails, it does not retry and falls over because during a random split second http protocol does not exist...
+            //         // this error we are getting is VERY similiar to the reddis connection problems.. they are likely the same underlying issue.
+            //         $res = Http::timeout(60)
+            //             ->retry(3, 2000, function ($exception, $requestNumber) use ($url) {
+            //                 logger()->warning('Retrying feature flag fetch', [
+            //                     'url' => $url,
+            //                     'attempt' => $requestNumber,
+            //                     'error' => $exception->getMessage(),
+            //                 ]);
+            //             })
+            //             ->get($url);
+            //     } catch (ConnectionException $e) {
+            //         logger()->error('ConnectionException when fetching feature flags', [
+            //             'url' => $url,
+            //             'error' => $e->getMessage(),
+            //         ]);
+            //         /// this is temp until the new GCS solution JB is in place
+            //         return [
+            //         'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
+            //         'Aliases' => ['enabled' => true],
+            //     ];
+            //     }
+
+            //     if (!$res->successful()) {
+            //         logger()->error('Failed to fetch feature flags', [
+            //             'url' => $url,
+            //             'status' => $res->status(),
+            //             'body' => $res->body(),
+            //         ]);
+            //         return [];
+            //     }
+
+            //     return $res->json();
+            // });
+
+            $featureFlags = [
                     'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
                     'Aliases' => ['enabled' => true],
-                ];
-                }
-
-                if (!$res->successful()) {
-                    logger()->error('Failed to fetch feature flags', [
-                        'url' => $url,
-                        'status' => $res->status(),
-                        'body' => $res->body(),
-                    ]);
-                    return [];
-                }
-
-                return $res->json();
-            });
+            ];
 
             if (is_array($featureFlags) && !empty($featureFlags)) {
                 app(FeatureFlagManager::class)->define($featureFlags);

--- a/app/Services/FeatureFlagManager.php
+++ b/app/Services/FeatureFlagManager.php
@@ -41,15 +41,20 @@ class FeatureFlagManager
     public function getAllFlags(): array
     {
         $url = env('FEATURE_FLAGGING_CONFIG_URL');
-        $featureFlags = Cache::remember('getAllFlags', now()->addMinutes(60), function () use ($url) {
-            $res = Http::get($url);
-            if ($res->successful()) {
-                return $res->json();
-            }
+        // $featureFlags = Cache::remember('getAllFlags', now()->addMinutes(60), function () use ($url) {
+        //     $res = Http::get($url);
+        //     if ($res->successful()) {
+        //         return $res->json();
+        //     }
 
-            logger()->error('Failed to fetch feature flags from URL', ['url' => $url]);
-            return [];
-        });
+        //     logger()->error('Failed to fetch feature flags from URL', ['url' => $url]);
+        //     return [];
+        // });
+
+        $featureFlags = [
+                    'SDEConciergeServiceEnquiry' => ['enabled' => env('SDEConciergeServiceEnquiry', true)],
+                    'Aliases' => ['enabled' => true],
+        ];
 
 
 

--- a/app/Services/FeatureFlagManager.php
+++ b/app/Services/FeatureFlagManager.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use Illuminate\Support\Facades\Http;
 use Laravel\Pennant\Feature;
-use Illuminate\Support\Facades\Cache;
+// use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
 class FeatureFlagManager


### PR DESCRIPTION
## Screenshots (if relevant)
![image](https://github.com/user-attachments/assets/4829fb1c-b3e5-4e68-97ae-eee384b711c8)

## Describe your changes
The 50 minute timoue we are seeing in dev (and now prod), the error originally was the same/similar to the redis error that randomly appears in prod. Pennant is one of the first things to load and it uses the laravel cache method which behind the scenes hits our redis instance.

For now just to check, remove the cache and just use the default fallback. Just to see if we still get hangs

![image](https://github.com/user-attachments/assets/e09af49e-482a-4623-8470-7926a7440a84)

REMEMBER THIS IS A TEMP SOLUTION PLEASE.

This only happens in dev and now prod. 

i am 100% convinced this is redis. 

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
