### PR TITLE
fix(GAT-7391): The search function does not work to filter SAIL datasets by 'keyword'

### DIFF
--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -75,7 +75,7 @@ trait IndexElastic
 
             $toIndex = [
                 'abstract' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.abstract'], ''),
-                'keywords' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.keywords'], ''),
+                'keywords' => explode(';,;', $this->getValueByPossibleKeys($metadata, ['metadata.summary.keywords'], '')),
                 'description' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.description'], ''),
                 'shortTitle' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], ''),
                 'title' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.title'], ''),


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
The search function does not work to filter SAIL datasets by 'keyword'

## Issue ticket link
https://hdruk.atlassian.net/issues/GAT-7391

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
reindex datasets

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
