### PR TITLE
fix(GAT-7331): Move data reads in all artisan commands out of __construct() and into handle().

### DIFF
--- a/app/Console/Commands/AddDataProviderNetwork.php
+++ b/app/Console/Commands/AddDataProviderNetwork.php
@@ -25,17 +25,12 @@ class AddDataProviderNetwork extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/data_provider_networkv3.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/data_provider_networkv3.csv');
         $askDataProviderNetwork = $this->ask('Data Provider Network for import, based on file "../storage/migration_files/data_provider_networkv3.csv"? [default value all]', 'all');
         $askInitDataProviderNetwork = $this->ask('Do you want to initialize the database for "Data Provider Network"? yes/no [default value no]', 'no');
 

--- a/app/Console/Commands/AssignTeamToCollection.php
+++ b/app/Console/Commands/AssignTeamToCollection.php
@@ -24,17 +24,12 @@ class AssignTeamToCollection extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/mapped_collections_team_id.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/mapped_collections_team_id.csv');
 
         $csvData = $this->csvData;
         $fallbackTeam = Team::where("name", "like", "%Health Data Research UK%")->select("id")->first();

--- a/app/Console/Commands/DatasetPublicationLinkagePostMigration.php
+++ b/app/Console/Commands/DatasetPublicationLinkagePostMigration.php
@@ -28,17 +28,12 @@ class DatasetPublicationLinkagePostMigration extends Command
      */
     protected $description = 'CLI command to post-process migrated datasets and publications from mk1 mongo db. Updates PublicationHasDatasetVersion::link_type with values from file by matching titles';
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->csvData = $this->readMigrationFile(storage_path() . '/migration_files/datasets_publications_linkages.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->csvData = $this->readMigrationFile(storage_path() . '/migration_files/datasets_publications_linkages.csv');
         $reindex = $this->argument('reindex');
         $reindexEnabled = $reindex !== null;
 

--- a/app/Console/Commands/FixCollectionImages.php
+++ b/app/Console/Commands/FixCollectionImages.php
@@ -24,17 +24,12 @@ class FixCollectionImages extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/collection_images_update_and_fix.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/collection_images_update_and_fix.csv');
         $dryRun = $this->option('dryRun');
         $csvData = $this->csvData;
 

--- a/app/Console/Commands/MakeCollectionsActive.php
+++ b/app/Console/Commands/MakeCollectionsActive.php
@@ -24,17 +24,12 @@ class MakeCollectionsActive extends Command
     protected $description = 'Command description';
 
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/collections_make_active.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/collections_make_active.csv');
 
         $progressbar = $this->output->createProgressBar(count($this->csvData));
         foreach ($this->csvData as $csv) {

--- a/app/Console/Commands/PublicationTypePostMigration.php
+++ b/app/Console/Commands/PublicationTypePostMigration.php
@@ -25,17 +25,12 @@ class PublicationTypePostMigration extends Command
      */
     protected $description = 'CLI command to post-process migrated publications from mk1 mongo db. Updates Publication::publication_type with values from file by matching publication titles';
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->csvData = $this->readMigrationFile(storage_path() . '/migration_files/mapped_publications_types.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->csvData = $this->readMigrationFile(storage_path() . '/migration_files/mapped_publications_types.csv');
         $reindex = $this->argument('reindex');
         $reindexEnabled = $reindex !== null;
 

--- a/app/Console/Commands/UpdateCollectionHasUsers.php
+++ b/app/Console/Commands/UpdateCollectionHasUsers.php
@@ -25,17 +25,12 @@ class UpdateCollectionHasUsers extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/production.collections.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/production.collections.csv');
         foreach ($this->csvData as $item) {
             $collectionMongoId = strtoupper(trim($item['_id']));
             $userAdmin = User::where('is_admin', 1)->first();

--- a/app/Console/Commands/UpdateLeadTimeGat5620.php
+++ b/app/Console/Commands/UpdateLeadTimeGat5620.php
@@ -27,17 +27,12 @@ class UpdateLeadTimeGat5620 extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/delivery_lead_time_mk1_mappings.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/delivery_lead_time_mk1_mappings.csv');
         $action = $this->argument('argument');
         switch ($action) {
             case 'create_backup':

--- a/app/Console/Commands/UpdateMissingPublications.php
+++ b/app/Console/Commands/UpdateMissingPublications.php
@@ -31,17 +31,12 @@ class UpdateMissingPublications extends Command
 
     private $csvData = [];
 
-    public function __construct()
-    {
-        parent::__construct();
-        $this->readMigrationFile(storage_path() . '/migration_files/finding.publications.update.csv');
-    }
-
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->readMigrationFile(storage_path() . '/migration_files/finding.publications.update.csv');
         $userAdmin = User::where('is_admin', 1)->first();
 
         $progressbar = $this->output->createProgressBar(count($this->csvData));

--- a/tests/Feature/DataAccessTemplateTest.php
+++ b/tests/Feature/DataAccessTemplateTest.php
@@ -493,11 +493,12 @@ class DataAccessTemplateTest extends TestCase
         // test the template is listed by team
         $response = $this->get('api/v1/teams/' . 1 . '/dar/templates/', $this->header);
 
+        $lastIndex = count($response->decodeResponseJson()['data']) - 1;
         $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
             ->assertJsonStructure([
                 'current_page',
                 'data' => [
-                    0 => [
+                    $lastIndex => [
                         'id',
                         'created_at',
                         'updated_at',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
The contents of `__construct()` are run while generating signatures for commands, which is a frequent task in other commands.

Change made so that all the data reads are not run during pest runs or during artisan list calls. Was causing occasional local testing failures.

Also fix an unrelated intermittent test failure.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
