### PR TITLE
feat(GAT-7088): Create v2 endpoints for use of 'Data Custodian' terminology

### DIFF
--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -35,7 +35,6 @@ class DataCustodianNetworksController extends Controller
     /**
      * @OA\Get(
      *      path="/api/v2/data_custodian_networks",
-     *      summary="List of DataCustodianNetworks",
      *      description="Returns a list of DataCustodianNetworks enabled on the system",
      *      tags={"DataCustodianNetworks"},
      *      summary="DataCustodianNetworks@index",
@@ -89,6 +88,17 @@ class DataCustodianNetworksController extends Controller
                     return $item;
                 });
 
+            foreach ($dpc as $data) {
+                // Manually rename the field 'data_provider_coll_id' to 'data_custodian_network_id' to provide consistent naming
+                // for users of the API. This can be removed if and when internal naming changes too.
+                foreach ($data['teams'] as &$team) {
+                    $team['pivot']['data_custodian_network_id'] = $team['pivot']['data_provider_coll_id'];
+                    unset($team['pivot']['data_provider_coll_id']);
+                }
+                unset($team);
+            }
+            unset($data);
+
             Auditor::log([
                 'action_type' => 'GET',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
@@ -113,20 +123,19 @@ class DataCustodianNetworksController extends Controller
     /**
      * @OA\Get(
      *      path="/api/v2/data_custodian_networks/{id}",
-     *      summary="Return a single DataCustodianNetworks",
-     *      description="Return a single DataCustodianNetworks",
+     *      description="Return a single DataCustodianNetwork",
      *      tags={"DataCustodianNetworks"},
      *      summary="DataCustodianNetworks@show",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
      *         name="id",
      *         in="path",
-     *         description="DataCustodianNetworks ID",
+     *         description="DataCustodianNetwork ID",
      *         required=true,
      *         example="1",
      *         @OA\Schema(
      *            type="integer",
-     *            description="DataCustodianNetworks ID",
+     *            description="DataCustodianNetwork ID",
      *         ),
      *      ),
      *      @OA\Response(
@@ -176,6 +185,14 @@ class DataCustodianNetworksController extends Controller
             $result = array_merge($dpc->toArray(), [
                 'service' => empty($service) ? null : $service,
             ]);
+
+            // Manually rename the field 'data_provider_coll_id' to 'data_custodian_network_id' to provide consistent naming
+            // for users of the API. This can be removed if and when internal naming changes too.
+            foreach ($result['teams'] as &$team) {
+                $team['pivot']['data_custodian_network_id'] = $team['pivot']['data_provider_coll_id'];
+                unset($team['pivot']['data_provider_coll_id']);
+            }
+            unset($team);
 
             return response()->json([
                 'message' => Config::get('statuscodes.STATUS_OK.message'),
@@ -346,7 +363,6 @@ class DataCustodianNetworksController extends Controller
     /**
      * @OA\Post(
      *      path="/api/v2/data_custodian_networks",
-     *      summary="Create a new DataCustodianNetwork",
      *      description="Creates a new DataCustodianNetwork",
      *      tags={"DataCustodianNetworks"},
      *      summary="DataCustodianNetworks@store",
@@ -446,7 +462,6 @@ class DataCustodianNetworksController extends Controller
     /**
      * @OA\Put(
      *      path="/api/v2/data_custodian_networks/{id}",
-     *      summary="Update a DataCustodianNetwork",
      *      description="Update a DataCustodianNetwork",
      *      tags={"DataCustodianNetworks"},
      *      summary="DataCustodianNetwork@update",

--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -1,0 +1,849 @@
+<?php
+
+namespace App\Http\Controllers\Api\V2;
+
+use Config;
+use Auditor;
+use Exception;
+use App\Models\Team;
+use App\Models\Dataset;
+use Illuminate\Http\Request;
+use App\Models\DatasetVersion;
+use App\Models\DataProviderColl;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Models\Collection;
+use App\Models\DataProviderCollHasTeam;
+use App\Models\Dur;
+use App\Models\Publication;
+use App\Models\Tool;
+use App\Http\Traits\GetValueByPossibleKeys;
+use App\Http\Traits\IndexElastic;
+
+class DataCustodianNetworksController extends Controller
+{
+    use IndexElastic;
+    use GetValueByPossibleKeys;
+
+    private $datasets = [];
+    private $durs = [];
+    private $tools = [];
+    private $publications = [];
+    private $collections = [];
+
+    /**
+     * @OA\Get(
+     *      path="/api/v2/data_custodian_networks",
+     *      summary="List of DataCustodianNetworks",
+     *      description="Returns a list of DataCustodianNetworks enabled on the system",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetworks@index",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *          name="per_page",
+     *          in="query",
+     *          description="per page",
+     *          required=false,
+     *          example="1",
+     *          @OA\Schema(
+     *              type="integer",
+     *              description="per page",
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="id", type="integer", example="123"),
+     *                      @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                      @OA\Property(property="name", type="string", example="Name"),
+     *                      @OA\Property(property="summary", type="string", example="Summary"),
+     *                      @OA\Property(property="enabled", type="boolean", example="1"),
+     *                      @OA\Property(property="service", type="string", example="https://example"),
+     *                  )
+     *              )
+     *          )
+     *      )
+     * )
+     */
+    public function index(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+
+            $perPage = request('per_page', Config::get('constants.per_page'));
+            $mediaBaseUrl = Config::get('services.media.base_url');
+
+            $dpc = DataProviderColl::with([
+                'teams'
+                ])->where('enabled', 1)
+                ->paginate((int) $perPage, ['*'], 'page')
+                ->through(function ($item) use ($mediaBaseUrl) {
+                    $item->img_url = (is_null($item->img_url) || strlen(trim($item->img_url)) === 0) ? null : (preg_match('/^https?:\/\//', $item->img_url) ? $item->img_url : $mediaBaseUrl . $item->img_url);
+                    return $item;
+                });
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataCustodianNetworks list'
+            ]);
+
+            return response()->json(
+                $dpc,
+            );
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v2/data_custodian_networks/{id}",
+     *      summary="Return a single DataCustodianNetworks",
+     *      description="Return a single DataCustodianNetworks",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetworks@show",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetworks ID",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetworks ID",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Name"),
+     *                  @OA\Property(property="summary", type="string", example="Summary"),
+     *                  @OA\Property(property="enabled", type="boolean", example="1"),
+     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function show(Request $request, int $id): JsonResponse
+    {
+        try {
+            $dpc = DataProviderColl::with([
+                'teams',
+                ])->where('id', $id)->firstOrFail();
+
+            $mediaBaseUrl = Config::get('services.media.base_url');
+            $dpc->img_url = (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? null : (preg_match('/^https?:\/\//', $dpc->img_url) ? $dpc->img_url : $mediaBaseUrl . $dpc->img_url);
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataCustodianNetworks get ' . $id,
+            ]);
+
+            $service = array_values(array_filter(explode(",", $dpc->service)));
+
+            $result = array_merge($dpc->toArray(), [
+                'service' => empty($service) ? null : $service,
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $result
+            ]);
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/api/v2/data_custodian_networks/{id}/summary",
+     *      description="Return a single DataCustodianNetwork - summary",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetworks@showSummary",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetwork ID - summary",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetwork ID - summary",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example=1),
+     *                  @OA\Property(property="name", type="string", example="Name"),
+     *                  @OA\Property(property="img_url", type="string", example="http://placeholder"),
+     *                  @OA\Property(property="url", type="string", example="http://placeholder.url"),
+     *                  @OA\Property(property="summary", type="string", example="Summary"),
+     *                  @OA\Property(property="datasets", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="durs", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="tools", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="publications", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="collections", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
+    public function showSummary(Request $request, int $id): JsonResponse
+    {
+        try {
+            $dpc = DataProviderColl::select('id', 'name', 'img_url', 'enabled', 'url', 'service')
+                ->with('teams')
+                ->where([
+                    'id' => $id,
+                    'enabled' => 1,
+            ])->first();
+
+            if (!$dpc) {
+                return response()->json([
+                    'message' => 'DataCustodianNetwork not found or not enabled',
+                    'data' => null,
+                ], 404);
+            }
+
+            $teamsResult = $this->getTeams($dpc);
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataCustodianNetwork get ' . $id,
+            ]);
+
+            $durs = Dur::select(
+                'id',
+                'project_title',
+                'organisation_name',
+                'status',
+                'created_at',
+                'updated_at'
+            )->whereIn('id', $this->durs)->where('status', 'ACTIVE')->get()->toArray();
+            $tools = Tool::select(
+                'id',
+                'name',
+                'enabled',
+                'status',
+                'created_at',
+                'updated_at'
+            )->with(['user'])->whereIn('id', $this->tools)->where('status', 'ACTIVE')->get()->toArray();
+            $publications = Publication::select(
+                'id',
+                'paper_title',
+                'authors',
+                'publication_type',
+                'publication_type_mk1',
+                'status',
+                'created_at',
+                'updated_at'
+            )->whereIn('id', $this->publications)->where('status', 'ACTIVE')->get()->toArray();
+            $collections = Collection::select(
+                'id',
+                'name',
+                'image_link',
+                'status',
+                'created_at',
+                'updated_at'
+            )->whereIn('id', $this->collections)->where('status', 'ACTIVE')->get()->toArray();
+            $collections = array_map(function ($collection) {
+                if ($collection['image_link'] && !preg_match('/^https?:\/\//', $collection['image_link'])) {
+                    $collection['image_link'] = Config::get('services.media.base_url') . $collection['image_link'];
+                }
+                return $collection;
+            }, $collections);
+
+            $service = array_values(array_filter(explode(",", $dpc->service)));
+
+            $result = [
+                'id' => $dpc->id,
+                'name' => $dpc->name,
+                'img_url' => (is_null($dpc->img_url) || strlen(trim($dpc->img_url)) === 0) ? '' : (preg_match('/^https?:\/\//', $dpc->img_url) ? $dpc->img_url : Config::get('services.media.base_url') . $dpc->img_url),
+                'summary' => $dpc->summary,
+                'enabled' => $dpc->enabled,
+                'url' => $dpc->url,
+                'service' => empty($service) ? null : $service,
+                'teams_counts' => $teamsResult,
+                'datasets_total' => count($this->datasets),
+                'datasets' => $this->datasets,
+                'durs_total' => count($durs),
+                'durs' => $durs,
+                'tools_total' => count($tools),
+                'tools' => $tools,
+                'publications_total' => count($publications),
+                'publications' => $publications,
+                'collections_total' => count($collections),
+                'collections' => $collections
+            ];
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $result,
+            ]);
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *      path="/api/v2/data_custodian_networks",
+     *      summary="Create a new DataCustodianNetwork",
+     *      description="Creates a new DataCustodianNetwork",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetworks@store",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataCustodianNetwork definition",
+     *          @OA\JsonContent(
+     *              required={"name", "summary", "enabled", "team_ids"},
+     *              @OA\Property(property="name", type="string", example="Name"),
+     *              @OA\Property(property="summary", type="string", example="Summary"),
+     *              @OA\Property(property="enabled", type="boolean", example="true"),
+     *              @OA\Property(property="service", type="string", example="https://example"),
+     *              @OA\Property(property="team_ids", type="array", example="{3, 4, 5}",
+     *                  @OA\Items(
+     *                      @OA\Property(type="integer")
+     *                  )
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="success"),
+     *             @OA\Property(property="data", type="integer", example="100")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function store(Request $request): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $array = [
+                'enabled' => $input['enabled'],
+                'name' => $input['name'],
+                'img_url' => $input['img_url'],
+                'summary' => $input['summary'],
+                'url' => array_key_exists('url', $input) ? $input['url'] : null,
+                'service' => array_key_exists('service', $input) ? $input['service'] : null,
+            ];
+            if (isset($input['url'])) {
+                $array['url'] = $input['url'];
+            }
+
+            $dpc = DataProviderColl::create($array);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'CREATE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataProvider ' . $dpc->id . ' created',
+            ]);
+
+            foreach ($input['team_ids'] as $teamId) {
+                DataProviderCollHasTeam::create([
+                    'data_provider_coll_id' => $dpc->id,
+                    'team_id' => $teamId,
+                ]);
+
+                Auditor::log([
+                    'user_id' => (int)$jwtUser['id'],
+                    'action_type' => 'CREATE',
+                    'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                    'description' => 'DataProviderCollHasTeam ' . $dpc->id . '/' . $teamId . ' created',
+                ]);
+            }
+
+            $this->indexElasticDataProviderColl((int) $dpc->id);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_CREATED.message'),
+                'data' => $dpc->id,
+            ], Config::get('statuscodes.STATUS_CREATED.code'));
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Put(
+     *      path="/api/v2/data_custodian_networks/{id}",
+     *      summary="Update a DataCustodianNetwork",
+     *      description="Update a DataCustodianNetwork",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetwork@update",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetworks ID",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetwork ID",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataCustodianNetwork definition",
+     *          @OA\JsonContent(
+     *              required={"name", "summary", "enabled", "team_ids"},
+     *              @OA\Property(property="name", type="string", example="Name"),
+     *              @OA\Property(property="summary", type="string", example="Summary"),
+     *              @OA\Property(property="enabled", type="string", example="true"),
+     *              @OA\Property(property="service", type="string", example="https://example"),
+     *              @OA\Property(property="team_ids", type="array", example="{3, 4, 5}",
+     *                  @OA\Items(
+     *                      @OA\Property(type="integer")
+     *                  )
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Name"),
+     *                  @OA\Property(property="summary", type="string", example="Summary"),
+     *                  @OA\Property(property="enabled", type="boolean", example="1"),
+     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function update(Request $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $dpc = DataProviderColl::where('id', $id)->first();
+
+            $dpc->enabled = $input['enabled'];
+            $dpc->name = $input['name'];
+            $dpc->img_url = $input['img_url'];
+            $dpc->summary = $input['summary'];
+            $dpc->url = (isset($input['url']) ? $input['url'] : $dpc->url);
+            $dpc->service = (isset($input['service']) ? $input['service'] : $dpc->url);
+            $dpc->save();
+
+            if (isset($input['team_ids']) && !empty($input['team_ids'])) {
+                DataProviderCollHasTeam::where('data_provider_coll_id', $dpc->id)->delete();
+
+                foreach ($input['team_ids'] as $teamId) {
+                    DataProviderCollHasTeam::create([
+                        'data_provider_coll_id' => $dpc->id,
+                        'team_id' => $teamId,
+                    ]);
+                }
+            }
+
+            $this->indexElasticDataProviderColl((int) $id);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $dpc,
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Patch(
+     *      path="/api/v2/data_custodian_networks/{id}",
+     *      summary="Edit a DataCustodianNetwork",
+     *      description="Edit a DataCustodianNetwork",
+     *      tags={"DataCustodianNetwork"},
+     *      summary="DataCustodianNetwork@edit",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetwork ID",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetwork ID",
+     *         ),
+     *      ),
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="DataCustodianNetwork definition",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="name", type="string", example="Name"),
+     *              @OA\Property(property="summary", type="string", example="Summary"),
+     *              @OA\Property(property="enabled", type="string", example="true"),
+     *              @OA\Property(property="service", type="string", example="https://example"),
+     *              @OA\Property(property="team_ids", type="array", example="{3, 4, 5}",
+     *                  @OA\Items(
+     *                      @OA\Property(type="integer")
+     *                  )
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example="123"),
+     *                  @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                  @OA\Property(property="name", type="string", example="Name"),
+     *                  @OA\Property(property="summary", type="string", example="Summary"),
+     *                  @OA\Property(property="enabled", type="boolean", example="1"),
+     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function edit(Request $request, int $id): JsonResponse
+    {
+        try {
+            $input = $request->all();
+            $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+            $dpc = DataProviderColl::where('id', $id)->first();
+
+            $dpc->enabled = (isset($input['enabled']) ? $input['enabled'] : $dpc->enabled);
+            $dpc->name = (isset($input['name']) ? $input['name'] : $dpc->name);
+            $dpc->img_url = (isset($input['img_url']) ? $input['img_url'] : $dpc->img_url);
+            $dpc->summary = (isset($input['summary']) ? $input['summary'] : $dpc->summary);
+            $dpc->url = (isset($input['url']) ? $input['url'] : $dpc->url);
+            $dpc->service = (isset($input['service']) ? $input['service'] : $dpc->service);
+
+            $dpc->save();
+
+            if (isset($input['team_ids']) && !empty($input['team_ids'])) {
+                DataProviderCollHasTeam::where('data_provider_coll_id', $dpc->id)->delete();
+
+                foreach ($input['team_ids'] as $teamId) {
+                    DataProviderCollHasTeam::create([
+                        'data_provider_coll_id' => $dpc->id,
+                        'team_id' => $teamId,
+                    ]);
+                }
+            }
+
+            $this->indexElasticDataProviderColl((int) $id);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $dpc,
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *      path="/api/v2/data_custodian_networks/{id}",
+     *      summary="Delete a DataCustodianNetwork",
+     *      description="Delete a DataCustodianNetwork",
+     *      tags={"DataCustodianNetwork"},
+     *      summary="DataCustodianNetwork@destroy",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetwork ID",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetwork ID",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found")
+     *           ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success")
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function destroy(Request $request, int $id): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            DataProviderCollHasTeam::where(['data_provider_coll_id' => $id])->delete();
+            DataProviderColl::where(['id' => $id])->delete();
+
+            $this->deleteDataProviderCollFromElastic($id);
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'DELETE',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'DataProvider ' . $id . ' deleted',
+            ]);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    public function getTeams(DataProviderColl $dp)
+    {
+        $idTeams = DataProviderCollHasTeam::where(['data_provider_coll_id' => $dp->id])->pluck('team_id')->toArray();
+        $teamsResult = [];
+
+        foreach ($idTeams as $idTeam) {
+            $team = Team::select('id', 'name')->where(['id' => $idTeam])->first();
+            $counts = $this->getDatasets((int) $team->id);
+            $teamCollections = Collection::where(['team_id' => $idTeam])->where('status', 'ACTIVE')->pluck('id')->toArray();
+
+            $this->collections = array_unique([...$this->collections, ...$teamCollections]);
+
+            $teamsResult[] = array_merge([
+                'name' => $team->name,
+                'id' => $team->id,
+            ], $counts);
+        }
+
+        return $teamsResult;
+    }
+
+    public function getDatasets(int $teamId)
+    {
+        $datasetIds = Dataset::where(['team_id' => $teamId])->where('status', 'ACTIVE')->pluck('id')->toArray();
+
+        $teamResourceIds = [
+            'durs' => [],
+            'publications' => [],
+            'tools' => [],
+            'collections' => []
+        ];
+        foreach ($datasetIds as $datasetId) {
+            $datasetResources = $this->checkingDataset($datasetId);
+            foreach ($datasetResources as $k => $v) {
+                $teamResourceIds[$k] = array_unique(array_merge($v, $teamResourceIds[$k]));
+            }
+        }
+        $counts = [
+            'datasets_count' => count($datasetIds),
+            'durs_count' => count($teamResourceIds['durs']),
+            'publications_count' => count($teamResourceIds['publications']),
+            'tools_count' => count($teamResourceIds['tools']),
+            'collections_count' => count($teamResourceIds['collections']),
+        ];
+
+        return $counts;
+    }
+
+    public function checkingDataset(int $datasetId)
+    {
+        $dataset = Dataset::where(['id' => $datasetId])->first();
+
+        // Accessed through the accessor
+        $durIds = array_column($dataset->allDurs, 'id') ?? [];
+        $collectionIds = array_column($dataset->allCollections, 'id') ?? [];
+        $publicationIds = array_column($dataset->allPublications, 'id') ?? [];
+        $toolIds = array_column($dataset->allTools, 'id') ?? [];
+
+        $version = $dataset->latestVersion();
+        $withLinks = DatasetVersion::where('id', $version['id'])
+            ->with(['linkedDatasetVersions'])
+            ->first();
+
+        $dataset->setAttribute('versions', [$withLinks]);
+
+        $metadataSummary = $dataset['versions'][0]['metadata']['metadata']['summary'] ?? [];
+
+        $title = $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
+        $populationSize = $this->getValueByPossibleKeys($metadataSummary, ['populationSize'], -1);
+        $datasetType = $this->getValueByPossibleKeys($metadataSummary, ['datasetType'], '');
+
+        if (empty($title) || $title === '') {
+            Log::error('DataCustodianNetworksController: Dataset title is empty or unknown', [
+                'datasetId' => $dataset->id
+            ]);
+        }
+
+        $this->datasets[] = [
+            'id' => $dataset->id,
+            'status' => $dataset->status,
+            'title' => $title,
+            'populationSize' => $populationSize,
+            'datasetType' => $datasetType
+        ];
+
+        $this->durs = array_unique(array_merge($this->durs, $durIds));
+        $this->publications = array_unique(array_merge($this->publications, $publicationIds));
+        $this->tools = array_unique(array_merge($this->tools, $toolIds));
+        $this->collections = array_unique(array_merge($this->collections, $collectionIds));
+
+        $datasetResources = [
+            'durs' => $durIds,
+            'publications' => $publicationIds,
+            'tools' => $toolIds,
+            'collections' => $collectionIds
+        ];
+
+        return $datasetResources;
+    }
+}

--- a/config/routes_v2.php
+++ b/config/routes_v2.php
@@ -1194,7 +1194,7 @@ return [
         ],
     ],
 
-     // DataProviders
+     // Data Custodian Networks
     [
         'name' => 'data_custodian_networks.get',
         'method' => 'get',

--- a/config/routes_v2.php
+++ b/config/routes_v2.php
@@ -1193,4 +1193,94 @@ return [
             'id' => '[0-9]+',
         ],
     ],
+
+     // DataProviders
+    [
+        'name' => 'data_custodian_networks.get',
+        'method' => 'get',
+        'path' => '/data_custodian_networks',
+        'methodController' => 'DataCustodianNetworksController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'data_custodian_networks.get.one',
+        'method' => 'get',
+        'path' => '/data_custodian_networks/{id}',
+        'methodController' => 'DataCustodianNetworksController@show',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.get.one.summary',
+        'method' => 'get',
+        'path' => '/data_custodian_networks/{id}/summary',
+        'methodController' => 'DataCustodianNetworksController@showSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.create',
+        'method' => 'post',
+        'path' => '/data_custodian_networks',
+        'methodController' => 'DataCustodianNetworksController@store',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'data_custodian_networks.update',
+        'method' => 'put',
+        'path' => '/data_custodian_networks/{id}',
+        'methodController' => 'DataCustodianNetworksController@update',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.edit',
+        'method' => 'patch',
+        'path' => '/data_custodian_networks/{id}',
+        'methodController' => 'DataCustodianNetworksController@edit',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.destroy',
+        'method' => 'delete',
+        'path' => '/data_custodian_networks/{id}',
+        'methodController' => 'DataCustodianNetworksController@destroy',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
 ];

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace Tests\Feature\V2;
+
+use Tests\TestCase;
+use Database\Seeders\DurSeeder;
+use Database\Seeders\TagSeeder;
+use App\Models\DataProviderColl;
+use Database\Seeders\TeamSeeder;
+use Database\Seeders\ToolSeeder;
+use Tests\Traits\MockExternalApis;
+use Database\Seeders\DatasetSeeder;
+use Database\Seeders\KeywordSeeder;
+use Database\Seeders\LicenseSeeder;
+use ElasticClientController as ECC;
+use Database\Seeders\CategorySeeder;
+use Database\Seeders\CollectionSeeder;
+use App\Models\DataProviderCollHasTeam;
+use Database\Seeders\ApplicationSeeder;
+use Database\Seeders\MinimalUserSeeder;
+use Database\Seeders\PublicationSeeder;
+use Database\Seeders\TeamHasUserSeeder;
+use Database\Seeders\TypeCategorySeeder;
+use Database\Seeders\DatasetVersionSeeder;
+use Database\Seeders\CollectionHasDurSeeder;
+use Database\Seeders\CollectionHasToolSeeder;
+use Database\Seeders\CollectionHasUserSeeder;
+use Database\Seeders\DataProviderCollsSeeder;
+use Database\Seeders\CollectionHasKeywordSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Database\Seeders\CollectionHasPublicationSeeder;
+use Database\Seeders\CollectionHasDatasetVersionSeeder;
+use Database\Seeders\PublicationHasDatasetVersionSeeder;
+
+class DataCustodianNetworkTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const TEST_URL = '/api/v2/data_custodian_networks';
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->seed([
+            MinimalUserSeeder::class,
+            TeamSeeder::class,
+            TeamHasUserSeeder::class,
+            DataProviderCollsSeeder::class,
+            ApplicationSeeder::class,
+            CollectionSeeder::class,
+            DatasetSeeder::class,
+            DatasetVersionSeeder::class,
+            KeywordSeeder::class,
+            CategorySeeder::class,
+            TypeCategorySeeder::class,
+            LicenseSeeder::class,
+            ToolSeeder::class,
+            TagSeeder::class,
+            DurSeeder::class,
+            CollectionHasKeywordSeeder::class,
+            CollectionHasDatasetVersionSeeder::class,
+            CollectionHasToolSeeder::class,
+            CollectionHasDurSeeder::class,
+            PublicationSeeder::class,
+            PublicationHasDatasetVersionSeeder::class,
+            CollectionHasPublicationSeeder::class,
+            CollectionHasUserSeeder::class,
+        ]);
+    }
+
+    public function test_get_all_data_provider_colls_with_success(): void
+    {
+        $response = $this->json('GET', self::TEST_URL, [], $this->header);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'current_page',
+            'data' => [
+                0 => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'enabled',
+                    'name',
+                    'summary',
+                    'img_url',
+                    'service',
+                    'teams',
+                ],
+            ],
+            'first_page_url',
+            'from',
+            'last_page',
+            'last_page_url',
+            'links',
+            'next_page_url',
+            'path',
+            'per_page',
+            'prev_page_url',
+            'to',
+            'total',
+        ]);
+    }
+
+    public function test_get_data_provider_coll_by_id_with_success(): void
+    {
+        $response = $this->json('GET', self::TEST_URL . '/1', [], $this->header);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data' => [
+                'id',
+                'created_at',
+                'updated_at',
+                'deleted_at',
+                'enabled',
+                'name',
+                'summary',
+                'service',
+                'img_url',
+                'teams',
+            ]
+        ]);
+        $content = $response->decodeResponseJson();
+
+        $this->assertEquals($content['data']['img_url'], 'https://fakeimg.pl/300x200');
+        $countTeams = count($content['data']['teams']);
+        $this->assertTrue(($countTeams === 1));
+    }
+
+
+    public function test_get_data_provider_coll_by_id_summary_with_success(): void
+    {
+        $response = $this->json('GET', self::TEST_URL . '/1/summary', [], $this->header);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data' => [
+                'id',
+                'name',
+                'img_url',
+                'summary',
+                'service',
+                'datasets',
+                'durs',
+                'tools',
+                'publications',
+                'collections',
+            ]
+        ]);
+    }
+
+    public function test_data_provider_collection_summary()
+    {
+        $id = DataProviderColl::where(['enabled' => 1])->first()->id;
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/summary', [], $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'img_url',
+                    'summary',
+                    'service',
+                    'enabled',
+                    'teams_counts' => [
+                        0 => [
+                            'name',
+                            'id',
+                            'datasets_count',
+                            'tools_count',
+                            'durs_count',
+                            'publications_count',
+                            'collections_count'
+                        ]
+                    ],
+                    'datasets_total',
+                    'datasets',
+                    'durs_total',
+                    'durs',
+                    'tools_total',
+                    'tools',
+                    'publications_total',
+                    'publications',
+                    'collections_total',
+                    'collections',
+                ],
+            ]);
+    }
+
+    public function test_create_data_provider_coll_with_success(): void
+    {
+
+        ECC::shouldReceive("indexDocument")
+            ->times(1);
+
+        $payload = [
+            'enabled' => true,
+            'name' => 'Loki Data Provider',
+            'summary' => fake()->text(255),
+            'img_url' => 'https://doesntexist.com/img.jpeg',
+            'team_ids' => [
+                1,
+                2,
+                3,
+            ],
+            'service' => 'https://service.local/test',
+        ];
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $dpsId = $response->decodeResponseJson()['data'];
+
+        $relations = DataProviderCollHasTeam::where('data_provider_coll_id', $dpsId)->get();
+        $this->assertNotNull($relations);
+        $this->assertEquals(count($relations), 3);
+
+    }
+
+    public function test_update_data_provider_with_success(): void
+    {
+        ECC::shouldReceive("indexDocument")
+            ->times(2);
+
+        $payload = [
+            'enabled' => true,
+            'name' => 'Loki Data Provider',
+            'summary' => fake()->text(255),
+            'img_url' => 'https://doesntexist.com/img.jpeg',
+            'team_ids' => [
+                1,
+                2,
+                3,
+            ],
+            'service' => 'https://service.local/test',
+        ];
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $dpsId = $response->decodeResponseJson()['data'];
+
+        $payload['name'] = 'Loki Updated Data Provider';
+
+        $response = $this->json(
+            'PUT',
+            self::TEST_URL . '/' . $dpsId,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(200);
+        $content = $response->decodeResponseJson()['data'];
+
+        $this->assertEquals($content['name'], 'Loki Updated Data Provider');
+
+
+    }
+
+
+    public function test_delete_data_provider_coll_with_success(): void
+    {
+        ECC::shouldReceive("indexDocument")
+            ->times(1);
+        ECC::shouldReceive("deleteDocument")
+            ->times(1);
+
+        $payload = [
+            'enabled' => true,
+            'name' => 'Loki Data Provider',
+            'summary' => fake()->text(255),
+            'img_url' => 'https://doesntexist.com/img.jpeg',
+            'team_ids' => [
+                1,
+                2,
+                3,
+            ],
+        ];
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $dpsId = $response->decodeResponseJson()['data'];
+
+        $response = $this->json(
+            'DELETE',
+            self::TEST_URL . '/' . $dpsId,
+            [],
+            $this->header,
+        );
+
+        $response->assertStatus(200);
+    }
+
+    public function test_can_update_team_associations_with_success(): void
+    {
+        $payload = [
+            'enabled' => true,
+            'name' => 'Loki Data Provider',
+            'summary' => fake()->text(255),
+            'img_url' => 'https://doesntexist.com/img.jpeg',
+            'team_ids' => [
+                1,
+                2,
+                3,
+            ],
+            'service' => 'https://service.local/test',
+        ];
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'message',
+            'data',
+        ]);
+
+        $dpsId = $response->decodeResponseJson()['data'];
+
+        // First confirm teams are as configured
+        $response = $this->json(
+            'GET',
+            self::TEST_URL . '/' . $dpsId,
+            [],
+            $this->header,
+        );
+
+        $response->assertStatus(200);
+
+        $content = $response->decodeResponseJson()['data'];
+
+        $this->assertTrue(count($content['teams']) === 3);
+
+        foreach ($content['teams'] as $team) {
+            $this->assertTrue(in_array($team['id'], $payload['team_ids']));
+        }
+
+        $payload['team_ids'] = [ 2, 3 ];
+        // Now re-associate team ids
+        $response = $this->json(
+            'PUT',
+            self::TEST_URL . '/' . $dpsId,
+            $payload,
+            $this->header,
+        );
+
+        $response->assertStatus(200);
+
+        $response = $this->json(
+            'GET',
+            self::TEST_URL . '/' . $dpsId,
+            [],
+            $this->header,
+        );
+
+        $content = $response->decodeResponseJson()['data'];
+
+        $this->assertTrue(count($content['teams']) === 2);
+
+        foreach ($content['teams'] as $team) {
+            $this->assertTrue(in_array($team['id'], $payload['team_ids']));
+        }
+
+    }
+}

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -74,7 +74,7 @@ class DataCustodianNetworkTest extends TestCase
         ]);
     }
 
-    public function test_get_all_data_provider_colls_with_success(): void
+    public function test_get_all_data_custodian_networks_with_success(): void
     {
         $response = $this->json('GET', self::TEST_URL, [], $this->header);
 
@@ -109,7 +109,7 @@ class DataCustodianNetworkTest extends TestCase
         ]);
     }
 
-    public function test_get_data_provider_coll_by_id_with_success(): void
+    public function test_get_data_custodian_network_by_id_with_success(): void
     {
         $response = $this->json('GET', self::TEST_URL . '/1', [], $this->header);
 
@@ -136,30 +136,7 @@ class DataCustodianNetworkTest extends TestCase
         $this->assertTrue(($countTeams === 1));
     }
 
-
-    public function test_get_data_provider_coll_by_id_summary_with_success(): void
-    {
-        $response = $this->json('GET', self::TEST_URL . '/1/summary', [], $this->header);
-
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'message',
-            'data' => [
-                'id',
-                'name',
-                'img_url',
-                'summary',
-                'service',
-                'datasets',
-                'durs',
-                'tools',
-                'publications',
-                'collections',
-            ]
-        ]);
-    }
-
-    public function test_data_provider_collection_summary()
+    public function test_get_data_custodian_network_summary_with_success()
     {
         $id = DataProviderColl::where(['enabled' => 1])->first()->id;
         $response = $this->json('GET', self::TEST_URL . '/' . $id . '/summary', [], $this->header);
@@ -198,7 +175,7 @@ class DataCustodianNetworkTest extends TestCase
             ]);
     }
 
-    public function test_create_data_provider_coll_with_success(): void
+    public function test_create_data_custodian_network_with_success(): void
     {
 
         ECC::shouldReceive("indexDocument")
@@ -289,7 +266,7 @@ class DataCustodianNetworkTest extends TestCase
     }
 
 
-    public function test_delete_data_provider_coll_with_success(): void
+    public function test_delete_data_custodian_network_with_success(): void
     {
         ECC::shouldReceive("indexDocument")
             ->times(1);


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Add V2 DataCustodianNetworks endpoints to replace the V2 DataProviderColls endpoints.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7088

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
