### PR TITLE
fix(GAT-7522): apply restrictions to cohort request endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1303,8 +1303,8 @@ class CohortRequestController extends Controller
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
-        // Check that either the user has the cohort.read permission, or is asking only for their own record.
-        if (!(($jwtUser['id'] === $id) || in_array("cohort.read", $input['jwt_user']['role_perms']['extra']['perms']))) {
+        // Check that the user is asking only for their own record.
+        if (!($jwtUser['id'] === $id)) {
             throw new UnauthorizedException();
         }
 

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -18,6 +18,7 @@ use Illuminate\Http\JsonResponse;
 use App\Models\CohortRequestHasLog;
 use App\Http\Controllers\Controller;
 use App\Http\Traits\HubspotContacts;
+use App\Exceptions\UnauthorizedException;
 use App\Models\CohortRequestHasPermission;
 use App\Http\Requests\CohortRequest\GetCohortRequest;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -1262,7 +1263,7 @@ class CohortRequestController extends Controller
 
     /* @OA\Get(
         *    path="/api/v1/cohort_requests/user/{id}",
-        *    operationId="fetch_cohort_requests_by_usr",
+        *    operationId="fetch_cohort_requests_by_user",
         *    tags={"Cohort Requests"},
         *    summary="CohortRequestController@byUser",
         *    description="Returns cohort request for given user ID",
@@ -1301,6 +1302,12 @@ class CohortRequestController extends Controller
     {
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        // Check that either the user has the cohort.read permission, or is asking only for their own record.
+        if (!(($jwtUser['id'] === $id) || in_array("cohort.read", $input['jwt_user']['role_perms']['extra']['perms']))) {
+            throw new UnauthorizedException();
+        }
+
         try {
             $cohortRequest = CohortRequest::where('user_id', (int)$id)->first();
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -2478,10 +2478,12 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,cohort.read',
         ],
         'constraint' => [],
     ],
     [
+        // User needs access - used in button (many places) and form - so this is handled inside the endpoint
         'name' => 'cohort_requests_user',
         'method' => 'get',
         'path' => '/cohort_requests/user/{id}',
@@ -2513,6 +2515,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,cohort.read',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -2541,6 +2544,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'check.access:permissions,cohort.update',
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -2554,6 +2558,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'check.access:permissions,cohort.delete',
         ],
         'constraint' => [
             'id' => '[0-9]+',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Lock down several cohort_requests endpoints so that only cohort admin can use them, and lock down the endpoint for a given user's cohort rewuest so only the user can use it.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7522

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
