### PR TITLE
fix(GAT-7233): Fix deleteDataset for elastic observer

### DIFF
--- a/app/MetadataManagementController/MetadataManagementController.php
+++ b/app/MetadataManagementController/MetadataManagementController.php
@@ -179,13 +179,15 @@ class MetadataManagementController
             if (!$dataset) {
                 throw new Exception('Dataset with id=' . $id . ' cannot be found');
             }
-            $dataset->deleted_at = Carbon::now();
 
             // maintain compatibility with v1 (set status to archived) while supporting v2 (don't set status)
             if ($setToArchived) {
+                $dataset->deleted_at = Carbon::now();
                 $dataset->status = Dataset::STATUS_ARCHIVED;
+                $dataset->save();
+            } else {
+                $dataset->delete();
             }
-            $dataset->save();
 
             foreach ($dataset->versions as $metadata) {
                 $metadata->deleted_at = Carbon::now();


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Trying to DELETE from the v2 endpoints was throwing a "dataset not found" exception because the `MMC::deleteDataset` method triggered the `update` action of the Observer rather than the `delete`.  This change continues the support for v1 archiving behaviour but updates delete so that it actually deletes. 

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
