### PR TITLE
fix(GAT-7264): Dataset relationship not showing on Analysis Script & Software on the landing page

### DIFF
--- a/app/Http/Controllers/Api/V1/ToolController.php
+++ b/app/Http/Controllers/Api/V1/ToolController.php
@@ -324,6 +324,18 @@ class ToolController extends Controller
      *       example="1",
      *       @OA\Schema( type="integer", description="tool id" ),
      *    ),
+     *    @OA\Parameter(
+     *       name="view_type",
+     *       in="query",
+     *       description="Query flag to show full tool data or a trimmed version (defaults to full).",
+     *       required=false,
+     *       @OA\Schema(
+     *          type="string",
+     *          default="full",
+     *          description="Flag to show all data ('full') or trimmed data ('mini')"
+     *       ),
+     *       example="full"
+     *    ),
      *    @OA\Response(
      *       response="200",
      *       description="Success response",
@@ -352,8 +364,11 @@ class ToolController extends Controller
     {
         list($userId, $teamId) = $this->getAccessorUserAndTeam($request);
 
+        $viewType = $request->query('view_type', 'full');
+        $trimmed = $viewType === 'mini';
+
         try {
-            $tool = $this->getToolById($id, true);
+            $tool = $this->getToolById($id, true, $trimmed);
 
             Auditor::log([
                 'user_id' => $userId,
@@ -1082,7 +1097,7 @@ class ToolController extends Controller
         }
     }
 
-    private function getToolById(int $toolId, bool $onlyActive = false)
+    private function getToolById(int $toolId, bool $onlyActive = false, bool $trimmed = false)
     {
         $tool = Tool::with([
             'user',
@@ -1108,6 +1123,18 @@ class ToolController extends Controller
                 }
             },
             'category',
+            'versions' => function ($query) use ($trimmed) {
+                $query->whereHas('dataset', fn ($q) => $q->where('status', 'ACTIVE'));
+                $query->when($trimmed, function ($q) {
+                    $q->selectRaw('
+                        dataset_versions.id,dataset_versions.dataset_id,
+                        short_title as shortTitle,
+                        CONVERT(JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.populationSize")), SIGNED) as populationSize,
+                        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.datasetType")) as datasetType,
+                        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.publisher.name")) as dataCustodian
+                    ');
+                });
+            },
         ])
         ->withTrashed()
         ->where(['id' => $toolId])

--- a/app/Http/Controllers/Api/V2/TeamToolController.php
+++ b/app/Http/Controllers/Api/V2/TeamToolController.php
@@ -248,6 +248,18 @@ class TeamToolController extends Controller
      *          description="tool id",
      *       ),
      *    ),
+     *    @OA\Parameter(
+     *       name="view_type",
+     *       in="query",
+     *       description="Query flag to show full tool data or a trimmed version (defaults to full).",
+     *       required=false,
+     *       @OA\Schema(
+     *          type="string",
+     *          default="full",
+     *          description="Flag to show all data ('full') or trimmed data ('mini')"
+     *       ),
+     *       example="full"
+     *    ),
      *    @OA\Response(
      *       response="200",
      *       description="Success response",
@@ -289,8 +301,11 @@ class TeamToolController extends Controller
     {
         $this->checkAccess($request->all(), $teamId, null, 'team', $request->header());
 
+        $viewType = $request->query('view_type', 'full');
+        $trimmed = $viewType === 'mini';
+
         try {
-            $tool = $this->getToolById($id, teamId: $teamId, onlyActiveRelated: true);
+            $tool = $this->getToolById($id, teamId: $teamId, onlyActiveRelated: true, trimmed: $trimmed);
 
             Auditor::log([
                 'action_type' => 'GET',

--- a/app/Http/Controllers/Api/V2/UserToolController.php
+++ b/app/Http/Controllers/Api/V2/UserToolController.php
@@ -234,6 +234,18 @@ class UserToolController extends Controller
      *       example="1",
      *       @OA\Schema( type="integer", description="tool id" ),
      *    ),
+     *    @OA\Parameter(
+     *       name="view_type",
+     *       in="query",
+     *       description="Query flag to show full tool data or a trimmed version (defaults to full).",
+     *       required=false,
+     *       @OA\Schema(
+     *          type="string",
+     *          default="full",
+     *          description="Flag to show all data ('full') or trimmed data ('mini')"
+     *       ),
+     *       example="full"
+     *    ),
      *    @OA\Response(
      *       response="200",
      *       description="Success response",
@@ -267,8 +279,11 @@ class UserToolController extends Controller
     {
         $this->checkAccess($request->all(), null, $userId, 'user');
 
+        $viewType = $request->query('view_type', 'full');
+        $trimmed = $viewType === 'mini';
+
         try {
-            $tool = $this->getToolById($id, userId: $userId, onlyActiveRelated: true);
+            $tool = $this->getToolById($id, userId: $userId, onlyActiveRelated: true, trimmed: $trimmed);
 
             Auditor::log([
                 'action_type' => 'GET',

--- a/app/Http/Traits/ToolsV2Helper.php
+++ b/app/Http/Traits/ToolsV2Helper.php
@@ -23,7 +23,7 @@ use App\Models\ToolHasProgrammingLanguage;
 
 trait ToolsV2Helper
 {
-    public function getToolById(int $toolId, ?int $teamId = null, ?int $userId = null, ?bool $onlyActive = false, ?bool $onlyActiveRelated = false)
+    public function getToolById(int $toolId, ?int $teamId = null, ?int $userId = null, ?bool $onlyActive = false, ?bool $onlyActiveRelated = false, ?bool $trimmed = false)
     {
         $tool = Tool::with([
             'user',
@@ -49,6 +49,18 @@ trait ToolsV2Helper
                 }
             },
             'category',
+            'versions' => function ($query) use ($trimmed) {
+                $query->whereHas('dataset', fn ($q) => $q->where('status', 'ACTIVE'));
+                $query->when($trimmed, function ($q) {
+                    $q->selectRaw('
+                        dataset_versions.id,dataset_versions.dataset_id,
+                        short_title as shortTitle,
+                        CONVERT(JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.populationSize")), SIGNED) as populationSize,
+                        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.datasetType")) as datasetType,
+                        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(dataset_versions.metadata), "$.metadata.summary.publisher.name")) as dataCustodian
+                    ');
+                });
+            },
         ])
         ->where(['id' => $toolId])
         ->when($teamId, function ($query) use ($teamId) {

--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -151,7 +151,7 @@ class Tool extends Model
     /**
      * Retrieve versions associated with this tool
      */
-    public function versions()
+    public function versions(): BelongsToMany
     {
         return $this->belongsToMany(DatasetVersion::class, 'dataset_version_has_tool', 'tool_id', 'dataset_version_id');
     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Add reduced dataset version values to all tool controllers.
Must be merged in parallel with https://github.com/HDRUK/gateway-web/pull/1250

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7264

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
