### PR TITLE
feat(GAT-7330): Data migration for changed archiving behaviour

### DIFF
--- a/app/Console/Commands/CompareGAT7330.php
+++ b/app/Console/Commands/CompareGAT7330.php
@@ -2,12 +2,8 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Dur;
-use App\Models\Tool;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
-use App\Models\Collection;
-use App\Models\Publication;
 
 use Illuminate\Console\Command;
 
@@ -52,11 +48,10 @@ class CompareGAT7330 extends Command
                     $dataset = Dataset::where('id', $dv->dataset_id)->first();
                     $teamId = $dataset->team_id;
                 }
-            }
-            else {
+            } else {
                 $teamId = $entity->team_id ?? "";
             }
-            
+
             $entityResultString = $entity->type . " | " . $entity->id . " | " . $teamId . " | " . ($entity->user_id ?? "") . " | ";
             $difference = false;
             $match = array_filter($json_post, function ($val) use ($entity) {

--- a/app/Console/Commands/MigrateGAT7330.php
+++ b/app/Console/Commands/MigrateGAT7330.php
@@ -20,7 +20,6 @@ use App\Models\Dur;
 use App\Models\Publication;
 use App\Models\Tool;
 
-
 class MigrateGAT7330 extends Command
 {
     /**
@@ -70,7 +69,7 @@ class MigrateGAT7330 extends Command
         Collection::onlyTrashed()->where('status', 'ARCHIVED')->restore();
         Collection::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
 
-        // DatasetVersions: restore only the latest version of a given dataset if that version has been deleted. 
+        // DatasetVersions: restore only the latest version of a given dataset if that version has been deleted.
         // We thus keep old versions deleted, but DatasetVersions are moved to the new archiving behaviour.
         $datasets = Dataset::withTrashed()->get();
         foreach ($datasets as $dataset) {

--- a/app/Console/Commands/MigrateGAT7330.php
+++ b/app/Console/Commands/MigrateGAT7330.php
@@ -44,8 +44,6 @@ class MigrateGAT7330 extends Command
     {
         // For relationships, if deleted then remove. If not deleted, then keep.
         // Most have a deleted_at.
-        // dataset_has_tools does not, for some reason - but is empty on dev, so is it unused alongside dataset_version_has_tool?
-
 
         /** CollectionHasX */
         CollectionHasDatasetVersion::onlyTrashed()->forceDelete();

--- a/app/Console/Commands/MigrateGAT7330.php
+++ b/app/Console/Commands/MigrateGAT7330.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\CollectionHasDatasetVersion;
+use App\Models\CollectionHasDur;
+use App\Models\CollectionHasPublication;
+use App\Models\CollectionHasTool;
+use App\Models\DatasetVersionHasTool;
+use App\Models\DurHasDatasetVersion;
+use App\Models\DurHasPublication;
+use App\Models\DurHasTool;
+use App\Models\PublicationHasDatasetVersion;
+use App\Models\PublicationHasTool;
+use App\Models\Collection;
+use App\Models\Dataset;
+use App\Models\Dur;
+use App\Models\Publication;
+use App\Models\Tool;
+
+
+class MigrateGAT7330 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:migrate-archiving-behaviour-gat-7330';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run this command to migrate data entities to use the "new" archiving/deletion behaviour';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // For relationships, if deleted then remove. If not deleted, then keep.
+        // Most have a deleted_at.
+        // dataset_has_tools does not, for some reason - but is empty on dev, so is it unused alongside dataset_version_has_tool?
+
+
+        /** CollectionHasX */
+        CollectionHasDatasetVersion::onlyTrashed()->forceDelete();
+        CollectionHasDur::onlyTrashed()->forceDelete();
+        CollectionHasPublication::onlyTrashed()->forceDelete();
+        CollectionHasTool::onlyTrashed()->forceDelete();
+
+        /** DatasetVersionHasX */
+        DatasetVersionHasTool::onlyTrashed()->forceDelete();
+
+        /** DurHasX */
+        DurHasDatasetVersion::onlyTrashed()->forceDelete();
+        DurHasPublication::onlyTrashed()->forceDelete();
+        DurHasTool::onlyTrashed()->forceDelete();
+
+        /** PublicationHasX */
+        PublicationHasDatasetVersion::onlyTrashed()->forceDelete();
+        PublicationHasTool::onlyTrashed()->forceDelete();
+
+
+        // For entities, if archived and soft-deleted, then move to only archived
+        // If archived and not soft-deleted, keep as-is.
+        // If soft-deleted but not archived, then more to archived and deleted.
+        Collection::onlyTrashed()->where('status', 'ARCHIVED')->restore();
+        Collection::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
+
+        Dataset::onlyTrashed()->where('status', 'ARCHIVED')->restore();
+        Dataset::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
+
+        Dur::onlyTrashed()->where('status', 'ARCHIVED')->restore();
+        Dur::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
+
+        Publication::onlyTrashed()->where('status', 'ARCHIVED')->restore();
+        Publication::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
+
+        Tool::onlyTrashed()->where('status', 'ARCHIVED')->restore();
+        Tool::onlyTrashed()->where('status', '!=', 'ARCHIVED')->update(['status' => 'ARCHIVED']);
+    }
+}

--- a/app/Console/Commands/PostcheckGAT7330.php
+++ b/app/Console/Commands/PostcheckGAT7330.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dur;
+use App\Models\Tool;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Collection;
+use App\Models\Publication;
+
+use Illuminate\Console\Command;
+
+class PostcheckGAT7330 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:postcheck-gat-7330';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run this command to output a summary of the existing entities and their relationships under the "new" archiving/deletion behaviour, for comparison with the output of the "precheck" command.';
+
+    private function classnameFromClass($class)
+    {
+        $exp = explode('\\', $class);
+        return end($exp);
+    }
+
+    private function entityRow(string $entity)
+    {
+        return [
+                $this->classnameFromClass($entity),
+                $entity::withTrashed()->count(),
+                $entity::onlyTrashed()->count(),
+                $entity::withTrashed()->where('status', 'ACTIVE')->count(),
+                $entity::onlyTrashed()->where('status', 'ACTIVE')->count(),
+                $entity::withTrashed()->where('status', 'DRAFT')->count(),
+                $entity::onlyTrashed()->where('status', 'DRAFT')->count(),
+                $entity::withTrashed()->where('status', 'ARCHIVED')->count(),
+                $entity::onlyTrashed()->where('status', 'ARCHIVED')->count(),
+        ];
+    }
+
+    private function classToIdString(string $className)
+    {
+        // Split the string into an array based on uppercase letters
+        $words = preg_split('/(?=[A-Z])/', $className, -1, PREG_SPLIT_NO_EMPTY);
+        
+        // Join the array elements with an underscore
+        $snakeCase = implode('_', $words);
+        
+        // Convert the resulting string to lowercase
+        $snakeCase = strtolower($snakeCase);
+        
+        return $snakeCase . '_id';
+    }
+
+    private function idStringToClass(string $idString)
+    {
+        // Remove '_id' suffix
+        $string = substr($idString,0,-3);
+        
+        // Split by underscores
+        $words = explode('_', $string);
+        
+        // Convert the resulting strings to Capitalised case
+        $capitalisedWords = array_map('ucfirst', $words);
+
+        // Glue strings together
+        return implode('', $capitalisedWords);
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // We run a series of checks, from highest level to most granular, outputting data and stats at each point to build up a picture of the "before"
+        // state of all entities and their relationships
+
+        // For each entity type,
+        // - get a count of how many are active/draft/archived/?deleted
+
+        // - split by team and user, get a count of how many are active/draft/archived/?deleted
+
+        // - output a list of each entity and its self-reported links to other entities
+
+
+        // Overview table of entities by status:
+        $headers = ['Entity', 'total', 'of which deleted', 'active', 'of which deleted', 'draft', 'of which deleted (should all be zero)', 'archived', 'of which deleted (should all be zero)'];
+        $overviewEntities = [Collection::class, Dataset::class, Dur::class, Publication::class, Tool::class];
+
+        echo("\n\n-----------------------------------------------------\n  Summary of entities by status and deleted_at value.\n-----------------------------------------------------\n");
+
+        $data = array_map('self::entityRow', $overviewEntities);
+        $this->table($headers, $data);
+
+        echo("\n\n---------------------------------------------------\n  Summary of entities with inconsistencies.\n---------------------------------------------------\n");
+
+        // Run checks - are all archived = soft-deleted?
+        $headers = ['Entity', 'deleted not archived (should be none)', 'archived not deleted (should be all)'];
+        $data = array_map(function ($entity) {
+            return [
+                $entity,
+                json_encode(array_column($entity::onlyTrashed()->where('status', '!=', 'archived')->select('id')->get()->toArray(), 'id')),
+                json_encode(array_column($entity::where('status', '=', 'archived')->select('id')->get()->toArray(), 'id')),
+            ];
+        }, $overviewEntities);
+        $this->table($headers, $data);
+
+
+        // var_dump($this->classnameFromClass(Collection::class));
+
+        echo("\n\n---------------------------------------------------\n  Summary of relationships (should match before).\n---------------------------------------------------\n");
+
+        // Overview table of Has relations
+        $entityTypes = [Collection::class, DatasetVersion::class, Dur::class, Publication::class, Tool::class];
+
+        $hasRelations = [
+            'Collection' => [
+                'CollectionHasDatasetVersion' => 'dataset_version_id',
+                'CollectionHasDur' => 'dur_id',
+                'CollectionHasPublication' => 'publication_id',
+                'CollectionHasTool' => 'tool_id',
+            ],
+            'DatasetVersion' => [
+                'CollectionHasDatasetVersion' => 'collection_id',
+                'DatasetVersionHasTool' => 'tool_id',
+                'DurHasDatasetVersion' => 'dur_id',
+                'PublicationHasDatasetVersion' => 'publication_id',
+            ],
+            'Dur' => [
+                'CollectionHasDur' => 'collection_id',
+                'DurHasDatasetVersion' => 'dataset_version_id',
+                'DurHasPublication' => 'publication_id',
+                'DurHasTool' => 'tool_id',
+            ],
+            'Publication' => [
+                'CollectionHasPublication' => 'collection_id',
+                'DurHasPublication' => 'dur_id',
+                'PublicationHasDatasetVersion' => 'dataset_version_id',
+                'PublicationHasTool' => 'tool_id',
+            ],
+            'Tool' => [
+                'CollectionHasTool' => 'collection_id',
+                'DatasetVersionHasTool' => 'dataset_version_id',
+                'DurHasTool' => 'dur_id',
+                'PublicationHasTool' => 'publication_id',
+            ],
+        ];
+
+        $hasArray = [];
+        foreach ($entityTypes as $entity1) {
+            $hasRow = [$entity1];
+            foreach ($entityTypes as $entity2) {
+                $hasClassName = $this->classnameFromClass($entity1) . 'Has' . $this->classnameFromClass($entity2);
+                if (class_exists('App\\Models\\' . $hasClassName)) {
+                    $test = new ('App\\Models\\' . $hasClassName)();
+                    $hasRow[] = $test->count();
+                } else {
+                    $hasRow[] = '';
+                }
+            }
+            $hasArray[] = $hasRow;
+        }
+        $hasHeaders = ['', ...$entityTypes];
+        $this->table($hasHeaders, $hasArray);
+
+
+
+        // For each entity type, print out all its entries, including status and its links to other entities. We want to ultimately
+        // be able to say "this is what a user sees on the Gateway" in each scenario and have it match.
+
+        echo("\n\n---------------------------------------------------\n  Complete record of all relationships by entity (should match before).\n---------------------------------------------------\n");
+
+        $headerRow = ['entity type', 'entity id', 'relation type', 'relation count', 'relationId'];
+
+        $data = [];
+        foreach ($entityTypes as $entityType) {
+            $entitiesOfThisType = $entityType::select('id')->get();
+            foreach ($entitiesOfThisType as $entity) {
+                foreach ($hasRelations[$this->classnameFromClass($entityType)] as $relation => $idName) {
+                    $relationEntries = array_column(
+                        (new ('App\\Models\\' . $relation)())
+                        ::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
+                        ->select($idName)
+                        ->get()->toArray(), $idName);
+                    
+                    $relatedEntityType = $this->idStringToClass($idName);
+
+                    if ($relatedEntityType != 'DatasetVersion') {
+                        $relatedActiveEntities = (new ('App\\Models\\' . $relatedEntityType))::whereIn('id', $relationEntries)->where('status', 'ACTIVE')->select('id')->get()->toArray();
+                    } else
+                    {
+                        $datasetVersions = (new ('App\\Models\\' . $relatedEntityType))::whereIn('id', $relationEntries)->select('id', 'dataset_id')->get()->toArray();
+                        $active = [];
+                        foreach ($datasetVersions as $datasetVersion) {
+                            $dataset = Dataset::where('id', $datasetVersion['dataset_id'])->first();
+                            if ($dataset->status = ['ACTIVE']) {
+                                $active[] = $datasetVersion;
+                            }
+                        }
+                        $relatedActiveEntities = $active;
+                    }
+                    $relatedActiveEntityIds = array_column($relatedActiveEntities, 'id');
+                    sort($relatedActiveEntityIds);
+
+                    $data[] = [$this->classnameFromClass($entityType), $entity->id, $relation, count($relatedActiveEntities), json_encode($relatedActiveEntityIds)];
+                }
+            }
+        }
+
+        $this->table($headerRow, $data);
+    }
+}

--- a/app/Console/Commands/PostcheckGAT7330.php
+++ b/app/Console/Commands/PostcheckGAT7330.php
@@ -182,13 +182,13 @@ class PostcheckGAT7330 extends Command
         $csvData = [];
         foreach ($entityTypes as $entityType) {
             if (in_array($entityType, [Collection::class, Publication::class])) {
-                $entitiesOfThisType = $entityType::orderBy('id')->select('id', 'team_id')->get();
+                $entitiesOfThisType = $entityType::orderBy('id')->select(['id', 'team_id'])->get();
             }
             elseif (in_array($entityType, [DatasetVersion::class])) {
                 $entitiesOfThisType = $entityType::orderBy('id')->select('id')->get();
             }
             else {
-                $entitiesOfThisType = $entityType::orderBy('id')->select('id', 'team_id', 'user_id')->get();
+                $entitiesOfThisType = $entityType::orderBy('id')->select(['id', 'team_id', 'user_id'])->get();
             }
             foreach ($entitiesOfThisType as $entity) {
                 $csvDataRow = ['type' => null, 'id' => null, 'Collection' => null, 'Dur' => null, 'DatasetVersion' => null, 'Publication' => null, 'Tool' => null];

--- a/app/Console/Commands/PostcheckGAT7330.php
+++ b/app/Console/Commands/PostcheckGAT7330.php
@@ -52,24 +52,24 @@ class PostcheckGAT7330 extends Command
     {
         // Split the string into an array based on uppercase letters
         $words = preg_split('/(?=[A-Z])/', $className, -1, PREG_SPLIT_NO_EMPTY);
-        
+
         // Join the array elements with an underscore
         $snakeCase = implode('_', $words);
-        
+
         // Convert the resulting string to lowercase
         $snakeCase = strtolower($snakeCase);
-        
+
         return $snakeCase . '_id';
     }
 
     private function idStringToClass(string $idString)
     {
         // Remove '_id' suffix
-        $string = substr($idString,0,-3);
-        
+        $string = substr($idString, 0, -3);
+
         // Split by underscores
         $words = explode('_', $string);
-        
+
         // Convert the resulting strings to Capitalised case
         $capitalisedWords = array_map('ucfirst', $words);
 
@@ -183,11 +183,9 @@ class PostcheckGAT7330 extends Command
         foreach ($entityTypes as $entityType) {
             if (in_array($entityType, [Collection::class, Publication::class])) {
                 $entitiesOfThisType = $entityType::orderBy('id')->select(['id', 'team_id'])->get();
-            }
-            elseif (in_array($entityType, [DatasetVersion::class])) {
+            } elseif (in_array($entityType, [DatasetVersion::class])) {
                 $entitiesOfThisType = $entityType::orderBy('id')->select('id')->get();
-            }
-            else {
+            } else {
                 $entitiesOfThisType = $entityType::orderBy('id')->select(['id', 'team_id', 'user_id'])->get();
             }
             foreach ($entitiesOfThisType as $entity) {
@@ -199,17 +197,17 @@ class PostcheckGAT7330 extends Command
 
                 foreach ($hasRelations[$this->classnameFromClass($entityType)] as $relation => $idName) {
                     $relationEntries = array_column(
-                        (new ('App\\Models\\' . $relation)())
-                        ::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
+                        (new ('App\\Models\\' . $relation)())::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
                         ->select($idName)
-                        ->get()->toArray(), $idName);
-                    
+                        ->get()->toArray(),
+                        $idName
+                    );
+
                     $relatedEntityType = $this->idStringToClass($idName);
 
                     if ($relatedEntityType != 'DatasetVersion') {
                         $relatedActiveEntities = (new ('App\\Models\\' . $relatedEntityType))::whereIn('id', $relationEntries)->where('status', 'ACTIVE')->select('id')->get()->toArray();
-                    } else
-                    {
+                    } else {
                         $datasetVersions = (new ('App\\Models\\' . $relatedEntityType))::whereIn('id', $relationEntries)->select('id', 'dataset_id')->get()->toArray();
                         $active = [];
                         foreach ($datasetVersions as $datasetVersion) {

--- a/app/Console/Commands/PostcheckGAT7330.php
+++ b/app/Console/Commands/PostcheckGAT7330.php
@@ -115,9 +115,6 @@ class PostcheckGAT7330 extends Command
         }, $overviewEntities);
         $this->table($headers, $data);
 
-
-        // var_dump($this->classnameFromClass(Collection::class));
-
         echo("\n\n---------------------------------------------------\n  Summary of relationships (should match before).\n---------------------------------------------------\n");
 
         // Overview table of Has relations
@@ -173,8 +170,6 @@ class PostcheckGAT7330 extends Command
         $hasHeaders = ['', ...$entityTypes];
         $this->table($hasHeaders, $hasArray);
 
-
-
         // For each entity type, print out all its entries, including status and its links to other entities. We want to ultimately
         // be able to say "this is what a user sees on the Gateway" in each scenario and have it match.
 
@@ -196,7 +191,6 @@ class PostcheckGAT7330 extends Command
                 $entitiesOfThisType = $entityType::orderBy('id')->select('id', 'team_id', 'user_id')->get();
             }
             foreach ($entitiesOfThisType as $entity) {
-                // var_dump($entity);
                 $csvDataRow = ['type' => null, 'id' => null, 'Collection' => null, 'Dur' => null, 'DatasetVersion' => null, 'Publication' => null, 'Tool' => null];
                 $csvDataRow['type'] = $this->classnameFromClass($entityType);
                 $csvDataRow['id'] = $entity->id;
@@ -232,7 +226,6 @@ class PostcheckGAT7330 extends Command
                     $data[] = [$this->classnameFromClass($entityType), $entity->id, $relation, count($relatedActiveEntities), json_encode($relatedActiveEntityIds)];
                     $csvDataRow[$relatedEntityType] = (is_null($relatedActiveEntityIds) || empty($relatedActiveEntityIds)) ? null : json_encode($relatedActiveEntityIds);
                 }
-                // var_dump($csvDataRow);
                 $csvData[] = $csvDataRow;
             }
         }

--- a/app/Console/Commands/PrecheckGAT7330.php
+++ b/app/Console/Commands/PrecheckGAT7330.php
@@ -52,24 +52,24 @@ class PrecheckGAT7330 extends Command
     {
         // Split the string into an array based on uppercase letters
         $words = preg_split('/(?=[A-Z])/', $className, -1, PREG_SPLIT_NO_EMPTY);
-        
+
         // Join the array elements with an underscore
         $snakeCase = implode('_', $words);
-        
+
         // Convert the resulting string to lowercase
         $snakeCase = strtolower($snakeCase);
-        
+
         return $snakeCase . '_id';
     }
 
     private function idStringToClass(string $idString)
     {
         // Remove '_id' suffix
-        $string = substr($idString,0,-3);
-        
+        $string = substr($idString, 0, -3);
+
         // Split by underscores
         $words = explode('_', $string);
-        
+
         // Convert the resulting strings to Capitalised case
         $capitalisedWords = array_map('ucfirst', $words);
 
@@ -183,11 +183,9 @@ class PrecheckGAT7330 extends Command
         foreach ($entityTypes as $entityType) {
             if (in_array($entityType, [Collection::class, Publication::class])) {
                 $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select(['id', 'team_id'])->get();
-            }
-            elseif (in_array($entityType, [DatasetVersion::class])) {
+            } elseif (in_array($entityType, [DatasetVersion::class])) {
                 $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select('id')->get();
-            }
-            else {
+            } else {
                 $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select(['id', 'team_id', 'user_id'])->get();
             }
             foreach ($entitiesOfThisType as $entity) {
@@ -201,9 +199,8 @@ class PrecheckGAT7330 extends Command
                 }
                 $csvDataRow['user_id'] = $entity->user_id ?? null;
                 foreach ($hasRelations[$this->classnameFromClass($entityType)] as $relation => $idName) {
-                    $relationEntries = 
-                        (new ('App\\Models\\' . $relation)())
-                        ::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
+                    $relationEntries =
+                        (new ('App\\Models\\' . $relation)())::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
                         ->get()
                         ->toArray();
                     $relatedEntryIds = array_column($relationEntries, $idName);

--- a/app/Console/Commands/PrecheckGAT7330.php
+++ b/app/Console/Commands/PrecheckGAT7330.php
@@ -115,9 +115,6 @@ class PrecheckGAT7330 extends Command
         }, $overviewEntities);
         $this->table($headers, $data);
 
-
-        // var_dump($this->classnameFromClass(Collection::class));
-
         echo("\n\n---------------------------------------------------\n  Summary of relationships.\n---------------------------------------------------\n");
 
         // Overview table of Has relations
@@ -172,8 +169,6 @@ class PrecheckGAT7330 extends Command
         }
         $hasHeaders = ['', ...$entityTypes];
         $this->table($hasHeaders, $hasArray);
-
-
 
         // For each entity type, print out all its entries, including status and its links to other entities. We want to ultimately
         // be able to say "this is what a user sees on the Gateway" in each scenario and have it match.

--- a/app/Console/Commands/PrecheckGAT7330.php
+++ b/app/Console/Commands/PrecheckGAT7330.php
@@ -181,13 +181,13 @@ class PrecheckGAT7330 extends Command
         $data = [];
         foreach ($entityTypes as $entityType) {
             if (in_array($entityType, [Collection::class, Publication::class])) {
-                $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select('id', 'team_id')->get();
+                $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select(['id', 'team_id'])->get();
             }
             elseif (in_array($entityType, [DatasetVersion::class])) {
                 $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select('id')->get();
             }
             else {
-                $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select('id', 'team_id', 'user_id')->get();
+                $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select(['id', 'team_id', 'user_id'])->get();
             }
             foreach ($entitiesOfThisType as $entity) {
                 $csvDataRow = ['type' => null, 'id' => null, 'team_id' => null, 'user_id' => null, 'Collection' => null, 'Dur' => null, 'DatasetVersion' => null, 'Publication' => null, 'Tool' => null];

--- a/app/Console/Commands/PrecheckGAT7330.php
+++ b/app/Console/Commands/PrecheckGAT7330.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dur;
+use App\Models\Tool;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Collection;
+use App\Models\Publication;
+
+use Illuminate\Console\Command;
+
+class PrecheckGAT7330 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:precheck-gat-7330';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run this command to output a summary of the existing entities and their relationships under the "old" archiving/deletion behaviour';
+
+    private function classnameFromClass($class)
+    {
+        $exp = explode('\\', $class);
+        return end($exp);
+    }
+
+    private function entityRow(string $entity)
+    {
+        return [
+                $this->classnameFromClass($entity),
+                $entity::withTrashed()->count(),
+                $entity::onlyTrashed()->count(),
+                $entity::withTrashed()->where('status', 'ACTIVE')->count(),
+                $entity::onlyTrashed()->where('status', 'ACTIVE')->count(),
+                $entity::withTrashed()->where('status', 'DRAFT')->count(),
+                $entity::onlyTrashed()->where('status', 'DRAFT')->count(),
+                $entity::withTrashed()->where('status', 'ARCHIVED')->count(),
+                $entity::onlyTrashed()->where('status', 'ARCHIVED')->count(),
+        ];
+    }
+
+    private function classToIdString(string $className)
+    {
+        // Split the string into an array based on uppercase letters
+        $words = preg_split('/(?=[A-Z])/', $className, -1, PREG_SPLIT_NO_EMPTY);
+        
+        // Join the array elements with an underscore
+        $snakeCase = implode('_', $words);
+        
+        // Convert the resulting string to lowercase
+        $snakeCase = strtolower($snakeCase);
+        
+        return $snakeCase . '_id';
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // We run a series of checks, from highest level to most granular, outputting data and stats at each point to build up a picture of the "before"
+        // state of all entities and their relationships
+
+        // For each entity type,
+        // - get a count of how many are active/draft/archived/?deleted
+
+        // - split by team and user, get a count of how many are active/draft/archived/?deleted
+
+        // - output a list of each entity and its self-reported links to other entities
+
+
+        // Overview table of entities by status:
+        $headers = ['Entity', 'total', 'of which deleted', 'active', 'of which deleted', 'draft', 'of which deleted', 'archived', 'of which deleted'];
+        $overviewEntities = [Collection::class, Dataset::class, Dur::class, Publication::class, Tool::class];
+
+        echo("\n\n-----------------------------------------------------\n  Summary of entities by status and deleted_at value.\n-----------------------------------------------------\n");
+
+        $data = array_map('self::entityRow', $overviewEntities);
+        $this->table($headers, $data);
+
+        echo("\n\n---------------------------------------------------\n  Summary of entities with inconsistencies.\n---------------------------------------------------\n");
+
+        // Run checks - are all archived = soft-deleted?
+        $headers = ['Entity', 'deleted not archived', 'archived not deleted'];
+        $data = array_map(function ($entity) {
+            return [
+                $entity,
+                json_encode(array_column($entity::onlyTrashed()->where('status', '!=', 'archived')->select('id')->get()->toArray(), 'id')),
+                json_encode(array_column($entity::where('status', '=', 'archived')->select('id')->get()->toArray(), 'id')),
+            ];
+        }, $overviewEntities);
+        $this->table($headers, $data);
+
+
+        // var_dump($this->classnameFromClass(Collection::class));
+
+        echo("\n\n---------------------------------------------------\n  Summary of relationships.\n---------------------------------------------------\n");
+
+        // Overview table of Has relations
+        $entityTypes = [Collection::class, DatasetVersion::class, Dur::class, Publication::class, Tool::class];
+
+        $hasRelations = [
+            'Collection' => [
+                'CollectionHasDatasetVersion' => 'dataset_version_id',
+                'CollectionHasDur' => 'dur_id',
+                'CollectionHasPublication' => 'publication_id',
+                'CollectionHasTool' => 'tool_id',
+            ],
+            'DatasetVersion' => [
+                'CollectionHasDatasetVersion' => 'collection_id',
+                'DatasetVersionHasTool' => 'tool_id',
+                'DurHasDatasetVersion' => 'dur_id',
+                'PublicationHasDatasetVersion' => 'publication_id',
+            ],
+            'Dur' => [
+                'CollectionHasDur' => 'collection_id',
+                'DurHasDatasetVersion' => 'dataset_version_id',
+                'DurHasPublication' => 'publication_id',
+                'DurHasTool' => 'tool_id',
+            ],
+            'Publication' => [
+                'CollectionHasPublication' => 'collection_id',
+                'DurHasPublication' => 'dur_id',
+                'PublicationHasDatasetVersion' => 'dataset_version_id',
+                'PublicationHasTool' => 'tool_id',
+            ],
+            'Tool' => [
+                'CollectionHasTool' => 'collection_id',
+                'DatasetVersionHasTool' => 'dataset_version_id',
+                'DurHasTool' => 'dur_id',
+                'PublicationHasTool' => 'publication_id',
+            ],
+        ];
+
+        $hasArray = [];
+        foreach ($entityTypes as $entity1) {
+            $hasRow = [$entity1];
+            foreach ($entityTypes as $entity2) {
+                $hasClassName = $this->classnameFromClass($entity1) . 'Has' . $this->classnameFromClass($entity2);
+                if (class_exists('App\\Models\\' . $hasClassName)) {
+                    $test = new ('App\\Models\\' . $hasClassName)();
+                    $hasRow[] = $test->count();
+                } else {
+                    $hasRow[] = '';
+                }
+            }
+            $hasArray[] = $hasRow;
+        }
+        $hasHeaders = ['', ...$entityTypes];
+        $this->table($hasHeaders, $hasArray);
+
+
+
+        // For each entity type, print out all its entries, including status and its links to other entities. We want to ultimately
+        // be able to say "this is what a user sees on the Gateway" in each scenario and have it match.
+
+        echo("\n\n---------------------------------------------------\n  Complete record of all relationships by entity.\n---------------------------------------------------\n");
+
+        $headerRow = ['entity type', 'entity id', 'relation type', 'relation count', 'relationId'];
+
+        $data = [];
+        foreach ($entityTypes as $entityType) {
+            $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select('id')->get();
+            foreach ($entitiesOfThisType as $entity) {
+                foreach ($hasRelations[$this->classnameFromClass($entityType)] as $relation => $idName) {
+                    $relationEntries = 
+                        (new ('App\\Models\\' . $relation)())
+                        ::where($this->classToIdString($this->classnameFromClass($entityType)), $entity->id)
+                        ->get()
+                        ->toArray();
+                    $relatedEntryIds = array_column($relationEntries, $idName);
+                    sort($relatedEntryIds);
+                    $data[] = [$this->classnameFromClass($entityType), $entity->id, $relation, count($relationEntries), json_encode($relatedEntryIds)];
+                }
+            }
+        }
+
+        $this->table($headerRow, $data);
+    }
+}

--- a/app/Console/Commands/PrecheckGAT7330.php
+++ b/app/Console/Commands/PrecheckGAT7330.php
@@ -179,6 +179,7 @@ class PrecheckGAT7330 extends Command
         $csvHeaderRow = ['entity type', 'id', 'Collection', 'Dur', 'DatasetVersion', 'Publication', 'Tool'];
 
         $data = [];
+        $csvData = [];
         foreach ($entityTypes as $entityType) {
             if (in_array($entityType, [Collection::class, Publication::class])) {
                 $entitiesOfThisType = $entityType::withTrashed()->orderBy('id')->select(['id', 'team_id'])->get();


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Adds 4 commands for use in migrating to the new archiving behaviour. See https://hdruk.atlassian.net/wiki/spaces/HDT/pages/3492544513/Entity+archiving+migration+-+impact+analysis for more details.

`app:precheck-gat-7330`: This generates a high-level overview of the data as it is and as the existing controllers understand it.

`app:migrate-archiving-behaviour-gat-7330`: This performs the data migration as detailed in the section above.

`app:postcheck-gat-7330`: This generates a high-level overview of the data after migration and as the new controllers understand it.

`app:compare-gat-7330 /location/of/precheck.json /location/of/postcheck.json`: Compares before and after to highlight data changes that may require investigation or communication.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7330

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Requires multiple commands to be run - see https://hdruk.atlassian.net/wiki/spaces/HDT/pages/3492544513/Entity+archiving+migration+-+impact+analysis for more details.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
