### PR TITLE
fix(GAT-7596): Fixes legacy bug preventing newly linked BHF datasets …

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1794,7 +1794,7 @@ class SearchController extends Controller
         foreach ($datasets as $dataset) {
             $datasetTitles[] = [
                 'title' => $dataset['metadata']['metadata']['summary']['shortTitle'],
-                'id' => $dataset['id'],
+                'id' => $dataset['dataset_id'],
             ];
 
         }


### PR DESCRIPTION
…from being clicked

## Screenshots (if relevant)

## Describe your changes
We discovered a legacy bug from the initial migration, whereby happenstance caused Dataset and DatasetVersion IDs to be identical. This prevents future updates to linkages pulling correctly.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7596

## Environment / Configuration changes (if applicable)
No.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
