### PR TITLE
feat(GAT-7556): Commands to retain cohort preprod users

### DIFF
--- a/app/Console/Commands/CohortPreprodUsersRestore.php
+++ b/app/Console/Commands/CohortPreprodUsersRestore.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CohortRequest;
+use App\Models\CohortRequestHasLog;
+use App\Models\CohortRequestHasPermission;
+use App\Models\CohortRequestLog;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class CohortPreprodUsersRestore extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cohort-preprod-users-restore';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Restore the users with preprod only access to cohort discovery from file.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        // Set all migrated requests to "BOTH" - because they will all have been migrated from prod
+        CohortRequest::where('request_status', 'APPROVED')
+            ->update([
+                'access_to_env' => 'BOTH'
+            ]);
+
+        // Load data from the file
+        $cohortUsersFile = Storage::disk('local')->get('cohort_preprod_users.json');
+        $cohortUsers = json_decode($cohortUsersFile, true);
+
+        foreach ($cohortUsers as $cohortUser) {
+            // Identify the new user id
+            if (is_null($cohortUser['user'])) {
+                echo 'Cohort request with id ' . $cohortUser['id'] . ' has no user - skipping.';
+                continue;
+            }
+            $userEmail = $cohortUser['user']['email'];
+            $matchUser = User::where('email', $userEmail)->first();
+
+            if ($matchUser) {
+                $cohortRequest = CohortRequest::where('user_id', $matchUser->id)->first();
+
+                if (!$cohortRequest) {
+                    $this->addCohortRequest($cohortUser, $matchUser->id);
+                    continue;
+                }
+
+                // If the user had a non-approved request on prod - override status with preprod value
+                if (($cohortRequest) && ($cohortRequest->request_status !== 'APPROVED')) {
+                    $cohortRequest->request_status = $cohortUser['request_status'];
+                    $cohortRequest->access_to_env = 'PREPROD';
+                    $cohortRequest->save();
+                }
+
+            } else {
+                $newUser = User::create($cohortUser['user']);
+                $this->addCohortRequest($cohortUser, $newUser->id);
+            }
+
+        }
+
+    }
+
+    private function addCohortRequest(array $cohortRequest, int $userId): void
+    {
+        $permission = Permission::where([
+            'name' => 'GENERAL_ACCESS',
+            'application' => 'cohort',
+        ])->first();
+
+        if (!$permission) {
+            echo 'Cohort access permission not found!';
+        }
+
+        $cohortRequest['user_id'] = $userId;
+        $cohortRequest['access_to_env'] = 'PREPROD';
+        $request = CohortRequest::create($cohortRequest);
+        CohortRequestHasPermission::create([
+            'cohort_request_id' => $request->id,
+            'permission_id' => $permission->id,
+        ]);
+
+        foreach ($cohortRequest['logs'] as $log) {
+            $log['user_id'] = $userId;
+            $newLog = CohortRequestLog::create($log);
+            CohortRequestHasLog::create([
+                'cohort_request_id' => $request->id,
+                'cohort_request_log_id' => $newLog->id
+            ]);
+        }
+
+    }
+}

--- a/app/Console/Commands/CohortPreprodUsersSave.php
+++ b/app/Console/Commands/CohortPreprodUsersSave.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CohortRequest;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Console\Command;
+
+class CohortPreprodUsersSave extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cohort-preprod-users-save';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Save a list of users with cohort discovery access on preprod to a file.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $cohortRequests = CohortRequest::with(['user', 'logs', 'permissions'])->get();
+        Storage::disk('local')->put('cohort_preprod_users.json', $cohortRequests);
+    }
+}

--- a/app/Models/CohortRequest.php
+++ b/app/Models/CohortRequest.php
@@ -33,6 +33,7 @@ class CohortRequest extends Model
         'created_at',
         'accept_declaration',
         'is_nhse_sde_approval',
+        'access_to_env',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_07_09_140813_apply-existing-admins-to-all-teams.php
+++ b/database/migrations/2025_07_09_140813_apply-existing-admins-to-all-teams.php
@@ -1,15 +1,12 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
 use App\Models\User;
 use App\Models\Team;
 use App\Models\TeamHasUser;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_07_10_124435_update_cohort_requests_table.php
+++ b/database/migrations/2025_07_10_124435_update_cohort_requests_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('cohort_requests', function (Blueprint $table) {
+            $table->string('access_to_env', 15)->default('NONE');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cohort_requests', function (Blueprint $table) {
+            $table->dropColumn('access_to_env');
+        });
+    }
+};


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-7556

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

Commands to be run on preprod:

```
php artisan app:cohort-preprod-users-save // before migrating prod data to preprod
php artisan app:cohort-preprod-users-restore // after migrating prod data to preprod
```

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
