### PR TITLE
fix(GAT-7599): Cannot view datasets after creation

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -405,6 +405,7 @@ class DatasetController extends Controller
     public function show(GetDataset $request, int $id): JsonResponse|BinaryFileResponse
     {
         try {
+
             $exportStructuralMetadata = $request->query('export', null);
 
             // Retrieve the dataset with collections, publications, and counts
@@ -576,7 +577,7 @@ class DatasetController extends Controller
         ->toArray();
 
         $datasetVersion = DatasetVersion::where('id', $datasetVersionId)->first();
-        $metadataLinkage = $datasetVersion['metadata']['metadata']['linkage']['datasetLinkage'];
+        $metadataLinkage = $datasetVersion['metadata']['metadata']['linkage']['datasetLinkage'] ?? [];
         $allTitles = [];
         foreach ($metadataLinkage as $linkageType => $link) {
             if (($link) && is_array($link)) {


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1928" height="730" alt="image" src="https://github.com/user-attachments/assets/793ea709-a1d3-4e34-a2d5-1b3d62659045" />

## Describe your changes
message": "foreach() argument must be of type array|object, null given",
    "details": {
        "exception": "Exception",
        "trace": [
            {
                "file": "/var/www/vendor/laravel/framework/src/Illuminate/Routing/Controller.php",
    "line": 54,
                "function": "show",
                "class": "App\\Http\\Controllers\\Api\\V1\\DatasetController",
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
