### PR TITLE
chore(GAT-7294): Add contextual logging

### DIFF
--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -18,6 +18,7 @@ use App\Models\TeamHasFederation;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Http;
 use App\Models\FederationHasNotification;
+use App\Http\Traits\LoggingContext;
 use App\Http\Traits\RequestTransformation;
 use App\Http\Requests\Federation\GetFederation;
 use App\Http\Requests\Federation\EditFederation;
@@ -29,6 +30,7 @@ use App\Http\Requests\Federation\UpdateFederation;
 class FederationController extends Controller
 {
     use RequestTransformation;
+    use LoggingContext;
 
     public function __construct()
     {
@@ -96,6 +98,9 @@ class FederationController extends Controller
      */
     public function index(GetAllFederation $request, int $teamId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
@@ -124,6 +129,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -188,6 +194,9 @@ class FederationController extends Controller
      */
     public function show(GetFederation $request, int $teamId, int $federationId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
@@ -216,6 +225,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -285,6 +295,9 @@ class FederationController extends Controller
      */
     public function store(CreateFederation $request, int $teamId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
@@ -312,7 +325,7 @@ class FederationController extends Controller
                     "secret_id" => $auth_secret_key_location,
                     "payload" => json_encode($secrets_payload)
                 ];
-                $response = Http::post(env('GMI_SERVICE_URL') . '/federation', $payload);
+                $response = Http::withHeaders($loggingContext)->post(env('GMI_SERVICE_URL') . '/federation', $payload);
 
                 if (!$response->successful()) {
                     Federation::where('id', $federation->id)->delete();
@@ -371,6 +384,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -452,6 +466,9 @@ class FederationController extends Controller
      */
     public function update(UpdateFederation $request, int $teamId, int $federationId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
@@ -479,7 +496,7 @@ class FederationController extends Controller
                     "payload" => json_encode($secrets_payload)
                 ];
 
-                $response = Http::patch(env('GMI_SERVICE_URL') . '/federation', $payload);
+                $response = Http::withHeaders($loggingContext)->patch(env('GMI_SERVICE_URL') . '/federation', $payload);
 
                 if (!$response->successful()) {
                     return response()->json([
@@ -543,6 +560,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -623,6 +641,9 @@ class FederationController extends Controller
      */
     public function edit(EditFederation $request, int $teamId, int $federationId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
@@ -652,7 +673,7 @@ class FederationController extends Controller
                     "payload" => json_encode($secrets_payload)
                 ];
 
-                $response = Http::patch(env('GMI_SERVICE_URL') . '/federation', $payload);
+                $response = Http::withHeaders($loggingContext)->patch(env('GMI_SERVICE_URL') . '/federation', $payload);
 
                 if (!$response->successful()) {
                     return response()->json([
@@ -718,6 +739,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -823,6 +845,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -861,10 +884,13 @@ class FederationController extends Controller
      */
     public function testFederation(Request $request)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
 
         try {
-            $response = Http::post(env('GMI_SERVICE_URL') . '/test', $input);
+            $response = Http::withHeaders($loggingContext)->post(env('GMI_SERVICE_URL') . '/test', $input);
             return response()->json([
                 'data' => $response->json(),
             ], 200);
@@ -875,6 +901,7 @@ class FederationController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }

--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -807,6 +807,9 @@ class FederationController extends Controller
      */
     public function destroy(DeleteFederation $request, int $teamId, int $federationId)
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -24,6 +24,7 @@ use App\Models\DatasetVersion;
 use App\Exports\ToolListExport;
 use App\Models\DataProviderColl;
 use App\Http\Traits\IndexElastic;
+use App\Http\Traits\LoggingContext;
 use App\Models\DurHasPublication;
 use Illuminate\Http\JsonResponse;
 use App\Exports\DatasetListExport;
@@ -57,6 +58,7 @@ class SearchController extends Controller
     use IndexElastic;
     use GetValueByPossibleKeys;
     use PaginateFromArray;
+    use LoggingContext;
 
     /**
      * @OA\Examples(
@@ -144,6 +146,9 @@ class SearchController extends Controller
     public function datasets(Request $request): JsonResponse|BinaryFileResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
 
             $download = array_key_exists('download', $input) ? $input['download'] : false;
@@ -160,7 +165,7 @@ class SearchController extends Controller
             $input['aggs'] = $aggs;
 
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/datasets';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
             if (!$response->successful()) {
                 return response()->json([
@@ -246,6 +251,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search datasets export data - list',
                 ]);
+                \Log::info('Search datasets export data - list', $loggingContext);
                 return Excel::download(new DatasetListExport($datasetsArray), 'datasets.csv');
             }
 
@@ -255,6 +261,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search datasets export data - table',
                 ]);
+                \Log::info('Search datasets export data - table', $loggingContext);
                 return Excel::download(new DatasetTableExport($datasetsArray), 'datasets.csv');
             }
 
@@ -285,6 +292,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -336,9 +344,12 @@ class SearchController extends Controller
     public function similarDatasets(Request $request): JsonResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $id = (string)$request['id'];
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/similar/datasets';
-            $response = Http::post($urlString, ['id' => $id]);
+            $response = Http::withHeaders($loggingContext)->post($urlString, ['id' => $id]);
 
             $datasetsArray = $response['hits']['hits'];
             $matchedIds = [];
@@ -371,6 +382,8 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -465,6 +478,9 @@ class SearchController extends Controller
     public function tools(Request $request): JsonResponse|BinaryFileResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
 
             $download = array_key_exists('download', $input) ? $input['download'] : false;
@@ -481,13 +497,14 @@ class SearchController extends Controller
 
             try {
                 $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/tools';
-                $response = Http::post($urlString, $input);
+                $response = Http::withHeaders($loggingContext)->post($urlString, $input);
             } catch (ConnectionException $e) {
                 Auditor::log([
                     'action_type' => 'EXCEPTION',
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => $e->getMessage(),
                 ]);
+                \Log::info($e->getMessage(), $loggingContext);
                 throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
             } catch (Exception $e) {
                 Auditor::log([
@@ -495,6 +512,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => $e->getMessage(),
                 ]);
+                \Log::info($e->getMessage(), $loggingContext);
                 throw new Exception($e->getMessage());
             }
 
@@ -586,6 +604,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search tools export data - list',
                 ]);
+                \Log::info('Search tools export data - list', $loggingContext);
                 return Excel::download(new ToolListExport($toolsArray), 'tools.csv');
             }
 
@@ -614,6 +633,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -701,6 +721,9 @@ class SearchController extends Controller
     public function collections(Request $request): JsonResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
 
             $sort = $request->query('sort', 'score:desc');
@@ -712,7 +735,7 @@ class SearchController extends Controller
             $input['aggs'] = $aggs;
 
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/collections';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
             $collectionArray = $response['hits']['hits'];
             $totalResults = $response['hits']['total']['value'];
@@ -772,6 +795,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -868,6 +892,9 @@ class SearchController extends Controller
      */
     public function dataUses(Request $request): JsonResponse|BinaryFileResponse
     {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
         $input = $request->all();
         $download = array_key_exists('download', $input) ? $input['download'] : false;
         $sort = $request->query('sort', 'score:desc');
@@ -882,13 +909,14 @@ class SearchController extends Controller
 
         try {
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/dur';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
         } catch (ConnectionException $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
             throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
         } catch (Exception $e) {
             Auditor::log([
@@ -896,6 +924,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
             throw new Exception($e->getMessage());
         }
 
@@ -942,6 +971,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search dur export data',
                 ]);
+                \Log::info('Search dur export data', $loggingContext);
                 return Excel::download(new DataUseExport($durArray), 'dur.csv');
             }
 
@@ -972,6 +1002,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -1088,6 +1119,9 @@ class SearchController extends Controller
     public function publications(PublicationSearch $request): JsonResponse|BinaryFileResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
 
             $download = array_key_exists('download', $input) ? $input['download'] : false;
@@ -1107,13 +1141,14 @@ class SearchController extends Controller
 
                 try {
                     $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/publications';
-                    $response = Http::post($urlString, $input);
+                    $response = Http::withHeaders($loggingContext)->post($urlString, $input);
                 } catch (ConnectionException $e) {
                     Auditor::log([
                         'action_type' => 'EXCEPTION',
                         'action_name' => class_basename($this) . '@' . __FUNCTION__,
                         'description' => $e->getMessage(),
                     ]);
+                    \Log::info($e->getMessage(), $loggingContext);
                     throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
                 } catch (Exception $e) {
                     Auditor::log([
@@ -1121,6 +1156,7 @@ class SearchController extends Controller
                         'action_name' => class_basename($this) . '@' . __FUNCTION__,
                         'description' => $e->getMessage(),
                     ]);
+                    \Log::info($e->getMessage(), $loggingContext);
                     throw new Exception($e->getMessage());
                 }
 
@@ -1183,13 +1219,14 @@ class SearchController extends Controller
                 $input['field'] = ['TITLE', 'ABSTRACT', 'METHODS'];
 
                 try {
-                    $response = Http::post($urlString, $input);
+                    $response = Http::withHeaders($loggingContext)->post($urlString, $input);
                 } catch (ConnectionException $e) {
                     Auditor::log([
                         'action_type' => 'EXCEPTION',
                         'action_name' => class_basename($this) . '@' . __FUNCTION__,
                         'description' => $e->getMessage(),
                     ]);
+                    \Log::info($e->getMessage(), $loggingContext);
                     throw new Exception('Operation timeout: The search query is too long. Please try searching with fewer keywords');
                 } catch (Exception $e) {
                     Auditor::log([
@@ -1197,6 +1234,7 @@ class SearchController extends Controller
                         'action_name' => class_basename($this) . '@' . __FUNCTION__,
                         'description' => $e->getMessage(),
                     ]);
+                    \Log::info($e->getMessage(), $loggingContext);
                     throw new Exception($e->getMessage());
                 }
 
@@ -1225,6 +1263,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => "Search publications export data",
                 ]);
+                \Log::info('Search publications export data', $loggingContext);
                 return Excel::download(new PublicationExport($pubArray), 'publications.csv');
             }
 
@@ -1258,6 +1297,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -1383,10 +1423,13 @@ class SearchController extends Controller
     public function doiSearch(DOISearch $request): Response | JsonResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
 
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/federated_papers/doi';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
             if (!isset($response['resultList']['result']) || !is_array($response['resultList']['result'])) {
                 CloudLogger::write([
@@ -1431,6 +1474,7 @@ class SearchController extends Controller
                 'data' => $pubResult
             ], 200);
         } catch (Exception $e) {
+            \Log::info($e->getMessage(), $loggingContext);
             throw new Exception($e->getMessage());
         }
     }
@@ -1516,6 +1560,9 @@ class SearchController extends Controller
     public function dataCustodianNetworks(Request $request): JsonResponse|BinaryFileResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
             $download = array_key_exists('download', $input) ? $input['download'] : false;
             $sort = $request->query('sort', 'score:desc');
@@ -1529,7 +1576,7 @@ class SearchController extends Controller
             $input['aggs'] = $aggs;
 
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/data_custodian_networks';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
             $dataCustodianNetworksArray = $response['hits']['hits'];
             $totalResults = $response['hits']['total']['value'];
@@ -1566,6 +1613,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search data custodian network export data',
                 ]);
+                \Log::info('Search data custodian network export data', $loggingContext);
                 return Excel::download(new DataProviderCollExport($dataCustodianNetworksArray), 'dataCustodianNetworks.csv');
             }
 
@@ -1595,6 +1643,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }
@@ -1687,6 +1736,9 @@ class SearchController extends Controller
     public function dataCustodians(Request $request): JsonResponse|BinaryFileResponse
     {
         try {
+            $loggingContext = $this->getLoggingContext($request);
+            $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
             $input = $request->all();
             $download = array_key_exists('download', $input) ? $input['download'] : false;
             $sort = $request->query('sort', 'score:desc');
@@ -1700,7 +1752,7 @@ class SearchController extends Controller
             $input['aggs'] = $aggs;
 
             $urlString = env('SEARCH_SERVICE_URL', 'http://localhost:8003') . '/search/data_providers';
-            $response = Http::post($urlString, $input);
+            $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
             $dataCustodianArray = $response['hits']['hits'];
             $totalResults = $response['hits']['total']['value'];
@@ -1734,6 +1786,7 @@ class SearchController extends Controller
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
                     'description' => 'Search data provider export data',
                 ]);
+                \Log::info('Search data provider export data', $loggingContext);
                 return Excel::download(new DataProviderExport($dataCustodianArray), 'dataCustodian.csv');
             }
 
@@ -1764,6 +1817,7 @@ class SearchController extends Controller
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
+            \Log::info($e->getMessage(), $loggingContext);
 
             throw new Exception($e->getMessage());
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\ProfileRequest::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \App\Http\Middleware\HstsMiddleware::class,
+        \App\Http\Middleware\LogRequestResponse::class,
     ];
 
     /**

--- a/app/Http/Middleware/LogRequestResponse.php
+++ b/app/Http/Middleware/LogRequestResponse.php
@@ -22,7 +22,7 @@ class LogRequestResponse
 
         // Log the incoming request
         Log::info('Request', [
-            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'x-request-session-id' => $request->headers->all()['x-request-session-id'] ?? null,
             'url' => $request->fullUrl(),
             'http_method' => $request->getMethod(),
             'method_name' => $methodName,
@@ -37,7 +37,7 @@ class LogRequestResponse
         $responseBody = $this->maskSensitive($responseBody);
         $responseBody = $this->truncateBody($responseBody);
         Log::info('Response', [
-            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'x-request-session-id' => $request->headers->all()['x-request-session-id'] ?? null,
             'url' => $request->fullUrl(),
             'http_method' => $request->getMethod(),
             'method_name' => $methodName,

--- a/app/Http/Middleware/LogRequestResponse.php
+++ b/app/Http/Middleware/LogRequestResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class LogRequestResponse
+{
+    // List of sensitive fields to mask
+    protected $sensitiveFields = ['password', 'token', 'access_token', 'authorization'];
+    // Max body length to log
+    protected $maxBodyLength = 2048;
+
+    public function handle(Request $request, Closure $next)
+    {
+        // Mask sensitive fields in request body
+        $body = $this->maskSensitive($request->all());
+        $body = $this->truncateBody($body);
+        $methodName = $this->getMethodName($request);
+
+        // Log the incoming request
+        Log::info('Request', [
+            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'url' => $request->fullUrl(),
+            'http_method' => $request->getMethod(),
+            'method_name' => $methodName,
+            'body' => $body,
+        ]);
+
+        $response = $next($request);
+
+        // Log the outgoing response
+        $responseBody = method_exists($response, 'getContent') ? $response->getContent() : null;
+        $responseBody = json_decode($responseBody, true);
+        $responseBody = $this->maskSensitive($responseBody);
+        $responseBody = $this->truncateBody($responseBody);
+        Log::info('Response', [
+            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'url' => $request->fullUrl(),
+            'http_method' => $request->getMethod(),
+            'method_name' => $methodName,
+            'body' => $responseBody,
+            'status' => $response->getStatusCode(),
+        ]);
+
+        return $response;
+    }
+
+    protected function maskSensitive($data)
+    {
+        if (is_array($data)) {
+            foreach ($data as $key => &$value) {
+                if (in_array(strtolower($key), $this->sensitiveFields)) {
+                    $value = '***';
+                } elseif (is_array($value)) {
+                    $value = $this->maskSensitive($value);
+                }
+            }
+        }
+        return $data;
+    }
+
+    protected function getMethodName($request): ?string
+    {
+        $route = app('router')->getRoutes()->match(
+            app('request')->create($request->fullUrl(), $request->getMethod())
+        );
+
+        return $route->action['controller'] ?? null;
+    }
+
+    protected function truncateBody($body)
+    {
+        if (is_array($body)) {
+            $body = json_encode($body);
+        }
+        if (is_string($body) && strlen($body) > $this->maxBodyLength) {
+            return substr($body, 0, $this->maxBodyLength) . '...';
+        }
+        return $body;
+    }
+}

--- a/app/Http/Middleware/LogRequestResponse.php
+++ b/app/Http/Middleware/LogRequestResponse.php
@@ -21,7 +21,7 @@ class LogRequestResponse
         $methodName = $this->getMethodName($request);
 
         // Log the incoming request
-        Log::info('Request', [
+        Log::debug('Request', [
             'x-request-session-id' => $request->headers->all()['x-request-session-id'] ?? null,
             'url' => $request->fullUrl(),
             'http_method' => $request->getMethod(),
@@ -36,7 +36,7 @@ class LogRequestResponse
         $responseBody = json_decode($responseBody, true);
         $responseBody = $this->maskSensitive($responseBody);
         $responseBody = $this->truncateBody($responseBody);
-        Log::info('Response', [
+        Log::debug('Response', [
             'x-request-session-id' => $request->headers->all()['x-request-session-id'] ?? null,
             'url' => $request->fullUrl(),
             'http_method' => $request->getMethod(),

--- a/app/Http/Traits/LoggingContext.php
+++ b/app/Http/Traits/LoggingContext.php
@@ -11,7 +11,7 @@ trait LoggingContext
         $methodName = $this->getMethodName($request);
 
         $context = [
-            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'x-request-session-id' => $request->headers->all()['x-request-session-id'] ?? null,
             'url' => $request->fullUrl(),
             'http_method' => $request->getMethod(),
             'method_name' => $methodName,

--- a/app/Http/Traits/LoggingContext.php
+++ b/app/Http/Traits/LoggingContext.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Traits;
+
+use Illuminate\Http\Request;
+
+trait LoggingContext
+{
+    public function getLoggingContext(Request $request)
+    {
+        $methodName = $this->getMethodName($request);
+
+        $context = [
+            'request_id' => $request->headers->all()['x-request-session-id'] ?? null,
+            'url' => $request->fullUrl(),
+            'http_method' => $request->getMethod(),
+            'method_name' => $methodName,
+        ];
+
+        return $context;
+    }
+
+    protected function getMethodName($request): ?string
+    {
+        if (is_null($request->route())) {
+            return null;
+        }
+
+        $route = app('router')->getRoutes()->match(
+            app('request')->create($request->fullUrl(), $request->getMethod())
+        );
+
+        return $route->action['controller'] ?? null;
+    }
+}

--- a/app/Jobs/AdminControlTriggerTermExtractionDirector.php
+++ b/app/Jobs/AdminControlTriggerTermExtractionDirector.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use Auditor;
+use App\Http\Traits\LoggingContext;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -16,13 +17,17 @@ class AdminControlTriggerTermExtractionDirector implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+    use LoggingContext;
+
+    private ?array $loggingContext = null;
 
     /**
      * Create a new job instance.
      */
     public function __construct()
     {
-        //
+        $this->loggingContext = $this->getLoggingContext(\request());
+        $this->loggingContext['method_name'] = class_basename($this);
     }
 
     /**
@@ -37,6 +42,8 @@ class AdminControlTriggerTermExtractionDirector implements ShouldQueue
             'action_name' => class_basename($this) . '@'.__FUNCTION__,
             'description' => 'manually triggered TED',
         ]);
+
+        \Log::info('Manually triggered TED', $this->loggingContext);
     }
 
     public function tags(): array

--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -62,25 +62,25 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 ->first();
 
         if (is_null($metadata)) {
-            \Log::warn('ExtractPublicationsFromMetadata :: Metadata not found.', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: Metadata not found.', $this->loggingContext);
             return;
         }
 
         $dataset = Dataset::where('id', $metadata->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
         if (is_null($dataset)) {
-            \Log::warn('ExtractPublicationsFromMetadata :: Dataset not found.', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: Dataset not found.', $this->loggingContext);
             return;
         }
 
         $user = User::where('id', $dataset->user_id)->first();
         if (is_null($user)) {
-            \Log::warn('ExtractPublicationsFromMetadata :: User not found.', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: User not found.', $this->loggingContext);
             return;
         }
 
         $team = Team::where('id', $dataset->team_id)->first();
         if (is_null($team)) {
-            \Log::warn('ExtractPublicationsFromMetadata :: Team not found.', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: Team not found.', $this->loggingContext);
             return;
         }
 
@@ -133,7 +133,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
             $checkPublication = Publication::where('paper_doi', 'like', '%' . $publication . '%')->first();
 
             if (!is_null($checkPublication)) {
-                \Log::warn('ExtractPublicationsFromMetadata :: Publication already exists.', $this->loggingContext);
+                \Log::warning('ExtractPublicationsFromMetadata :: Publication already exists.', $this->loggingContext);
                 $this->createLinkPublicationDatasetVersion($checkPublication->id, $datasetVersionId, $type);
                 continue;
             }
@@ -145,7 +145,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 }
 
                 if ($searchDoi['data']['is_preprint']) {
-                    \Log::warn('ExtractPublicationsFromMetadata :: No publication - is_preprint is true', $this->loggingContext);
+                    \Log::warning('ExtractPublicationsFromMetadata :: No publication - is_preprint is true', $this->loggingContext);
                     continue;
                 }
 
@@ -193,7 +193,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     public function searchDoi(string $doi)
     {
         if (strlen($doi) === 0 || !$doi) {
-            \Log::warn('ExtractPublicationsFromMetadata :: doi string invalid.', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: doi string invalid.', $this->loggingContext);
             return null;
         }
 
@@ -206,7 +206,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         if ($response->successful()) {
             return $response->json();
         } else {
-            \Log::warn('ExtractPublicationsFromMetadata :: Search Doi request failed', $this->loggingContext);
+            \Log::warning('ExtractPublicationsFromMetadata :: Search Doi request failed', $this->loggingContext);
             return null;
         }
     }

--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs;
 
-use CloudLogger;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Dataset;
@@ -15,6 +14,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use App\Models\PublicationHasDatasetVersion;
+use App\Http\Traits\LoggingContext;
 
 class ExtractPublicationsFromMetadata implements ShouldQueue
 {
@@ -22,8 +22,10 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
+    use LoggingContext;
 
     private int $datasetVersionId = 0;
+    private ?array $loggingContext = null;
 
     /**
      * Create a new job instance.
@@ -31,6 +33,9 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     public function __construct(int $datasetVersionId)
     {
         $this->datasetVersionId = $datasetVersionId;
+
+        $this->loggingContext = $this->getLoggingContext(\request());
+        $this->loggingContext['method_name'] = class_basename($this);
     }
 
     /**
@@ -57,25 +62,25 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 ->first();
 
         if (is_null($metadata)) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: Metadata not found.', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: Metadata not found.', $this->loggingContext);
             return;
         }
 
         $dataset = Dataset::where('id', $metadata->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
         if (is_null($dataset)) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: Dataset not found.', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: Dataset not found.', $this->loggingContext);
             return;
         }
 
         $user = User::where('id', $dataset->user_id)->first();
         if (is_null($user)) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: User not found.', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: User not found.', $this->loggingContext);
             return;
         }
 
         $team = Team::where('id', $dataset->team_id)->first();
         if (is_null($team)) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: Team not found.', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: Team not found.', $this->loggingContext);
             return;
         }
 
@@ -112,7 +117,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         }
 
         foreach ($publications as $publication) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: ' . $publication);
+            \Log::info('ExtractPublicationsFromMetadata :: ' . $publication, $this->loggingContext);
 
             // check if gateway url
             if (str_contains($publication, env('GATEWAY_URL'))) {
@@ -128,7 +133,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
             $checkPublication = Publication::where('paper_doi', 'like', '%' . $publication . '%')->first();
 
             if (!is_null($checkPublication)) {
-                CloudLogger::write('ExtractPublicationsFromMetadata :: Publication already exists.', 'WARNING');
+                \Log::warn('ExtractPublicationsFromMetadata :: Publication already exists.', $this->loggingContext);
                 $this->createLinkPublicationDatasetVersion($checkPublication->id, $datasetVersionId, $type);
                 continue;
             }
@@ -140,11 +145,11 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 }
 
                 if ($searchDoi['data']['is_preprint']) {
-                    CloudLogger::write('ExtractPublicationsFromMetadata :: No publication - is_preprint is true', 'WARNING');
+                    \Log::warn('ExtractPublicationsFromMetadata :: No publication - is_preprint is true', $this->loggingContext);
                     continue;
                 }
 
-                CloudLogger::write('ExtractPublicationsFromMetadata :: search doi ' . json_encode($searchDoi));
+                \Log::info('ExtractPublicationsFromMetadata :: search doi ' . json_encode($searchDoi), $this->loggingContext);
 
                 $newPublication = new Publication();
                 $newPublication->abstract = $searchDoi['data']['abstract'];
@@ -170,7 +175,10 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
 
                 $newPublication->save();
                 $publicationId = $newPublication->id;
-                CloudLogger::write('ExtractPublicationsFromMetadata :: a new publication has been created with id = ' . $publicationId);
+                \Log::info(
+                    'ExtractPublicationsFromMetadata :: a new publication has been created with id = ' . $publicationId,
+                    $this->loggingContext
+                );
 
                 $this->createLinkPublicationDatasetVersion($publicationId, $datasetVersionId, $type);
 
@@ -185,7 +193,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     public function searchDoi(string $doi)
     {
         if (strlen($doi) === 0 || !$doi) {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: doi string invalid.', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: doi string invalid.', $this->loggingContext);
             return null;
         }
 
@@ -198,7 +206,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         if ($response->successful()) {
             return $response->json();
         } else {
-            CloudLogger::write('ExtractPublicationsFromMetadata :: Search Doi request failed', 'WARNING');
+            \Log::warn('ExtractPublicationsFromMetadata :: Search Doi request failed', $this->loggingContext);
             return null;
         }
     }

--- a/app/Services/CloudPubSubService.php
+++ b/app/Services/CloudPubSubService.php
@@ -5,16 +5,22 @@ namespace App\Services;
 use Config;
 use Google\Cloud\PubSub\PubSubClient;
 use Google\Cloud\PubSub\MessageBuilder;
+use App\Http\Traits\LoggingContext;
 
 class CloudPubSubService
 {
+    use LoggingContext;
+
     protected $pubSubClient;
+    private ?array $loggingContext = null;
 
     public function __construct()
     {
         $this->pubSubClient = new PubSubClient([
             'projectId' => Config::get('services.googlepubsub.project_id'),
         ]);
+        $this->loggingContext = $this->getLoggingContext(\request());
+        $this->loggingContext['method_name'] = class_basename($this);
     }
 
     public function setPubSubClient(PubSubClient $pubSubClient)
@@ -27,6 +33,8 @@ class CloudPubSubService
         if (Config::get('services.googlepubsub.enabled') === false) {
             return;
         }
+
+        \Log::info('Publishing message to PubSub', $this->loggingContext);
 
         $topic = $this->pubSubClient->topic(Config::get('services.googlepubsub.pubsub_topic'));
         $message = (new MessageBuilder())->setData(json_encode($data))->build();

--- a/app/Services/Hubspot.php
+++ b/app/Services/Hubspot.php
@@ -5,11 +5,16 @@ namespace App\Services;
 use Config;
 use Exception;
 use Illuminate\Support\Facades\Http;
+use App\Http\Traits\LoggingContext;
 
 class Hubspot
 {
+    use LoggingContext;
+
     protected $baseUrl;
     protected $header;
+
+    private ?array $loggingContext = null;
 
     public function __construct()
     {
@@ -18,6 +23,8 @@ class Hubspot
             'Accept' => 'application/json',
             'Authorization' => 'Bearer ' . Config::get('services.hubspot.key'),
         ];
+        $this->loggingContext = $this->getLoggingContext(\request());
+        $this->loggingContext['method_name'] = class_basename($this);
     }
 
     public function createContact(array $properties)
@@ -33,6 +40,8 @@ class Hubspot
 
             return $response->json();
         } catch (Exception $e) {
+            $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+            \Log::info('Failed to create contact ' . $e->getMessage(), $this->loggingContext);
             throw new Exception($e->getMessage());
         }
     }
@@ -51,6 +60,8 @@ class Hubspot
             // Returns a 204 No Content response on success
             return $response->json();
         } catch (Exception $e) {
+            $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+            \Log::info('Failed to update contact ' . $e->getMessage(), $this->loggingContext);
             throw new Exception($e->getMessage());
         }
     }
@@ -66,6 +77,8 @@ class Hubspot
 
             return (!is_array($responseBody)) ? null : (array_key_exists('vid', $responseBody) ? $responseBody['vid'] : null);
         } catch (Exception $e) {
+            $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+            \Log::info('Failed to fetch contact ' . $e->getMessage(), $this->loggingContext);
             throw new Exception($e->getMessage());
         }
     }
@@ -79,6 +92,8 @@ class Hubspot
 
             return $response->json();
         } catch (Exception $e) {
+            $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+            \Log::info('Failed to fetch contact ' . $e->getMessage(), $this->loggingContext);
             throw new Exception($e->getMessage());
         }
     }
@@ -92,6 +107,8 @@ class Hubspot
 
             return $response->json();
         } catch (Exception $e) {
+            $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+            \Log::info('Failed to delete contact ' . $e->getMessage(), $this->loggingContext);
             throw new Exception($e->getMessage());
         }
     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adds logging with context in key areas:
- middleware to log incoming request and the response (I lifted that middleware from the registry - thank you registry!)
- in dispatched jobs - so we can track the requests that initiated those jobs
- wherever we call out to other services so that we can pass the `'x-request-session-id'` on

Note: when we upgrade to Laravel 11/12 we can use `Context` for this logging which will be more elegant (https://laravel.com/docs/12.x/context#main-content), but it is not available in Laravel 10.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-7294

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
