### PR TITLE
chore(GAT-5967): Add deprecation flags and sunset headers to v1 endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/CollectionController.php
+++ b/app/Http/Controllers/Api/V1/CollectionController.php
@@ -43,6 +43,7 @@ class CollectionController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/collections",
+     *    deprecated=true,
      *    operationId="fetch_all_collections",
      *    tags={"Collections"},
      *    summary="CollectionController@index",
@@ -272,6 +273,7 @@ class CollectionController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/collections/count/{field}",
+     *    deprecated=true,
      *    operationId="count_unique_fields_collections",
      *    tags={"Collections"},
      *    summary="CollectionController@count",
@@ -359,6 +361,7 @@ class CollectionController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/collections/{id}",
+     *    deprecated=true,
      *    operationId="fetch_collections",
      *    tags={"Collections"},
      *    summary="CollectionController@show",
@@ -455,6 +458,7 @@ class CollectionController extends Controller
     /**
      * @OA\Post(
      *    path="/api/v1/teams/{teamId}/collections",
+     *    deprecated=true,
      *    operationId="create_team_collections",
      *    tags={"Collections"},
      *    summary="CollectionController@store",
@@ -604,6 +608,7 @@ class CollectionController extends Controller
     /**
      * @OA\Put(
      *    path="/api/v1/teams/{teamId}/collections/{id}",
+     *    deprecated=true,
      *    tags={"Collections"},
      *    summary="Update a collection",
      *    description="Update a collection owned by a team",
@@ -786,6 +791,7 @@ class CollectionController extends Controller
     /**
      * @OA\Patch(
      *    path="/api/v1/teams/{teamId}/collections/{id}",
+     *    deprecated=true,
      *    tags={"Collections"},
      *    summary="Edit a collection",
      *    description="Edit a collection owned by a team",
@@ -1028,6 +1034,7 @@ class CollectionController extends Controller
     /**
      * @OA\Delete(
      *    path="/api/v1/teams/{teamId}/collections/{id}",
+     *    deprecated=true,
      *    tags={"Collections"},
      *    summary="Delete a collection",
      *    description="Delete a collection owned by a team",

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -44,6 +44,7 @@ class DatasetController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/datasets",
+     *    deprecated=true,
      *    operationId="fetch_all_datasets",
      *    tags={"Datasets"},
      *    summary="DatasetController@index",
@@ -261,6 +262,7 @@ class DatasetController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/datasets/count/{field}",
+     *    deprecated=true,
      *    operationId="count_unique_fields",
      *    tags={"Datasets"},
      *    summary="DatasetController@count",
@@ -335,6 +337,7 @@ class DatasetController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/datasets/{id}",
+     *    deprecated=true,
      *    operationId="fetch_datasets",
      *    tags={"Datasets"},
      *    summary="DatasetController@show",
@@ -608,6 +611,7 @@ class DatasetController extends Controller
     /**
      * @OA\Post(
      *    path="/api/v1/datasets",
+     *    deprecated=true,
      *    operationId="create_datasets",
      *    tags={"Datasets"},
      *    summary="DatasetController@store",
@@ -728,6 +732,7 @@ class DatasetController extends Controller
     /**
      * @OA\Put(
      *    path="/api/v1/datasets/{id}",
+     *    deprecated=true,
      *    operationId="update_datasets",
      *    tags={"Datasets"},
      *    summary="DatasetController@update",
@@ -915,6 +920,7 @@ class DatasetController extends Controller
     /**
      * @OA\Patch(
      *    path="/api/v1/datasets/{id}",
+     *    deprecated=true,
      *    operationId="patch_datasets",
      *    tags={"Datasets"},
      *    summary="DatasetController@edit",
@@ -1066,6 +1072,7 @@ class DatasetController extends Controller
     /**
      * @OA\Delete(
      *      path="/api/v1/datasets/{id}",
+     *      deprecated=true,
      *      operationId="delete_datasets",
      *      summary="Delete a dataset",
      *      description="Delete a dataset",

--- a/app/Http/Controllers/Api/V1/DurController.php
+++ b/app/Http/Controllers/Api/V1/DurController.php
@@ -40,6 +40,7 @@ class DurController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/dur",
+     *    deprecated=true,
      *    operationId="fetch_all_dur",
      *    tags={"Data Use Registers"},
      *    summary="DurController@index",
@@ -311,6 +312,7 @@ class DurController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/dur/{id}",
+     *    deprecated=true,
      *    operationId="fetch_dur_by_id",
      *    tags={"Data Use Registers"},
      *    summary="DurController@show",
@@ -445,6 +447,7 @@ class DurController extends Controller
     /**
      * @OA\Post(
      *    path="/api/v1/dur",
+     *    deprecated=true,
      *    operationId="create_dur",
      *    tags={"Data Use Registers"},
      *    summary="DurController@store",
@@ -659,6 +662,7 @@ class DurController extends Controller
     /**
      * @OA\Put(
      *    path="/api/v1/dur/{id}",
+     *    deprecated=true,
      *    tags={"Data Use Registers"},
      *    summary="Update a dur by id",
      *    description="Update a dur",
@@ -932,6 +936,7 @@ class DurController extends Controller
     /**
      * @OA\Patch(
      *    path="/api/v1/dur/{id}",
+     *    deprecated=true,
      *    tags={"Data Use Registers"},
      *    summary="Edit a dur",
      *    description="Edit a dur",
@@ -1247,6 +1252,7 @@ class DurController extends Controller
     /**
      * @OA\Delete(
      *    path="/api/v1/dur/{id}",
+     *    deprecated=true,
      *    tags={"Data Use Registers"},
      *    summary="Delete a dur",
      *    description="Delete a dur",

--- a/app/Http/Controllers/Api/V1/PublicationController.php
+++ b/app/Http/Controllers/Api/V1/PublicationController.php
@@ -32,6 +32,7 @@ class PublicationController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/publications",
+     *    deprecated=true,
      *    operationId="fetch_all_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@index",
@@ -164,6 +165,7 @@ class PublicationController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/publication/count/{field}",
+     *    deprecated=true,
      *    operationId="count_unique_fields_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@count",
@@ -251,6 +253,7 @@ class PublicationController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/publications/{id}",
+     *    deprecated=true,
      *    operationId="fetch_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@show",
@@ -329,6 +332,7 @@ class PublicationController extends Controller
     /**
      * @OA\Post(
      *    path="/api/v1/publications",
+     *    deprecated=true,
      *    operationId="create_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@store",
@@ -448,6 +452,7 @@ class PublicationController extends Controller
     /**
      * @OA\Put(
      *    path="/api/v1/publications/{id}",
+     *    deprecated=true,
      *    operationId="update_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@update",
@@ -600,6 +605,7 @@ class PublicationController extends Controller
     /**
       * @OA\Patch(
       *    path="/api/v1/publications/{id}",
+      *    deprecated=true,
       *    operationId="edit_publications",
       *    tags={"Publication"},
       *    summary="PublicationController@edit",
@@ -808,6 +814,7 @@ class PublicationController extends Controller
     /**
      * @OA\Delete(
      *    path="/api/v1/publications/{id}",
+     *    deprecated=true,
      *    operationId="delete_publications",
      *    tags={"Publication"},
      *    summary="PublicationController@destroy",

--- a/app/Http/Controllers/Api/V1/ToolController.php
+++ b/app/Http/Controllers/Api/V1/ToolController.php
@@ -55,6 +55,7 @@ class ToolController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/tools",
+     *    deprecated=true,
      *    operationId="fetch_all_tools",
      *    tags={"Tools"},
      *    summary="Fetch all tools",
@@ -240,6 +241,7 @@ class ToolController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/tools/count/{field}",
+     *    deprecated=true,
      *    operationId="count_unique_fields_tools",
      *    tags={"Tools"},
      *    summary="ToolController@count",
@@ -311,6 +313,7 @@ class ToolController extends Controller
     /**
      * @OA\Get(
      *    path="/api/v1/tools/{id}",
+     *    deprecated=true,
      *    operationId="fetch_tools",
      *    tags={"Tools"},
      *    summary="ToolController@show",
@@ -397,6 +400,7 @@ class ToolController extends Controller
     /**
      * @OA\Post(
      *    path="/api/v1/tools",
+     *    deprecated=true,
      *    operationId="create_tools",
      *    tags={"Tools"},
      *    summary="ToolController@store",
@@ -562,6 +566,7 @@ class ToolController extends Controller
     /**
      * @OA\Put(
      *    path="/api/v1/tools/{id}",
+     *    deprecated=true,
      *    operationId="update_tools",
      *    tags={"Tools"},
      *    summary="ToolController@update",
@@ -760,6 +765,7 @@ class ToolController extends Controller
     /**
      * @OA\Patch(
      *    path="/api/v1/tools/{id}",
+     *    deprecated=true,
      *    operationId="edit_tools",
      *    tags={"Tools"},
      *    summary="ToolController@edit",
@@ -999,6 +1005,7 @@ class ToolController extends Controller
     /**
      * @OA\Delete(
      *    path="/api/v1/tools/{id}",
+     *    deprecated=true,
      *    operationId="delete_tools",
      *    tags={"Tools"},
      *    summary="ToolController@destroy",

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -71,5 +71,6 @@ class Kernel extends HttpKernel
         'sanitize.input' => \App\Http\Middleware\SanitizeMiddleware::class,
         'check.access' => \App\Http\Middleware\CheckAccessMiddleware::class,
         'check.access.userId' => \App\Http\Middleware\CheckUserIdMatches::class,
+        'sunset' => \App\Http\Middleware\SunsetHeader::class,
     ];
 }

--- a/app/Http/Middleware/SunsetHeader.php
+++ b/app/Http/Middleware/SunsetHeader.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SunsetHeader
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        $deprecationDate = 'Thurs, 22 Jan 2026 23:59:59 GMT';
+
+        $response->headers->set('Deprecation', 'true');
+        $response->headers->set('Sunset', $deprecationDate);
+
+        return $response;
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -555,7 +555,7 @@ return [
         'path' => '/tools',
         'methodController' => 'ToolController@index',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -564,7 +564,7 @@ return [
         'path' => '/tools/count/{field}',
         'methodController' => 'ToolController@count',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -573,7 +573,7 @@ return [
         'path' => '/tools/{id}',
         'methodController' => 'ToolController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [
             'id' => '[0-9]+',
         ],
@@ -587,6 +587,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -599,6 +600,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -613,6 +615,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -626,6 +629,7 @@ return [
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [
             'jwt.verify',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -643,6 +647,7 @@ return [
             'jwt.verify',
             'check.access:permissions,tools.read',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -656,6 +661,7 @@ return [
             'jwt.verify',
             'check.access:permissions,tools.read',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -671,6 +677,7 @@ return [
             'jwt.verify',
             'check.access:permissions,tools.create',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -684,6 +691,7 @@ return [
             'jwt.verify',
             'check.access:permissions,tools.update',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -699,6 +707,7 @@ return [
             'jwt.verify',
             'check.access:permissions,tools.update',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -713,6 +722,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,tools.delete',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1457,7 +1467,7 @@ return [
         'path' => '/collections',
         'methodController' => 'CollectionController@index',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -1466,7 +1476,7 @@ return [
         'path' => '/collections/count/{field}',
         'methodController' => 'CollectionController@count',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -1475,7 +1485,7 @@ return [
         'path' => '/collections/{id}',
         'methodController' => 'CollectionController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [
             'id' => '[0-9]+',
         ],
@@ -1490,6 +1500,7 @@ return [
             'jwt.verify',
             'sanitize.input',
             'check.access:permissions,collections.create',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -1503,6 +1514,7 @@ return [
             'jwt.verify',
             'sanitize.input',
             'check.access:permissions,collections.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1518,6 +1530,7 @@ return [
             'jwt.verify',
             'sanitize.input',
             'check.access:permissions,collections.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1532,6 +1545,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.delete',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1548,6 +1562,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.read',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -1560,6 +1575,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.read',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1574,6 +1590,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.create',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -1586,6 +1603,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1600,6 +1618,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1614,6 +1633,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,collections.delete',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1715,6 +1735,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.read',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -1727,6 +1748,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.read',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1742,6 +1764,7 @@ return [
             'jwt.verify',
             'check.access:permissions,dur.create',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -1755,6 +1778,7 @@ return [
             'jwt.verify',
             'check.access:permissions,dur.update',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1770,6 +1794,7 @@ return [
             'jwt.verify',
             'check.access:permissions,dur.update',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -1784,6 +1809,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.delete',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -2152,7 +2178,7 @@ return [
         'path' => '/datasets',
         'methodController' => 'DatasetController@index',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -2161,7 +2187,7 @@ return [
         'path' => '/datasets/count/{field}',
         'methodController' => 'DatasetController@count',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -2170,7 +2196,7 @@ return [
         'path' => '/datasets/{id}',
         'methodController' => 'DatasetController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [
             'id' => '[0-9]+',
         ],
@@ -2185,6 +2211,7 @@ return [
             'jwt.verify',
             //'sanitize.input',
             'check.access:permissions,datasets.create',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -2198,6 +2225,7 @@ return [
             'jwt.verify',
             //'sanitize.input',
             'check.access:permissions,datasets.update',
+            'sunset'
         ],
         'constraint' => [
             'id', '[0-9]+'
@@ -2212,6 +2240,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,datasets.update',
+            'sunset'
         ],
         'constraint' => [
             'id', '[0-9]+'
@@ -2226,6 +2255,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,datasets.delete',
+            'sunset'
         ],
         'constraint' => [
             'id', '[0-9]+'
@@ -2296,6 +2326,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,datasets.read',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -2308,6 +2339,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,datasets.read',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -2323,6 +2355,7 @@ return [
             'jwt.verify',
             'check.access:permissions,datasets.create',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -2336,6 +2369,7 @@ return [
             'jwt.verify',
             'check.access:permissions,datasets.update',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -2348,6 +2382,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,datasets.delete',
+            'sunset'
         ],
         'constraint' => [
             'id', '[0-9]+'
@@ -2362,6 +2397,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'sanitize.input',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -2971,7 +3007,7 @@ return [
         'path' => '/dur',
         'methodController' => 'DurController@index',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -2980,7 +3016,7 @@ return [
         'path' => '/dur/count/{field}',
         'methodController' => 'DurController@count',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -2989,7 +3025,7 @@ return [
         'path' => '/dur/{id}',
         'methodController' => 'DurController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [
             'id' => '[0-9]+',
         ],
@@ -3003,6 +3039,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.create',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3017,6 +3054,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3031,6 +3069,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.update',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3045,6 +3084,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,dur.delete',
+            'sunset'
         ],
         'constraint' => [
             'id' => '[0-9]+',
@@ -3090,7 +3130,7 @@ return [
         'path' => 'publications',
         'methodController' => 'PublicationController@index',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -3099,7 +3139,7 @@ return [
         'path' => '/publications/count/{field}',
         'methodController' => 'PublicationController@count',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -3108,7 +3148,7 @@ return [
         'path' => 'publications/{id}',
         'methodController' => 'PublicationController@show',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
-        'middleware' => [],
+        'middleware' => ['sunset'],
         'constraint' => [],
     ],
     [
@@ -3120,6 +3160,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,papers.create',
+            'sunset'
         ],
         'constraint' => [
         ],
@@ -3133,6 +3174,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,papers.update',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -3145,6 +3187,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,papers.update',
+            'sunset'
         ],
         'constraint' => [],
     ],
@@ -3157,6 +3200,7 @@ return [
         'middleware' => [
             'jwt.verify',
             'check.access:permissions,papers.delete',
+            'sunset'
         ],
         'constraint' => [],
     ],


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Related docs page: https://hdruk.atlassian.net/wiki/x/AoDx0

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-5967

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
