### PR TITLE
fix(GAT-7294): fixing logging

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'dev'
+      - 'part2/GAT-7294'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +27,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: part2/GAT-7294
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +77,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: part2/GAT-7294
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'dev'
-      - 'part2/GAT-7294'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -27,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: part2/GAT-7294
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -77,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: part2/GAT-7294
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -882,7 +882,7 @@ class CohortRequestController extends Controller
 
                     // add the given number of rows to the file.
                     foreach ($result as $rowDetails) {
-                        if (!is_null($rowDetails['user'])){
+                        if (!is_null($rowDetails['user'])) {
                             $row = [
                                 (string)$rowDetails['user']['id'],
                                 (string)$rowDetails['user']['name'],

--- a/config/logging.php
+++ b/config/logging.php
@@ -95,7 +95,7 @@ return [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
-            'formatter' => env('LOG_STDERR_FORMATTER', \Monolog\Formatter\GoogleCloudLoggingFormatter::class),
+            // 'formatter' => env('LOG_STDERR_FORMATTER', \Monolog\Formatter\GoogleCloudLoggingFormatter::class),
             'with' => [
                 'stream' => 'php://stderr',
             ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -95,7 +95,6 @@ return [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
-            // 'formatter' => env('LOG_STDERR_FORMATTER', \Monolog\Formatter\GoogleCloudLoggingFormatter::class),
             'with' => [
                 'stream' => 'php://stderr',
             ],

--- a/tests/Feature/CohortRequestTest.php
+++ b/tests/Feature/CohortRequestTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use Config;
 use Tests\TestCase;
-use App\Models\User;
 use App\Models\CohortRequest;
 use App\Models\CohortRequestHasPermission;
 use Tests\Traits\Authorization;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Removing the formatter from logging configuration. Since we changed to frankenphp, this formatter was interfering with stderr logging. Now logs appear in gcp again.

<img width="1607" height="536" alt="tools_search_logs" src="https://github.com/user-attachments/assets/4df059b7-6481-4bf6-b148-886acfd6032e" />
<img width="1590" height="395" alt="detailed_log" src="https://github.com/user-attachments/assets/970df88b-9d5f-4084-8769-b74b716c14aa" />

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-7294

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
