### PR TITLE
fix(GAT-7665): Only count active entities under Data Custodian Networks.

### DIFF
--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -800,10 +800,10 @@ class DataProviderCollController extends Controller
         $dataset = Dataset::where(['id' => $datasetId])->first();
 
         // Accessed through the accessor
-        $durIds = array_column($dataset->allDurs, 'id') ?? [];
-        $collectionIds = array_column($dataset->allCollections, 'id') ?? [];
-        $publicationIds = array_column($dataset->allPublications, 'id') ?? [];
-        $toolIds = array_column($dataset->allTools, 'id') ?? [];
+        $durIds = array_column($dataset->allActiveDurs, 'id') ?? [];
+        $collectionIds = array_column($dataset->allActiveCollections, 'id') ?? [];
+        $publicationIds = array_column($dataset->allActivePublications, 'id') ?? [];
+        $toolIds = array_column($dataset->allActiveTools, 'id') ?? [];
 
         $version = $dataset->latestVersion();
         $withLinks = DatasetVersion::where('id', $version['id'])


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7665

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
