### PR TITLE
feat(GAT-7670): Implements federated token exchange

### DIFF
--- a/app/Http/Controllers/SSO/CustomAccessTokenController.php
+++ b/app/Http/Controllers/SSO/CustomAccessTokenController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\SSO;
+
+use Laravel\Passport\Http\Controllers\AccessTokenController as PassportAccessTokenController;
+use Illuminate\Http\Request;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ServerRequestInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomAccessTokenController extends PassportAccessTokenController
+{
+    public function issueOAuthToken(Request $request)
+    {
+        $psr17Factory = new Psr17Factory();
+        $psrHttpFactory = new PsrHttpFactory(
+            $psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory
+        );
+
+        $psrRequest = $psrHttpFactory->createRequest($request);
+
+        try {
+            return parent::issueToken($psrRequest);
+        } catch (OAuthServerException $e) {
+            return response()->json([
+                'code' => $e->getCode(),
+                'message' => $e->getMessage(),
+            ], 400);
+        }
+    }
+}

--- a/app/Http/Controllers/SSO/OAuth2Controller.php
+++ b/app/Http/Controllers/SSO/OAuth2Controller.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\SSO;
+
+use App\Models\OauthUser;
+use Illuminate\Http\Request;
+use Laravel\Passport\Passport;
+use Laravel\Passport\Bridge\User;
+use App\Http\Controllers\Controller;
+use Laravel\Passport\ClientRepository;
+use App\Http\Traits\HandlesOAuthErrors;
+use Nyholm\Psr7\Response as Psr7Response;
+use Psr\Http\Message\ServerRequestInterface;
+use League\OAuth2\Server\AuthorizationServer;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Laravel\Passport\Http\Controllers\RetrievesAuthRequestFromSession;
+
+
+class OAuth2Controller extends Controller
+{
+    use HandlesOAuthErrors;
+    use RetrievesAuthRequestFromSession;
+
+    protected AuthorizationServer $server;
+    protected ResponseFactory $response;
+
+    public function __construct(AuthorizationServer $server, ResponseFactory $response)
+    {
+        $this->server = $server;
+        $this->response = $response;
+    }
+
+    public function customAuthorize(
+        ServerRequestInterface $psrRequest,
+        Request $request,
+        ClientRepository $clients,
+    ) {
+        $userId = session('cr_uid') ?? env('CR_UID_DEBUG');
+
+        if (!$userId) {
+            abort(401, 'User not authenticated');
+        }
+
+        OAuthUser::updateOrCreate([
+            'user_id' => $userId,
+            'nonce' => '123456789',
+        ]);
+
+        return $this->withErrorHandling(function () use ($psrRequest, $userId) {
+            $authRequest = $this->server->validateAuthorizationRequest($psrRequest);
+            $user = new User($userId);
+
+            $authRequest->setUser($user);
+            $authRequest->setAuthorizationApproved(true);
+
+            return $this->server->completeAuthorizationRequest($authRequest, new Psr7Response);
+        });
+    }
+}

--- a/app/Http/Middleware/AppendJWTTokenResponse.php
+++ b/app/Http/Middleware/AppendJWTTokenResponse.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\RedirectResponse;
+
+use App\Http\Controllers\JwtController;
+use App\Models\User;
+use App\Http\Traits\CustomIdTokenTrait;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Signer\Key\InMemory;
+
+class AppendJWTTokenResponse
+{
+    use CustomIdTokenTrait;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response|JsonResponse
+     */
+    public function handle(Request $request, Closure $next): RedirectResponse|Response|JsonResponse
+    {
+        $response = $next($request);
+        $currentUrl = $request->url();
+
+        $content = json_decode($response->getContent(), true);
+        if (isset($content['access_token'])) {
+
+            $signer = new Sha256();
+            $key = InMemory::plainText(env('JWT_SECRET'));
+
+            // Configure the parser. No validation needed, just parsing.
+            $config = Configuration::forSymmetricSigner($signer, $key);
+            $token = $config->parser()->parse($content['access_token']);
+            
+            $jwtClass = new JwtController();
+            $jwt = $jwtClass->generateToken($token->claims()->get('sub'));
+
+            return response()->json([
+                'token' => $jwt,
+            ], $response->getStatusCode(), $response->headers->all());
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Middleware/AppendJWTTokenResponse.php
+++ b/app/Http/Middleware/AppendJWTTokenResponse.php
@@ -46,6 +46,7 @@ class AppendJWTTokenResponse
             $token = $config->parser()->parse($content['access_token']);
             
             $jwtClass = new JwtController();
+            /** @phpstan-ignore-next-line */
             $jwt = $jwtClass->generateToken($token->claims()->get('sub'));
 
             return response()->json([

--- a/app/Http/Traits/UserTransformation.php
+++ b/app/Http/Traits/UserTransformation.php
@@ -26,7 +26,7 @@ trait UserTransformation
                 'lastname' => $user['lastname'],
                 'email' => $user['email'],
                 'secondary_email' => $user['secondary_email'],
-                'secondary_email_verified_at' => $user['secondary_email_verified_at'],
+                'secondary_email_verified_at' => $user['secondary_email_verified_at'] ?? null,
                 'preferred_email' => $user['preferred_email'],
                 'provider' => $user['provider'],
                 'created_at' => $user['created_at'],

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -54,7 +54,10 @@ class AppServiceProvider extends ServiceProvider
             'rquestroles' => 'rquestroles',
         ]);
 
-        // Passport::useAccessTokenEntity(CustomAccessToken::class);
+        if (config('app.app_token_variant') === 'gateway') {
+            Passport::useAccessTokenEntity(CustomAccessToken::class);
+        }
+
         Passport::tokensExpireIn(now()->addDays(15));
         Passport::refreshTokensExpireIn(now()->addDays(30));
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -54,7 +54,7 @@ class AppServiceProvider extends ServiceProvider
             'rquestroles' => 'rquestroles',
         ]);
 
-        Passport::useAccessTokenEntity(CustomAccessToken::class);
+        // Passport::useAccessTokenEntity(CustomAccessToken::class);
         Passport::tokensExpireIn(now()->addDays(15));
         Passport::refreshTokensExpireIn(now()->addDays(30));
 

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,8 @@ return [
 
     'name' => env('APP_NAME', 'Laravel'),
 
+    'app_token_variant' => env('APP_TOKEN_VARIANT', 'gateway'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,9 +3,12 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SSO\JwksController;
 use App\Http\Middleware\AppendTokenResponse;
+use App\Http\Middleware\AppendJWTTokenResponse;
+use App\Http\Controllers\SSO\OAuth2Controller;
 use App\Http\Controllers\SSO\OpenIdController;
 use App\Http\Controllers\SSO\CustomAuthorizationController;
 use Laravel\Passport\Http\Controllers\AccessTokenController;
+use App\Http\Controllers\SSO\CustomAccessTokenController;
 
 /*
 |--------------------------------------------------------------------------
@@ -20,6 +23,9 @@ use Laravel\Passport\Http\Controllers\AccessTokenController;
 
 Route::get('/oauth/authorize', [CustomAuthorizationController::class, 'customAuthorize']);
 Route::post('/oauth/token', [AccessTokenController::class, 'issueToken'])->middleware(AppendTokenResponse::class);
+
+Route::get('/oauth2/authorize', [OAuth2Controller::class, 'customAuthorize'])->middleware('web');
+Route::post('/oauth2/token', [CustomAccessTokenController::class, 'issueOAuthToken'])->middleware(AppendJWTTokenResponse::class);
 
 Route::get('/oauth/.well-known/jwks', [JwksController::class, 'getJwks']);
 


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1603" height="963" alt="image" src="https://github.com/user-attachments/assets/ad7957ce-ee1e-437f-9adb-b1f402b1e9e3" />

## Describe your changes

## Issue ticket link
Intentionally omitted. Ask me. Pre-work required for Daphne and Gateway sharing tokens.

## Environment / Configuration changes (if applicable)
Only for debug with Daphne. But in order to bypass the current `session('cr_uid')` requirement, I've added:

```
CR_UID_DEBUG=XXXX
```
...to .env, to inject a user id to test with.

There is also a new

```
APP_TOKEN_VARIANT
```

...env variable, but I pass in a default to maintain existing config for now. Neither of these should be needed for general running right now.

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
