### PR TITLE
fix(GAT-7698): Index upon extracting metadata

### DIFF
--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -129,6 +129,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 if (!is_null($pub)) {
                     $this->createLinkPublicationDatasetVersion($publicationId, $datasetVersionId, $type);
                     $this->indexElasticPublication((string) $publicationId);
+
                     continue;
                 }
             }

--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -187,6 +187,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
 
                 $this->createLinkPublicationDatasetVersion($publicationId, $datasetVersionId, $type);
                 $this->indexElasticPublication((string) $publicationId);
+
                 continue;
             }
             unset($newPublication);

--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Http\Traits\IndexElastic;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Dataset;
@@ -23,6 +24,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
     use Queueable;
     use SerializesModels;
     use LoggingContext;
+    use IndexElastic;
 
     private int $datasetVersionId = 0;
     private ?array $loggingContext = null;
@@ -57,9 +59,9 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         $linkagePublicationUsingDataset = 'metadata.linkage.publicationUsingDataset';
 
         $metadata = \DB::table('dataset_versions')
-                ->where('id', $datasetVersionId)
-                ->select('id', 'dataset_id', 'metadata', \DB::raw('JSON_TYPE(metadata) as metadata_type'))
-                ->first();
+            ->where('id', $datasetVersionId)
+            ->select('id', 'dataset_id', 'metadata', \DB::raw('JSON_TYPE(metadata) as metadata_type'))
+            ->first();
 
         if (is_null($metadata)) {
             \Log::warning('ExtractPublicationsFromMetadata :: Metadata not found.', $this->loggingContext);
@@ -126,6 +128,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 $pub = Publication::where('id', $publicationId)->first();
                 if (!is_null($pub)) {
                     $this->createLinkPublicationDatasetVersion($publicationId, $datasetVersionId, $type);
+                    $this->indexElasticPublication((string) $publicationId);
                     continue;
                 }
             }
@@ -135,6 +138,8 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
             if (!is_null($checkPublication)) {
                 \Log::warning('ExtractPublicationsFromMetadata :: Publication already exists.', $this->loggingContext);
                 $this->createLinkPublicationDatasetVersion($checkPublication->id, $datasetVersionId, $type);
+                $this->indexElasticPublication((string) $checkPublication->id);
+
                 continue;
             }
 
@@ -181,7 +186,7 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
                 );
 
                 $this->createLinkPublicationDatasetVersion($publicationId, $datasetVersionId, $type);
-
+                $this->indexElasticPublication((string) $publicationId);
                 continue;
             }
             unset($newPublication);

--- a/app/Jobs/ExtractToolsFromMetadata.php
+++ b/app/Jobs/ExtractToolsFromMetadata.php
@@ -168,7 +168,8 @@ class ExtractToolsFromMetadata implements ShouldQueue
 
         if (is_null($check)) {
             // note: not sure about this..
-            // - the link could exist because it
+            // - it could exist in the table but have been soft deleted?
+            // - updateOrCreate instead to update the soft delete?
             DatasetVersionHasTool::create([
                 'tool_id' => $toolId,
                 'dataset_version_id' => $datasetVersionId,

--- a/app/Jobs/ExtractToolsFromMetadata.php
+++ b/app/Jobs/ExtractToolsFromMetadata.php
@@ -135,7 +135,7 @@ class ExtractToolsFromMetadata implements ShouldQueue
             'link_type' => $type,
         ])->get();
 
-        foreach($datasetVersionHasTools as $datasetVersionHasTool) {
+        foreach ($datasetVersionHasTools as $datasetVersionHasTool) {
             $toolId = $datasetVersionHasTool->tool_id;
 
             DatasetVersionHasTool::where([
@@ -143,24 +143,32 @@ class ExtractToolsFromMetadata implements ShouldQueue
                 'link_type' => $type,
                 'tool_id' => $toolId,
             ])
-            ->delete();
+                ->delete();
 
+            // note: not sure about this... 
+            // - shouldnt this be calling deleteFromElastic? 
+            // - you've just soft deleted it?
             $this->indexElasticTools((int) $toolId);
         }
 
+        // why? the dataset index has nothing to do with tools
+        // - the tool elastic index has something to do with datasets,
+        //   not the other way around
         $this->reindexElastic((int) $datasetId);
     }
 
     public function createLinkToolDatasetVersion(int $toolId, int $datasetVersionId, string $type): ?DatasetVersionHasTool
     {
         $check = DatasetVersionHasTool::where([
-                'tool_id' => $toolId,
-                'dataset_version_id' => $datasetVersionId,
-                'link_type' => $type,
-            ])
+            'tool_id' => $toolId,
+            'dataset_version_id' => $datasetVersionId,
+            'link_type' => $type,
+        ])
             ->first();
 
         if (is_null($check)) {
+            // note: not sure about this..
+            // - the link could exist because it
             DatasetVersionHasTool::create([
                 'tool_id' => $toolId,
                 'dataset_version_id' => $datasetVersionId,


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

The reason for the bug was because reindexing wasnt being called.....

**Current flow:**
-> DatasetVersion is created updated
-> DatasetVersions Observer is called
-> if active, elasticDatasetVersion dispatches job `ExtractPublicationsFromMetadata::dispatch($datasetVersion->id);`
--> finds linked publications from the metadata
--> loops over each publication 
----> creates links if they dont exist
----> 🔴 **does not re-index elastic** 🔴
---->  ✅ **NEED TO REINDEX PUBLICATIONS - these contain the  `datasetTitles` needed** 
-> if active, elasticDatasetVersion dispatches job `ExtractToolsFromMetadata::dispatch($datasetVersion->id);`
-> calls  `$this->reindexElastic($dataset->id);` **(reindex dataset)**
-> calls `$this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');`


## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-7698

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
