### PR TITLE
feat(GAT-7731): Add NhsSdeApplicationsEnabled feature flag to FeatureFlagSeeder.

### DIFF
--- a/database/seeders/FeatureFlagsSeeder.php
+++ b/database/seeders/FeatureFlagsSeeder.php
@@ -18,5 +18,10 @@ class FeatureFlagsSeeder extends Seeder
             ['key' => 'Aliases'],
             ['enabled' => true]
         );
+
+        FeatureFlag::updateOrCreate(
+            ['key' => 'NhsSdeApplicationsEnabled'],
+            ['enabled' => false]
+        );
     }
 }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Supports easy enable/disabling of NHS SDE buttons without code changes.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7731

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
`php artisan db:seed --class=FeatureFlagsSeeder`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
