### PR TITLE
fix(GAT-7550): Supply information about DAR templates' publication status per dataset to FE

### DIFF
--- a/app/Http/Controllers/Api/V1/LibraryController.php
+++ b/app/Http/Controllers/Api/V1/LibraryController.php
@@ -9,6 +9,7 @@ use App\Models\Library;
 use App\Models\Dataset;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use App\Models\DataAccessTemplate;
 use App\Http\Controllers\Controller;
 use App\Exceptions\NotFoundException;
 use App\Exceptions\UnauthorizedException;
@@ -106,6 +107,7 @@ class LibraryController extends Controller
             $transformedLibraries = $libraries->getCollection()->map(function ($library) {
                 $dataset = $library->dataset;
                 $team = $dataset->team;
+                $teamPublishedDARTemplates = DataAccessTemplate::where([['team_id', $team->id], ['published', 1]])->pluck('id');
 
                 // Using dynamic attributes to avoid undefined property error
                 $library->setAttribute('dataset_id', (int)$dataset->id);
@@ -114,7 +116,8 @@ class LibraryController extends Controller
                 $library->setAttribute('data_provider_id', $team->id);
                 $library->setAttribute('data_provider_dar_status', $team->uses_5_safes);
                 $library->setAttribute('data_provider_name', $team->name);
-                $library->setAttribute('data_provider_dar_enabled', $team->is_question_bank);
+                $library->setAttribute('data_provider_dar_enabled', !$teamPublishedDARTemplates->isEmpty());
+                $library->setAttribute('data_provider_published_dar_template', $team->is_question_bank);
                 $library->setAttribute('data_provider_member_of', $team->member_of);
                 $library->setAttribute('dataset_is_cohort_discovery', $dataset->is_cohort_discovery);
 

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -238,7 +238,7 @@ class SearchController extends Controller
                 $datasetsArray[$i]['team']['id'] = $model['team']['id'];
                 $datasetsArray[$i]['team']['is_question_bank'] = $model['team']['is_question_bank'];
                 $teamDARTemplates = DataAccessTemplate::where([['team_id', $model['team']['id']], ['published', 1]])->get();
-                $datasetsArray[$i]['team']['has_dar_template_published'] = !$teamDARTemplates->isEmpty();
+                $datasetsArray[$i]['team']['has_published_dar_template'] = !$teamDARTemplates->isEmpty();
                 $datasetsArray[$i]['team']['name'] = $model['team']['name'];
                 $datasetsArray[$i]['team']['member_of'] = $model['team']['member_of'];
                 $datasetsArray[$i]['team']['is_dar'] = $model['team']['is_dar'];

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -27,6 +27,7 @@ use App\Http\Traits\IndexElastic;
 use App\Http\Traits\LoggingContext;
 use App\Models\DurHasPublication;
 use Illuminate\Http\JsonResponse;
+use App\Models\DataAccessTemplate;
 use App\Exports\DatasetListExport;
 use App\Exports\PublicationExport;
 use App\Models\ProgrammingPackage;
@@ -236,6 +237,8 @@ class SearchController extends Controller
                 $datasetsArray[$i]['dataProviderColl'] = $this->getDataProviderColl($model);
                 $datasetsArray[$i]['team']['id'] = $model['team']['id'];
                 $datasetsArray[$i]['team']['is_question_bank'] = $model['team']['is_question_bank'];
+                $teamDARTemplates = DataAccessTemplate::where([['team_id', $model['team']['id']], ['published', 1]])->get();
+                $datasetsArray[$i]['team']['has_dar_template_published'] = !$teamDARTemplates->isEmpty();
                 $datasetsArray[$i]['team']['name'] = $model['team']['name'];
                 $datasetsArray[$i]['team']['member_of'] = $model['team']['member_of'];
                 $datasetsArray[$i]['team']['is_dar'] = $model['team']['is_dar'];

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -8,6 +8,7 @@ use App\Models\Dur;
 use App\Models\Dataset;
 use Illuminate\Support\Arr;
 use App\Models\DatasetVersion;
+use App\Models\DataAccessTemplate;
 use MetadataManagementController as MMC;
 use App\Http\Requests\V2\Dataset\GetDataset;
 
@@ -84,6 +85,10 @@ trait DatasetsV2Helpers
         } elseif ($outputSchemaModelVersion) {
             throw new Exception('You have given a schema_version but not schema_model');
         }
+
+        $teamPublishedDARTemplates = DataAccessTemplate::where([['team_id', $dataset['team']['id']], ['published', 1]])->pluck('id');
+        $dataset['team']['has_published_dar_template'] = !$teamPublishedDARTemplates->isEmpty();
+
         return $dataset;
     }
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
The FE wasn't checking whether the team owning the dataset in question has a published DAR template. This PR supplies that information in 3 controller responses that the FE requires it from.

Supports https://github.com/HDRUK/gateway-web/pull/1298

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7550

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
