### PR TITLE
fix(GAT-6005): SDE con email change and logic

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - 'fix/sde-con'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/sde-con
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: fix/sde-con
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'fix/sde-con'
+      - 'dev'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/sde-con
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/sde-con
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -361,11 +361,6 @@ class EnquiryThreadController extends Controller
 
         [$conciergeId, $conciergeName] = $this->getNetworkConcierge();
         $sdeTeamIds = $this->getSdeTeamIds();
-        $multipleDatasets = count($datasets) > 1;
-
-
-
-
 
         if ($input['is_general_enquiry']) {
             foreach ($datasets as $dataset) {
@@ -377,7 +372,7 @@ class EnquiryThreadController extends Controller
             if (count($teamIds) > 1) {
                 // 1/2/3 none sde and 1/2/3 sde - does go to con
                 // 1 sde - does not go to con - exact words from Big Stephen
-                if ($this->shouldUseConcierge($teamIds, $sdeTeamIds, $multipleDatasets)) {
+                if ($this->shouldUseConcierge($teamIds, $sdeTeamIds)) {
                     $teamIds[] = $conciergeId;
                     $teamNames[] = $conciergeName;
                 }
@@ -399,7 +394,7 @@ class EnquiryThreadController extends Controller
             }
 
             if (count($teamIds) > 1) {
-                if ($this->shouldUseConcierge($teamIds, $sdeTeamIds, $multipleDatasets)) {
+                if ($this->shouldUseConcierge($teamIds, $sdeTeamIds)) {
                     $teamIds[] = $conciergeId;
                     $teamNames[] = $conciergeName;
                 }
@@ -435,9 +430,9 @@ class EnquiryThreadController extends Controller
         return $sdeNetwork ? $sdeNetwork->teams->pluck('id')->toArray() : [];
     }
 
-    private function shouldUseConcierge(array $teamIds, array $sdeTeamIds, bool $multipleDatasets): bool
+    private function shouldUseConcierge(array $teamIds, array $sdeTeamIds): bool
     {
-        return !empty(array_intersect($teamIds, $sdeTeamIds)) && $multipleDatasets;
+        return !empty(array_intersect($teamIds, $sdeTeamIds));
     }
 
     private function getTeamFromDataset($dataset): Team

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -375,7 +375,7 @@ class EnquiryThreadController extends Controller
 
             $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
 
-            if (count($teamIds) > 1 && !empty($sdeOverlap)) {
+            if (!empty($sdeOverlap)) {
                 $filteredIds = array_diff($teamIds, $sdeTeamIds);
                 $filteredNames = [];
 
@@ -412,7 +412,7 @@ class EnquiryThreadController extends Controller
 
             $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
 
-            if (count($teamIds) > 1 && !empty($sdeOverlap)) {
+            if (!empty($sdeOverlap)) {
                 $filteredIds = array_diff($teamIds, $sdeTeamIds);
                 $filteredNames = [];
 

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -301,7 +301,6 @@ class EnquiryThreadController extends Controller
         }
     }
 
-
     private function buildPayload(array $input, User $user): array
     {
         return [
@@ -364,77 +363,37 @@ class EnquiryThreadController extends Controller
         $sdeTeamIds = $this->getSdeTeamIds();
 
         if ($input['is_general_enquiry']) {
-            $teamIds = [];
-            $teamNames = [];
-
             foreach ($datasets as $dataset) {
                 $team = Team::find($dataset['team_id']);
-                $teamIds[] = $team->id;
-                $teamNames[] = $team->name;
-            }
-
-            $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
-
-            if (count($teamIds) > 1 && count($sdeOverlap) >= 1) {
-                if (count($sdeOverlap) > 1) {
-                    $filteredIds = array_diff($teamIds, $sdeTeamIds);
-                    $filteredNames = [];
-
-                    foreach ($filteredIds as $id) {
-                        $team = Team::find($id);
-                        $filteredNames[] = $team->name;
-                    }
-
-                    $filteredIds[] = $conciergeId;
-                    $filteredNames[] = $conciergeName;
-
-                    $teamIds = array_values($filteredIds);
-                    $teamNames = array_values($filteredNames);
+                if ($this->shouldUseConcierge($team->id, $sdeTeamIds)) {
+                    $teamIds[] = $conciergeId;
+                    $teamNames[] = $conciergeName;
+                } else {
+                    $teamIds[] = $team->id;
+                    $teamNames[] = $team->name;
                 }
             }
-
         } elseif ($input['is_feasibility_enquiry'] || $input['is_dar_dialogue']) {
+            // Batch load datasets to avoid N+1 queries
             $datasetIds = collect($datasets)->pluck('dataset_id');
-
             $datasetsWithMetadata = Dataset::with('latestMetadata')
                 ->whereIn('id', $datasetIds)
                 ->get()
                 ->keyBy('id');
 
-            $teamIds = [];
-            $teamNames = [];
-
             foreach ($datasets as $dataset) {
                 $datasetModel = $datasetsWithMetadata[$dataset['dataset_id']];
                 $team = $this->getTeamFromDataset($datasetModel);
 
-                $teamIds[] = $team->id;
-                $teamNames[] = $team->name;
-            }
-
-            $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
-
-            if (count($teamIds) > 1 && count($sdeOverlap) >= 1) {
-                if (count($sdeOverlap) > 1) {
-                    $filteredIds = array_diff($teamIds, $sdeTeamIds);
-                    $filteredNames = [];
-
-                    foreach ($filteredIds as $id) {
-                        $team = Team::find($id);
-                        $filteredNames[] = $team->name;
-                    }
-
-                    $filteredIds[] = $conciergeId;
-                    $filteredNames[] = $conciergeName;
-
-                    $teamIds = array_values($filteredIds);
-                    $teamNames = array_values($filteredNames);
+                if ($this->shouldUseConcierge($team->id, $sdeTeamIds)) {
+                    $teamIds[] = $conciergeId;
+                    $teamNames[] = $conciergeName;
+                } else {
+                    $teamIds[] = $team->id;
+                    $teamNames[] = $team->name;
                 }
             }
         }
-
-
-
 
         return [
             'team_ids' => array_unique($teamIds),
@@ -464,9 +423,9 @@ class EnquiryThreadController extends Controller
         return $sdeNetwork ? $sdeNetwork->teams->pluck('id')->toArray() : [];
     }
 
-    private function shouldUseConcierge(array $teamIds, array $sdeTeamIds): bool
+    private function shouldUseConcierge(int $teamId, array $sdeTeamIds): bool
     {
-        return !empty(array_intersect($teamIds, $sdeTeamIds));
+        return in_array($teamId, $sdeTeamIds);
     }
 
     private function getTeamFromDataset($dataset): Team

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -375,20 +375,22 @@ class EnquiryThreadController extends Controller
 
             $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
 
-            if (!empty($sdeOverlap)) {
-                $filteredIds = array_diff($teamIds, $sdeTeamIds);
-                $filteredNames = [];
+            if (count($teamIds) > 1 && count($sdeOverlap) >= 1) {
+                if (count($sdeOverlap) > 1) {
+                    $filteredIds = array_diff($teamIds, $sdeTeamIds);
+                    $filteredNames = [];
 
-                foreach ($filteredIds as $id) {
-                    $team = Team::find($id);
-                    $filteredNames[] = $team->name;
+                    foreach ($filteredIds as $id) {
+                        $team = Team::find($id);
+                        $filteredNames[] = $team->name;
+                    }
+
+                    $filteredIds[] = $conciergeId;
+                    $filteredNames[] = $conciergeName;
+
+                    $teamIds = array_values($filteredIds);
+                    $teamNames = array_values($filteredNames);
                 }
-
-                $filteredIds[] = $conciergeId;
-                $filteredNames[] = $conciergeName;
-
-                $teamIds = array_values($filteredIds);
-                $teamNames = array_values($filteredNames);
             }
 
         } elseif ($input['is_feasibility_enquiry'] || $input['is_dar_dialogue']) {
@@ -412,22 +414,25 @@ class EnquiryThreadController extends Controller
 
             $sdeOverlap = array_intersect($teamIds, $sdeTeamIds);
 
-            if (!empty($sdeOverlap)) {
-                $filteredIds = array_diff($teamIds, $sdeTeamIds);
-                $filteredNames = [];
+            if (count($teamIds) > 1 && count($sdeOverlap) >= 1) {
+                if (count($sdeOverlap) > 1) {
+                    $filteredIds = array_diff($teamIds, $sdeTeamIds);
+                    $filteredNames = [];
 
-                foreach ($filteredIds as $id) {
-                    $team = Team::find($id);
-                    $filteredNames[] = $team->name;
+                    foreach ($filteredIds as $id) {
+                        $team = Team::find($id);
+                        $filteredNames[] = $team->name;
+                    }
+
+                    $filteredIds[] = $conciergeId;
+                    $filteredNames[] = $conciergeName;
+
+                    $teamIds = array_values($filteredIds);
+                    $teamNames = array_values($filteredNames);
                 }
-
-                $filteredIds[] = $conciergeId;
-                $filteredNames[] = $conciergeName;
-
-                $teamIds = array_values($filteredIds);
-                $teamNames = array_values($filteredNames);
             }
         }
+
 
 
 

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -363,48 +363,30 @@ class EnquiryThreadController extends Controller
         $sdeTeamIds = $this->getSdeTeamIds();
 
         if ($input['is_general_enquiry']) {
-            $teamIds = [];
-            $teamNames = [];
-
-            foreach ($datasets as $dataset) {
-                $team = Team::find($dataset['team_id']);
-                $teamIds[] = $team->id;
-                $teamNames[] = $team->name;
-            }
-
+            // gotta get em all team IDs
+            $teamIds = array_map(fn ($dataset) => $dataset['team_id'], $datasets);
+            $teamNames = array_map(fn ($id) => Team::find($id)->name, $teamIds);
 
             $sdeInTeams = array_intersect($teamIds, $sdeTeamIds);
 
-            if (count($sdeInTeams) > 1) {
-
-                $teamIds = array_diff($teamIds, $sdeInTeams);
-                $teamIds[] = $conciergeId;
-
-
-                $teamNames = array_values(array_diff($teamNames, array_map(fn ($id) => Team::find($id)->name, $sdeInTeams)));
-                $teamNames[] = $conciergeName;
-            } elseif (count($sdeInTeams) === 1 && count($teamIds) > 1) {
-
-                $teamIds = array_diff($teamIds, $sdeInTeams);
+            // SDE/Concierge logic
+            if (count($sdeInTeams) > 1 || (count($sdeInTeams) === 1 && count($teamIds) > 1)) {
+                $teamIds = array_values(array_diff($teamIds, $sdeInTeams));
                 $teamIds[] = $conciergeId;
 
                 $teamNames = array_values(array_diff($teamNames, array_map(fn ($id) => Team::find($id)->name, $sdeInTeams)));
                 $teamNames[] = $conciergeName;
             }
 
-            $teamIds = array_values($teamIds);
-            $teamNames = array_values($teamNames);
-
         } elseif ($input['is_feasibility_enquiry'] || $input['is_dar_dialogue']) {
-            $teamIds = [];
-            $teamNames = [];
-
-
             $datasetIds = collect($datasets)->pluck('dataset_id');
             $datasetsWithMetadata = Dataset::with('latestMetadata')
                 ->whereIn('id', $datasetIds)
                 ->get()
                 ->keyBy('id');
+
+            $teamIds = [];
+            $teamNames = [];
 
             foreach ($datasets as $dataset) {
                 $datasetModel = $datasetsWithMetadata[$dataset['dataset_id']];
@@ -413,26 +395,17 @@ class EnquiryThreadController extends Controller
                 $teamNames[] = $team->name;
             }
 
-
             $sdeInTeams = array_intersect($teamIds, $sdeTeamIds);
 
-            if (count($sdeInTeams) > 1) {
-                $teamIds = array_diff($teamIds, $sdeInTeams);
-                $teamIds[] = $conciergeId;
-
-                $teamNames = array_values(array_diff($teamNames, array_map(fn ($id) => Team::find($id)->name, $sdeInTeams)));
-                $teamNames[] = $conciergeName;
-            } elseif (count($sdeInTeams) === 1 && count($teamIds) > 1) {
-                $teamIds = array_diff($teamIds, $sdeInTeams);
+            if (count($sdeInTeams) > 1 || (count($sdeInTeams) === 1 && count($teamIds) > 1)) {
+                $teamIds = array_values(array_diff($teamIds, $sdeInTeams));
                 $teamIds[] = $conciergeId;
 
                 $teamNames = array_values(array_diff($teamNames, array_map(fn ($id) => Team::find($id)->name, $sdeInTeams)));
                 $teamNames[] = $conciergeName;
             }
-
-            $teamIds = array_values($teamIds);
-            $teamNames = array_values($teamNames);
         }
+
 
 
         return [

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -374,7 +374,7 @@ class EnquiryThreadController extends Controller
                 $teamNames[] = $team->name;
 
             }
-            if ($teamIds.length() > 1) {
+            if (count($teamIds) > 1) {
                 // 1/2/3 none sde and 1/2/3 sde - does go to con
                 // 1 sde - does not go to con - exact words from Big Stephen
                 if ($this->shouldUseConcierge($teamIds, $sdeTeamIds, $multipleDatasets)) {
@@ -398,7 +398,7 @@ class EnquiryThreadController extends Controller
                 $teamNames[] = $team->name;
             }
 
-            if ($teamIds.length() > 1) {
+            if (count($teamIds) > 1) {
                 if ($this->shouldUseConcierge($teamIds, $sdeTeamIds, $multipleDatasets)) {
                     $teamIds[] = $conciergeId;
                     $teamNames[] = $conciergeName;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -130,7 +130,7 @@ class User extends Authenticatable
     public function adminTeams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class, 'team_has_users', 'user_id', 'team_id')
-            ->whereHas('teamUsers.roles', fn($q) => $q->where('name', 'custodian.team.admin'));
+            ->whereHas('teamUsers.roles', fn ($q) => $q->where('name', 'custodian.team.admin'));
     }
 
     public function notifications(): BelongsToMany

--- a/app/Services/SDEConciergeService.php
+++ b/app/Services/SDEConciergeService.php
@@ -44,7 +44,7 @@ class SDEConciergeService
                 $teamNames[] = $team->name;
             }
 
-            $sdeInTeams = array_intersect($teamIds, $sdeTeamIds);
+            $sdeInTeams = array_values(array_unique(array_intersect($teamIds, $sdeTeamIds)));
 
             $this->determineEnquiryToSdeTeamOrConcierge(
                 $teamIds,

--- a/app/Services/SDEConciergeService.php
+++ b/app/Services/SDEConciergeService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Team;
 use App\Models\Dataset;
 use App\Models\DataProviderColl;
+use Illuminate\Support\Facades\Log;
 
 class SDEConciergeService
 {
@@ -68,12 +69,19 @@ class SDEConciergeService
         int $conciergeId,
         string $conciergeName
     ): void {
+        Log::info('Debugging SDE determineGeneralEnquiryToSdeTeamOrConcierge', [
+            'teamIds' => $teamIds,
+            'sdeInTeams' => $sdeInTeams,
+            'conciergeId' => $conciergeId,
+        ]);
         if (count($teamIds) === 1) {
+            Log::info('1 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to team that uploaded metadata
             return;
         }
 
         if (empty(array_diff($teamIds, $sdeInTeams))) {
+            Log::info('2 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to SDE Concierge, as all teams are SDE
             $teamIds = [$conciergeId];
             $teamNames = [$conciergeName];
@@ -81,6 +89,7 @@ class SDEConciergeService
         }
 
         if (!empty($sdeInTeams) && !empty(array_diff($teamIds, $sdeInTeams))) {
+            Log::info('3 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to SDE Concierge _and_ teams that uploaded metadata
             $nonSdeTeamIds = array_diff($teamIds, $sdeInTeams);
             $nonSdeTeamNames = array_map(fn ($id) => Team::find($id)->name, $nonSdeTeamIds);
@@ -98,20 +107,29 @@ class SDEConciergeService
         int $conciergeId,
         string $conciergeName
     ): void {
+        Log::info('Debugging SDE determineEnquiryToSdeTeamOrConcierge', [
+            'teamIds' => $teamIds,
+            'sdeInTeams' => $sdeInTeams,
+            'conciergeId' => $conciergeId,
+        ]);
+
         // CASE 1: Single dataset enquiry
         if (count($teamIds) === 1) {
+            Log::info('1 <<<<determineEnquiryToSdeTeamOrConcierge');
             // Whether SDE or non-SDE, honour the custodian
             return;
         }
 
         // CASE 2: Multi-dataset enquiry, all datasets belong to one SDE team
         if (count($sdeInTeams) === 1 && empty(array_diff($teamIds, $sdeInTeams))) {
+            Log::info('2 <<<<determineEnquiryToSdeTeamOrConcierge');
             // All datasets are from a single SDE custodian
             return;
         }
 
         // CASE 3: Multi-dataset enquiry, multiple SDE custodians
         if (count($sdeInTeams) > 1 && empty(array_diff($teamIds, $sdeInTeams))) {
+            Log::info('3 <<<<determineEnquiryToSdeTeamOrConcierge');
             // All datasets are SDE but from different custodians → concierge
             $teamIds = [$conciergeId];
             $teamNames = [$conciergeName];
@@ -120,6 +138,7 @@ class SDEConciergeService
 
         // CASE 4: Multi-dataset enquiry, SDE + non-SDE mix
         if (!empty($sdeInTeams) && !empty(array_diff($teamIds, $sdeInTeams))) {
+            Log::info('4 <<<<determineEnquiryToSdeTeamOrConcierge');
             $nonSdeTeamIds = array_diff($teamIds, $sdeInTeams);
             $nonSdeTeamNames = array_map(fn ($id) => Team::find($id)->name, $nonSdeTeamIds);
 
@@ -130,6 +149,7 @@ class SDEConciergeService
 
         // CASE 5: Multi-dataset enquiry, all non-SDE
         // → honor all custodians
+        Log::info('5 <<<<determineEnquiryToSdeTeamOrConcierge');
         return;
     }
 

--- a/app/Services/SDEConciergeService.php
+++ b/app/Services/SDEConciergeService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Team;
+use App\Models\Dataset;
+use App\Models\DataProviderColl;
+
+class SDEConciergeService
+{
+    public function getSdeTeamConfiguration(array $datasets, array $input): array
+    {
+        [$conciergeId, $conciergeName] = $this->getSdeNetworkConcierge();
+        $sdeTeamIds = $this->getSdeTeamIds();
+        $teamIds = [];
+        $teamNames = [];
+        $dataCustodians = [];
+
+        if ($input['is_general_enquiry']) {
+            $teamIds = array_map(fn ($dataset) => $dataset['team_id'], $datasets);
+            $teamNames = array_map(fn ($id) => Team::find($id)->name, $teamIds);
+
+            $sdeInTeams = array_intersect($teamIds, $sdeTeamIds);
+
+            $this->determineGeneralEnquiryToSdeTeamOrConcierge(
+                $teamIds,
+                $teamNames,
+                $sdeInTeams,
+                $conciergeId,
+                $conciergeName
+            );
+        } elseif ($input['is_feasibility_enquiry'] || $input['is_dar_dialogue']) {
+            $datasetIds = collect($datasets)->pluck('dataset_id');
+            $datasetsWithMetadata = Dataset::with('latestMetadata')
+                ->whereIn('id', $datasetIds)
+                ->get()
+                ->keyBy('id');
+
+            foreach ($datasets as $dataset) {
+                $datasetModel = $datasetsWithMetadata[$dataset['dataset_id']];
+                $team = $this->getTeamFromDataset($datasetModel);
+                $teamIds[] = $team->id;
+                $teamNames[] = $team->name;
+            }
+
+            $sdeInTeams = array_intersect($teamIds, $sdeTeamIds);
+
+            $this->determineEnquiryToSdeTeamOrConcierge(
+                $teamIds,
+                $teamNames,
+                $sdeInTeams,
+                $conciergeId,
+                $conciergeName
+            );
+        }
+
+        return [
+            'team_ids' => array_unique($teamIds),
+            'team_names' => array_unique($teamNames),
+            'data_custodians' => array_unique($dataCustodians),
+        ];
+    }
+
+    public function determineGeneralEnquiryToSdeTeamOrConcierge(
+        array &$teamIds,
+        array &$teamNames,
+        array $sdeInTeams,
+        int $conciergeId,
+        string $conciergeName
+    ): void {
+        if (count($teamIds) === 1) {
+            // Enquiry goes to team that uploaded metadata
+            return;
+        }
+
+        if (empty(array_diff($teamIds, $sdeInTeams))) {
+            // Enquiry goes to SDE Concierge, as all teams are SDE
+            $teamIds = [$conciergeId];
+            $teamNames = [$conciergeName];
+            return;
+        }
+
+        if (!empty($sdeInTeams) && !empty(array_diff($teamIds, $sdeInTeams))) {
+            // Enquiry goes to SDE Concierge _and_ teams that uploaded metadata
+            $nonSdeTeamIds = array_diff($teamIds, $sdeInTeams);
+            $nonSdeTeamNames = array_map(fn ($id) => Team::find($id)->name, $nonSdeTeamIds);
+
+            $teamIds = array_merge([$conciergeId], $nonSdeTeamIds);
+            $teamNames = array_merge([$conciergeName], $nonSdeTeamNames);
+            return;
+        }
+    }
+
+    public function determineEnquiryToSdeTeamOrConcierge(array &$teamIds, array &$teamNames, array $sdeInTeams, int $conciergeId, string $conciergeName): void
+    {
+        if (count($sdeInTeams) > 1 || (count($sdeInTeams) === 1 && count($teamIds) > 1)) {
+            // Enquiry goes to SDE Concierge, as multiple SDE teams or SDE and non-SDE teams
+            $teamIds = array_values(array_diff($teamIds, $sdeInTeams));
+            $teamIds[] = $conciergeId;
+
+            $teamNames = array_values(array_diff($teamNames, array_map(fn ($id) => Team::find($id)->name, $sdeInTeams)));
+            $teamNames[] = $conciergeName;
+            return;
+        }
+
+        // Enquiry goes to team that uploaded metadata
+        return;
+    }
+
+    public function getSdeNetworkConcierge(): array
+    {
+        $team = Team::where('name', 'LIKE', '%SDE Network%')->first(); // why not a boolean flag?!
+        if ($team) {
+            return [$team->id, $team->name];
+        }
+
+        return [null, null];
+    }
+
+    public function getSdeTeamIds(): array
+    {
+        $sdeNetwork = DataProviderColl::where('name', 'LIKE', '%SDE%')
+            ->with('teams')
+            ->first();
+
+        return $sdeNetwork ? $sdeNetwork->teams->pluck('id')->toArray() : [];
+    }
+
+    public function shouldUseConcierge(int $teamId, array $sdeTeamIds): bool
+    {
+        return in_array($teamId, $sdeTeamIds);
+    }
+
+    public function getTeamFromDataset($dataset): Team
+    {
+        $gatewayId = $dataset->latestMetadata->metadata['metadata']['summary']['publisher']['gatewayId'] ?? null;
+        return is_numeric($gatewayId)
+            ? Team::find((int) $gatewayId)
+            : Team::where('pid', $gatewayId)->first();
+    }
+}

--- a/app/Services/SDEConciergeService.php
+++ b/app/Services/SDEConciergeService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use App\Models\Team;
 use App\Models\Dataset;
 use App\Models\DataProviderColl;
-use Illuminate\Support\Facades\Log;
 
 class SDEConciergeService
 {
@@ -69,19 +68,13 @@ class SDEConciergeService
         int $conciergeId,
         string $conciergeName
     ): void {
-        Log::info('Debugging SDE determineGeneralEnquiryToSdeTeamOrConcierge', [
-            'teamIds' => $teamIds,
-            'sdeInTeams' => $sdeInTeams,
-            'conciergeId' => $conciergeId,
-        ]);
+
         if (count($teamIds) === 1) {
-            Log::info('1 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to team that uploaded metadata
             return;
         }
 
         if (empty(array_diff($teamIds, $sdeInTeams))) {
-            Log::info('2 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to SDE Concierge, as all teams are SDE
             $teamIds = [$conciergeId];
             $teamNames = [$conciergeName];
@@ -89,7 +82,6 @@ class SDEConciergeService
         }
 
         if (!empty($sdeInTeams) && !empty(array_diff($teamIds, $sdeInTeams))) {
-            Log::info('3 <<<<determineGeneralEnquiryToSdeTeamOrConcierge');
             // Enquiry goes to SDE Concierge _and_ teams that uploaded metadata
             $nonSdeTeamIds = array_diff($teamIds, $sdeInTeams);
             $nonSdeTeamNames = array_map(fn ($id) => Team::find($id)->name, $nonSdeTeamIds);
@@ -107,29 +99,21 @@ class SDEConciergeService
         int $conciergeId,
         string $conciergeName
     ): void {
-        Log::info('Debugging SDE determineEnquiryToSdeTeamOrConcierge', [
-            'teamIds' => $teamIds,
-            'sdeInTeams' => $sdeInTeams,
-            'conciergeId' => $conciergeId,
-        ]);
 
         // CASE 1: Single dataset enquiry
         if (count($teamIds) === 1) {
-            Log::info('1 <<<<determineEnquiryToSdeTeamOrConcierge');
             // Whether SDE or non-SDE, honour the custodian
             return;
         }
 
         // CASE 2: Multi-dataset enquiry, all datasets belong to one SDE team
         if (count($sdeInTeams) === 1 && empty(array_diff($teamIds, $sdeInTeams))) {
-            Log::info('2 <<<<determineEnquiryToSdeTeamOrConcierge');
             // All datasets are from a single SDE custodian
             return;
         }
 
         // CASE 3: Multi-dataset enquiry, multiple SDE custodians
         if (count($sdeInTeams) > 1 && empty(array_diff($teamIds, $sdeInTeams))) {
-            Log::info('3 <<<<determineEnquiryToSdeTeamOrConcierge');
             // All datasets are SDE but from different custodians → concierge
             $teamIds = [$conciergeId];
             $teamNames = [$conciergeName];
@@ -138,7 +122,6 @@ class SDEConciergeService
 
         // CASE 4: Multi-dataset enquiry, SDE + non-SDE mix
         if (!empty($sdeInTeams) && !empty(array_diff($teamIds, $sdeInTeams))) {
-            Log::info('4 <<<<determineEnquiryToSdeTeamOrConcierge');
             $nonSdeTeamIds = array_diff($teamIds, $sdeInTeams);
             $nonSdeTeamNames = array_map(fn ($id) => Team::find($id)->name, $nonSdeTeamIds);
 
@@ -149,7 +132,6 @@ class SDEConciergeService
 
         // CASE 5: Multi-dataset enquiry, all non-SDE
         // → honor all custodians
-        Log::info('5 <<<<determineEnquiryToSdeTeamOrConcierge');
         return;
     }
 

--- a/app/Traits/GatewayMetadataIngestionTrait.php
+++ b/app/Traits/GatewayMetadataIngestionTrait.php
@@ -39,7 +39,7 @@ trait GatewayMetadataIngestionTrait
 
         $response = Http::get(
             $url,
-            [ 
+            [
                 $this->determineAuthType($federation, $gsms),
                 'Accept' => 'application/json',
             ]
@@ -144,7 +144,7 @@ trait GatewayMetadataIngestionTrait
 
                 $this->log('info', "attempting to call dataset @ {$pid} from REMOTE collection: 
                     status={$response->status()}, url={$this->makeDatasetUrl($federation, $data)}");
-                
+
                 if ($response->status() === 200) {
                     try {
                         $input = [

--- a/database/migrations/2025_09_05_100621_update_sde_network_concierge_email.php
+++ b/database/migrations/2025_09_05_100621_update_sde_network_concierge_email.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('teams')
+            ->where('name', 'SDE Network Concierge')
+            ->update(['contact_point' => 'england.data.healthresearch@nhs.net']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('teams')
+            ->where('name', 'SDE Network Concierge')
+            ->update(['contact_point' => 'data.healthresearch@nhs.net']);
+    }
+};

--- a/tests/Feature/EnquiryThreadTest.php
+++ b/tests/Feature/EnquiryThreadTest.php
@@ -445,7 +445,7 @@ class EnquiryThreadTest extends TestCase
             ],
         ];
 
-        // Multi-dataset enquiry directs to concierge
+        // Multi-dataset enquiry should not direct to concierge, because its 1 sde
         $body = [
             'project_title' => 'Test Enquiry',
             'from' => 'example.test@hdruk.ac.uk',
@@ -472,9 +472,9 @@ class EnquiryThreadTest extends TestCase
 
         $numThreadsAfter = EnquiryThread::count();
 
-        // Test that an email was sent to the network concierge
+        // Test that an email was not sent to the network concierge
         Queue::assertPushed(function (SendEmailJob $email) {
-            return $email->to['to']['name'] === 'SDE Network Concierge';
+            return $email->to['to']['name'] !== 'SDE Network Concierge';
         });
 
         $this->assertEquals($numThreadsAfter, $numThreadsBefore + count($datasets));

--- a/tests/Feature/EnquiryThreadTest.php
+++ b/tests/Feature/EnquiryThreadTest.php
@@ -445,7 +445,7 @@ class EnquiryThreadTest extends TestCase
             ],
         ];
 
-        // Multi-dataset enquiry should not direct to concierge, because its 1 sde
+        // Multi-dataset enquiry directs to concierge
         $body = [
             'project_title' => 'Test Enquiry',
             'from' => 'example.test@hdruk.ac.uk',
@@ -472,9 +472,9 @@ class EnquiryThreadTest extends TestCase
 
         $numThreadsAfter = EnquiryThread::count();
 
-        // Test that an email was not sent to the network concierge
+        // Test that an email was sent to the network concierge
         Queue::assertPushed(function (SendEmailJob $email) {
-            return $email->to['to']['name'] !== 'SDE Network Concierge';
+            return $email->to['to']['name'] === 'SDE Network Concierge';
         });
 
         $this->assertEquals($numThreadsAfter, $numThreadsBefore + count($datasets));


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

example
$teamIds = [1,2,3,4,5,6,7,8,9]
$sdeTeamIds = [2,3,4,5]
$conciergeId = 10

expected result: [1,6,7,8,9,10]

example
$teamIds = [1,2]
$sdeTeamIds = [2,3,4,5]
$conciergeId = 10

expected result: [1,10]

example
$teamIds = [1,2,3]
$sdeTeamIds = [2,3,4,5]
$conciergeId = 10

expected result: [1,10]

// THIS IS THE ANNOYING ONE
// if the teamid is singular and is an SDE dont be con be an sde id
example
$teamIds = [2]
$sdeTeamIds = [2,3,4,5]
$conciergeId = 10

expected result: [2]

example
$teamIds = [1,8,9]
$sdeTeamIds = [2,3,4,5]
$conciergeId = 10

expected result: [1,8,9]

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
php artisan migrate --path=/database/migrations/2025_09_05_100621_update_sde_network_concierge_email.php
## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
