### PR TITLE
fix!(GAT-7816): User can select unverified email for receiving notifications

### DIFF
--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -477,6 +477,9 @@ class UserController extends Controller
                         // below if a user already has a secondary verified email and is changing
                         $array['secondary_email_verified_at'] = null;
 
+                        // Set the preferred email notification to primary as the secondary isn't verified
+                        $array['preferred_email'] = "primary";
+
                         EmailVerification::where('user_id', $user->id)->update(['expires_at' => now()]);
 
                         $newToken = Str::uuid();


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Added a check that the secondary email has been verified.

FE PR: https://github.com/HDRUK/gateway-web/pull/1315

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7816

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
