### PR TITLE
fix!(GAT-7759): Added sanitation on the search term and filters to search requests

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -53,6 +53,7 @@ use App\Http\Requests\Search\PublicationSearch;
 use Illuminate\Http\Client\ConnectionException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use App\Http\Requests\Search\Search;
+
 class SearchController extends Controller
 {
     use IndexElastic;

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -49,11 +49,10 @@ use App\Models\ToolHasProgrammingPackage;
 use App\Models\ToolHasProgrammingLanguage;
 use App\Http\Traits\GetValueByPossibleKeys;
 use App\Models\PublicationHasDatasetVersion;
-use Illuminate\Database\Eloquent\Casts\Json;
 use App\Http\Requests\Search\PublicationSearch;
 use Illuminate\Http\Client\ConnectionException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-
+use App\Http\Requests\Search\Search;
 class SearchController extends Controller
 {
     use IndexElastic;
@@ -144,7 +143,7 @@ class SearchController extends Controller
      *      )
      * )
      */
-    public function datasets(Request $request): JsonResponse|BinaryFileResponse
+    public function datasets(Search $request): JsonResponse|BinaryFileResponse
     {
         try {
             $loggingContext = $this->getLoggingContext($request);
@@ -478,7 +477,7 @@ class SearchController extends Controller
      *      )
      * )
      */
-    public function tools(Request $request): JsonResponse|BinaryFileResponse
+    public function tools(Search $request): JsonResponse|BinaryFileResponse
     {
         try {
             $loggingContext = $this->getLoggingContext($request);
@@ -723,7 +722,7 @@ class SearchController extends Controller
      *      )
      * )
      */
-    public function collections(Request $request): JsonResponse
+    public function collections(Search $request): JsonResponse
     {
         try {
             $loggingContext = $this->getLoggingContext($request);
@@ -895,12 +894,13 @@ class SearchController extends Controller
      *      )
      * )
      */
-    public function dataUses(Request $request): JsonResponse|BinaryFileResponse
+    public function dataUses(Search $request): JsonResponse|BinaryFileResponse
     {
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
         $input = $request->all();
+
         $download = array_key_exists('download', $input) ? $input['download'] : false;
         $sort = $request->query('sort', 'score:desc');
 
@@ -1738,7 +1738,7 @@ class SearchController extends Controller
      *      )
      * )
      */
-    public function dataCustodians(Request $request): JsonResponse|BinaryFileResponse
+    public function dataCustodians(Search $request): JsonResponse|BinaryFileResponse
     {
         try {
             $loggingContext = $this->getLoggingContext($request);

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1129,7 +1129,6 @@ class SearchController extends Controller
             $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
             $input = $request->all();
-
             $download = array_key_exists('download', $input) ? $input['download'] : false;
             $sort = $request->query('sort', 'score:desc');
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -25,6 +25,7 @@ class Kernel extends HttpKernel
         \Illuminate\Session\Middleware\StartSession::class,
         \App\Http\Middleware\HstsMiddleware::class,
         \App\Http\Middleware\DefineFeatureFlags::class,
+        \App\Http\Middleware\ValidateRequestID::class,
         \App\Http\Middleware\LogRequestResponse::class,
     ];
 

--- a/app/Http/Middleware/ValidateRequestID.php
+++ b/app/Http/Middleware/ValidateRequestID.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use App\Exceptions\UnauthorizedException;
+
+class ValidateRequestID
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $header = $request->header('x-request-session-id');
+        \Log::info($header);
+        \Log::info(!preg_match('/^[a-zA-Z0-9-]+$/', $header));
+        if ($header !== null && !preg_match('/^[a-zA-Z0-9-]+$/', $header)) {
+            throw new UnauthorizedException('The credentials provided are invalid');
+
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ValidateRequestID.php
+++ b/app/Http/Middleware/ValidateRequestID.php
@@ -18,6 +18,7 @@ class ValidateRequestID
     {
         $header = $request->header('x-request-session-id', "");
         // Header can have web: appended to it by front end
+        // so can't just be alphanumeric and -
         if ($header !== "" && !preg_match('/^[a-zA-Z0-9: -]+$/', $header)) {
             throw new UnauthorizedException('The credentials provided are invalid');
 

--- a/app/Http/Middleware/ValidateRequestID.php
+++ b/app/Http/Middleware/ValidateRequestID.php
@@ -16,10 +16,9 @@ class ValidateRequestID
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $header = $request->header('x-request-session-id');
-        \Log::info($header);
-        \Log::info(!preg_match('/^[a-zA-Z0-9-]+$/', $header));
-        if ($header !== null && !preg_match('/^[a-zA-Z0-9-]+$/', $header)) {
+        $header = trim($request->header('x-request-session-id'));
+        // Header can have web: appended to it by front end
+        if ($header !== null && !preg_match('/^[a-zA-Z0-9: -]+$/', $header)) {
             throw new UnauthorizedException('The credentials provided are invalid');
 
         }

--- a/app/Http/Middleware/ValidateRequestID.php
+++ b/app/Http/Middleware/ValidateRequestID.php
@@ -16,9 +16,9 @@ class ValidateRequestID
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $header = trim($request->header('x-request-session-id'));
+        $header = $request->header('x-request-session-id', "");
         // Header can have web: appended to it by front end
-        if ($header !== null && !preg_match('/^[a-zA-Z0-9: -]+$/', $header)) {
+        if ($header !== "" && !preg_match('/^[a-zA-Z0-9: -]+$/', $header)) {
             throw new UnauthorizedException('The credentials provided are invalid');
 
         }

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -35,8 +35,12 @@ class PublicationSearch extends BaseFormRequest
                         }
                         return;
                     }
+                    // Allow URL
+                    if (filter_var($value, FILTER_VALIDATE_URL)) {
+                        return;
+                    }
                     // If none of the above, fail
-                    $fail('The '.$attribute.' must be a string, an array, or empty.');
+                    $fail('The '.$attribute.' must be a string, an array, a URL, or empty.');
                 },
                 'max:255',
             ],

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -22,7 +22,7 @@ class PublicationSearch extends BaseFormRequest
                         return;
                     }
                     // Allow string (alphanumeric)
-                    if (is_string($value) && preg_match('/^[a-zA-Z0-9]*$/', $value)) {
+                    if (is_string($value) && preg_match('/^[a-zA-Z0-9\s]*$/', $value)) {
                         return;
                     }
                     // Allow array of alphanumeric strings

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -16,13 +16,29 @@ class PublicationSearch extends BaseFormRequest
         return [
             'query' => [
                 'nullable',
-                'sometimes',
-                'array',
-            ],
-            'query.*' => [
-                'nullable',
-                'alpha_num:ascii',
-                'max:255'
+                function ($attribute, $value, $fail) {
+                    // Allow empty
+                    if (is_null($value) || $value === '') {
+                        return;
+                    }
+                    // Allow string (alphanumeric)
+                    if (is_string($value) && preg_match('/^[a-zA-Z0-9]*$/', $value)) {
+                        return;
+                    }
+                    // Allow array of alphanumeric strings
+                    if (is_array($value)) {
+                        foreach ($value as $item) {
+                            if (!is_string($item) || !preg_match('/^[a-zA-Z0-9]*$/', $item)) {
+                                $fail('The '.$attribute.' must be alphanumeric or an array of alphanumeric strings.');
+                                return;
+                            }
+                        }
+                        return;
+                    }
+                    // If none of the above, fail
+                    $fail('The '.$attribute.' must be a string, an array, or empty.');
+                },
+                'max:255',
             ],
             'source' => [
                 'nullable',

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -15,8 +15,13 @@ class PublicationSearch extends BaseFormRequest
     {
         return [
             'query' => [
-                'alpha_dash',
                 'nullable',
+                'sometimes',
+                'array',
+            ],
+            'query.*' => [
+                'nullable',
+                'alpha_num:ascii',
                 'max:255'
             ],
             'source' => [

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -6,6 +6,13 @@ use App\Http\Requests\BaseFormRequest;
 
 class PublicationSearch extends BaseFormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'query' => preg_replace('/[^a-zA-Z0-9_-]/', '', $this->input('query')),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -16,28 +23,6 @@ class PublicationSearch extends BaseFormRequest
         return [
             'query' => [
                 'nullable',
-                function ($attribute, $value, $fail) {
-                    // Allow string (alphanumeric)
-                    if (is_string($value) && preg_match('/^[a-zA-Z0-9\s]*$/', $value)) {
-                        return;
-                    }
-                    // Allow array of alphanumeric strings
-                    if (is_array($value)) {
-                        foreach ($value as $item) {
-                            if (!is_string($item) || !preg_match('/^[a-zA-Z0-9\s]*$/', $item)) {
-                                $fail('The '.$attribute.' must be alphanumeric or an array of alphanumeric strings.');
-                                return;
-                            }
-                        }
-                        return;
-                    }
-                    // Allow URL
-                    if (is_string($value) && filter_var($value, FILTER_VALIDATE_URL)) {
-                        return;
-                    }
-                    // If none of the above, fail
-                    $fail('The '.$attribute.' must be an alphanumeric string, an array, a URL, or empty.');
-                },
                 'max:255',
             ],
             'source' => [
@@ -45,16 +30,11 @@ class PublicationSearch extends BaseFormRequest
                 'string',
                 'in:GAT,FED',
             ],
+            'page' => 'integer',
+            'per_page' => 'integer',
+            'sort' => [
+                'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i'
+            ],
         ];
-    }
-
-    /**
-     * Add Query parameters to the FormRequest.
-     *
-     * @return void
-     */
-    protected function prepareForValidation()
-    {
-        $this->merge(['source' => $this->query('source')]);
     }
 }

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -6,10 +6,22 @@ use App\Http\Requests\BaseFormRequest;
 
 class PublicationSearch extends BaseFormRequest
 {
+    private function validateQuery($query) {
+        if (filter_var($query, FILTER_VALIDATE_URL)) {
+            $parse = parse_url($query);
+            if ($parse['host'] === "doi.org") {
+                return $query;
+            }
+        }
+
+        return preg_replace('/[^a-zA-Z0-9_-]/', '', $query);
+    }
+
     protected function prepareForValidation(): void
     {
         $this->merge([
-            'query' => preg_replace('/[^a-zA-Z0-9_-]/', '', $this->input('query')),
+            'query' => $this->validateQuery($this->input('query')),
+            'source' => $this->source ?? 'GAT'
         ]);
     }
 
@@ -33,7 +45,8 @@ class PublicationSearch extends BaseFormRequest
             'page' => 'integer',
             'per_page' => 'integer',
             'sort' => [
-                'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i'
+                'regex:/^(projectTitle|created_at|year_of_publication|updated_at|name|score|date|title):(asc|desc)$/i',
+                'nullable'
             ],
         ];
     }

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -17,10 +17,6 @@ class PublicationSearch extends BaseFormRequest
             'query' => [
                 'nullable',
                 function ($attribute, $value, $fail) {
-                    // Allow empty
-                    if (is_null($value) || $value === '') {
-                        return;
-                    }
                     // Allow string (alphanumeric)
                     if (is_string($value) && preg_match('/^[a-zA-Z0-9\s]*$/', $value)) {
                         return;
@@ -36,11 +32,11 @@ class PublicationSearch extends BaseFormRequest
                         return;
                     }
                     // Allow URL
-                    if (filter_var($value, FILTER_VALIDATE_URL)) {
+                    if (is_string($value) && filter_var($value, FILTER_VALIDATE_URL)) {
                         return;
                     }
                     // If none of the above, fail
-                    $fail('The '.$attribute.' must be a string, an array, a URL, or empty.');
+                    $fail('The '.$attribute.' must be an alphanumeric string, an array, a URL, or empty.');
                 },
                 'max:255',
             ],

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -28,7 +28,7 @@ class PublicationSearch extends BaseFormRequest
                     // Allow array of alphanumeric strings
                     if (is_array($value)) {
                         foreach ($value as $item) {
-                            if (!is_string($item) || !preg_match('/^[a-zA-Z0-9]*$/', $item)) {
+                            if (!is_string($item) || !preg_match('/^[a-zA-Z0-9\s]*$/', $item)) {
                                 $fail('The '.$attribute.' must be alphanumeric or an array of alphanumeric strings.');
                                 return;
                             }

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\Search;
 
 use App\Http\Requests\BaseFormRequest;
 
-class PublicationSearch extends BaseFormRequest
+class Search extends BaseFormRequest
 {
     /**
      * Get the validation rules that apply to the request.
@@ -19,21 +19,10 @@ class PublicationSearch extends BaseFormRequest
                 'nullable',
                 'max:255'
             ],
-            'source' => [
-                'nullable',
-                'string',
-                'in:GAT,FED',
+            'sort' => [
+                'regex:/^(score|date|title):(asc|desc)$/i'
             ],
+            'download' => 'boolean',
         ];
-    }
-
-    /**
-     * Add Query parameters to the FormRequest.
-     *
-     * @return void
-     */
-    protected function prepareForValidation()
-    {
-        $this->merge(['source' => $this->query('source')]);
     }
 }

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -22,7 +22,6 @@ class Search extends BaseFormRequest
     {
         return [
             'query' => [
-                'alpha_dash',
                 'nullable',
                 'max:255'
             ],

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -6,6 +6,13 @@ use App\Http\Requests\BaseFormRequest;
 
 class Search extends BaseFormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'query' => preg_replace('/[^a-zA-Z0-9_-]/', '', $this->input('query')),
+        ]);
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -26,7 +26,8 @@ class Search extends BaseFormRequest
                 'max:255'
             ],
             'sort' => [
-                'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i'
+                'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i',
+                'nullable'
             ],
             'page' => 'integer',
             'view_type' => ['nullable', 'in:full,mini'],

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -22,6 +22,9 @@ class Search extends BaseFormRequest
             'sort' => [
                 'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i'
             ],
+            'page' => 'integer',
+            'view_type' => ['nullable', 'in:full,mini'],
+            'per_page' => 'integer',
             'download' => 'boolean',
         ];
     }

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -20,7 +20,7 @@ class Search extends BaseFormRequest
                 'max:255'
             ],
             'sort' => [
-                'regex:/^(updated_at|name|score|date|title):(asc|desc)$/i'
+                'regex:/^(projectTitle|updated_at|name|score|date|title):(asc|desc)$/i'
             ],
             'download' => 'boolean',
         ];

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -20,7 +20,7 @@ class Search extends BaseFormRequest
                 'max:255'
             ],
             'sort' => [
-                'regex:/^(score|date|title):(asc|desc)$/i'
+                'regex:/^(updated_at|name|score|date|title):(asc|desc)$/i'
             ],
             'download' => 'boolean',
         ];


### PR DESCRIPTION
## Screenshots (if relevant)
https://github.com/user-attachments/assets/3bab34b1-e051-4958-9a27-85cf255cd30d


## Describe your changes
Search terms are now stripped of non alphanumeric or - and _ characters
Filters can now only be set to specific values
x-header-request-id is now validated to only be alphanumeric plus : and -

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7759
https://hdruk.atlassian.net/browse/GAT-7760

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
