### PR TITLE
feat(GAT-7856): Never return a bare Exception object

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -916,7 +916,7 @@ class DatasetController extends Controller
                 'description' => $e->getMessage(),
             ]);
 
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 

--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -383,7 +383,7 @@ class TeamController extends Controller
                 'description' => $e,
             ]);
 
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 
@@ -1227,7 +1227,7 @@ class TeamController extends Controller
             );
 
         } catch (Exception $e) {
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -593,7 +593,7 @@ class DatasetController extends Controller
                 'description' => $e->getMessage(),
             ]);
 
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -666,7 +666,7 @@ class TeamDatasetController extends Controller
                 'description' => $e->getMessage(),
             ]);
 
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 

--- a/app/Http/Controllers/SSO/CustomLogoutController.php
+++ b/app/Http/Controllers/SSO/CustomLogoutController.php
@@ -28,7 +28,7 @@ class CustomLogoutController extends Controller
             $redirectUrl = env('GATEWAY_URL');
             return redirect()->away($redirectUrl);
         } catch (Exception $e) {
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 }

--- a/app/Http/Controllers/SSO/CustomUserController.php
+++ b/app/Http/Controllers/SSO/CustomUserController.php
@@ -69,7 +69,7 @@ class CustomUserController extends Controller
                 'rquestroles' => $rRoles,
             ]);
         } catch (Exception $e) {
-            throw new Exception($e);
+            throw new Exception($e->getMessage());
         }
     }
 }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
All instances of 
```
throw new Exception($e);
```
replaced with 
```
throw new Exception($e->getMessage());
```
## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7856

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
