### PR TITLE
feat(GAT-7864): Update scanning (clamav) service with basic auth

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,13 +4,13 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "feat/gat-7864"
+      - 'dev'
 
 env:
-  PROJECT_ID: "${{ secrets.PROJECT_ID }}"
-  GAR_LOCATION: "${{ secrets.GAR_LOCATION }}"
-  SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL}}"
-  SLACK_CHANNEL: "${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}"
+  PROJECT_ID: '${{ secrets.PROJECT_ID }}'
+  GAR_LOCATION: '${{ secrets.GAR_LOCATION }}'
+  SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL}}'
+  SLACK_CHANNEL: '${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}'
 
 jobs:
   build:
@@ -26,21 +26,21 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "feat/gat-7864"
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
         run: |
-          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
 
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: 'google-github-actions/auth@v2'
         with:
-          token_format: "access_token"
-          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
-          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
+          token_format: 'access_token'
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Login to GAR
         id: garlogin
@@ -53,11 +53,11 @@ jobs:
       - name: Build and Push Container
         id: build
         shell: bash
-        env:
+        env: 
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-
+          
         run: |-
           docker build -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:latest ./
           docker push --all-tags '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}
@@ -76,22 +76,22 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: "feat/gat-7864"
+          ref: dev
 
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: 'google-github-actions/auth@v2'
         with:
-          token_format: "access_token"
-          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
-          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
+          token_format: 'access_token'
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Read VERSION file
         id: getversion
         run: |
-          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
-
+            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+          
       - name: Deploy to Cloud Run
         uses: actions-hub/gcloud@master
         id: deploy
@@ -99,11 +99,11 @@ jobs:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          SERVICE_NAME: "${{ secrets.SERVICE_NAME_API }}"
-          SERVICE_REGION: "${{ secrets.SERVICE_REGION_API }}"
+          SERVICE_NAME: '${{ secrets.SERVICE_NAME_API }}'
+          SERVICE_REGION: '${{ secrets.SERVICE_REGION_API }}'
 
         with:
-          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}'
+          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}' 
 
       - name: Run Notification
         id: runnotificationsent

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,13 +4,13 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - "feat/gat-7864"
 
 env:
-  PROJECT_ID: '${{ secrets.PROJECT_ID }}'
-  GAR_LOCATION: '${{ secrets.GAR_LOCATION }}'
-  SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL}}'
-  SLACK_CHANNEL: '${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}'
+  PROJECT_ID: "${{ secrets.PROJECT_ID }}"
+  GAR_LOCATION: "${{ secrets.GAR_LOCATION }}"
+  SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL}}"
+  SLACK_CHANNEL: "${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}"
 
 jobs:
   build:
@@ -26,21 +26,21 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: feat/gat-7864
 
       - name: Read VERSION file
         id: getversion
         run: |
-            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          token_format: 'access_token'
-          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
-          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
+          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
 
       - name: Login to GAR
         id: garlogin
@@ -53,11 +53,11 @@ jobs:
       - name: Build and Push Container
         id: build
         shell: bash
-        env: 
+        env:
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          
+
         run: |-
           docker build -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:latest ./
           docker push --all-tags '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}
@@ -76,22 +76,22 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: feat/gat-7864
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          token_format: 'access_token'
-          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
-          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
+          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
 
       - name: Read VERSION file
         id: getversion
         run: |
-            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
-          
+          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+
       - name: Deploy to Cloud Run
         uses: actions-hub/gcloud@master
         id: deploy
@@ -99,11 +99,11 @@ jobs:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          SERVICE_NAME: '${{ secrets.SERVICE_NAME_API }}'
-          SERVICE_REGION: '${{ secrets.SERVICE_REGION_API }}'
+          SERVICE_NAME: "${{ secrets.SERVICE_NAME_API }}"
+          SERVICE_REGION: "${{ secrets.SERVICE_REGION_API }}"
 
         with:
-          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}' 
+          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}'
 
       - name: Run Notification
         id: runnotificationsent

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,13 +4,13 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - "feat/gat-7864"
+      - 'dev'
 
 env:
-  PROJECT_ID: "${{ secrets.PROJECT_ID }}"
-  GAR_LOCATION: "${{ secrets.GAR_LOCATION }}"
-  SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL}}"
-  SLACK_CHANNEL: "${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}"
+  PROJECT_ID: '${{ secrets.PROJECT_ID }}'
+  GAR_LOCATION: '${{ secrets.GAR_LOCATION }}'
+  SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL}}'
+  SLACK_CHANNEL: '${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}'
 
 jobs:
   build:
@@ -26,21 +26,21 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: feat/gat-7864
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
         run: |
-          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
 
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: 'google-github-actions/auth@v2'
         with:
-          token_format: "access_token"
-          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
-          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
+          token_format: 'access_token'
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Login to GAR
         id: garlogin
@@ -53,11 +53,11 @@ jobs:
       - name: Build and Push Container
         id: build
         shell: bash
-        env:
+        env: 
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-
+          
         run: |-
           docker build -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:latest ./
           docker push --all-tags '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}
@@ -76,22 +76,22 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: feat/gat-7864
+          ref: dev
 
       - name: Google Auth
         id: auth
-        uses: "google-github-actions/auth@v2"
+        uses: 'google-github-actions/auth@v2'
         with:
-          token_format: "access_token"
-          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
-          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
+          token_format: 'access_token'
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
 
       - name: Read VERSION file
         id: getversion
         run: |
-          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
-
+            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+          
       - name: Deploy to Cloud Run
         uses: actions-hub/gcloud@master
         id: deploy
@@ -99,11 +99,11 @@ jobs:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          SERVICE_NAME: "${{ secrets.SERVICE_NAME_API }}"
-          SERVICE_REGION: "${{ secrets.SERVICE_REGION_API }}"
+          SERVICE_NAME: '${{ secrets.SERVICE_NAME_API }}'
+          SERVICE_REGION: '${{ secrets.SERVICE_REGION_API }}'
 
         with:
-          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}'
+          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}' 
 
       - name: Run Notification
         id: runnotificationsent

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,13 +4,13 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - "feat/gat-7864"
 
 env:
-  PROJECT_ID: '${{ secrets.PROJECT_ID }}'
-  GAR_LOCATION: '${{ secrets.GAR_LOCATION }}'
-  SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK_URL}}'
-  SLACK_CHANNEL: '${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}'
+  PROJECT_ID: "${{ secrets.PROJECT_ID }}"
+  GAR_LOCATION: "${{ secrets.GAR_LOCATION }}"
+  SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL}}"
+  SLACK_CHANNEL: "${{ secrets.GITHUBACTIONS_SLACK_CHANNEL }}"
 
 jobs:
   build:
@@ -26,21 +26,21 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: "feat/gat-7864"
 
       - name: Read VERSION file
         id: getversion
         run: |
-            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          token_format: 'access_token'
-          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
-          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
+          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
 
       - name: Login to GAR
         id: garlogin
@@ -53,11 +53,11 @@ jobs:
       - name: Build and Push Container
         id: build
         shell: bash
-        env: 
+        env:
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          
+
         run: |-
           docker build -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} -t '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:latest ./
           docker push --all-tags '${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}
@@ -76,22 +76,22 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: "feat/gat-7864"
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          token_format: 'access_token'
-          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' 
-          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}'
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.WIF_PROVIDER }}"
+          service_account: "${{ secrets.WIF_SERVICE_ACCOUNT }}"
 
       - name: Read VERSION file
         id: getversion
         run: |
-            sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
-            echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
-          
+          sed -n 's/^appVersion:\(.*\)/\1/p' < chart/gateway-api/Chart.yaml > version
+          echo "version=$(sed '/.*\"\(.*\)\".*/ s//\1/g' version)" >> $GITHUB_OUTPUT
+
       - name: Deploy to Cloud Run
         uses: actions-hub/gcloud@master
         id: deploy
@@ -99,11 +99,11 @@ jobs:
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           GAR_LOCATION: ${{ secrets.GAR_LOCATION }}
           GAR_NAME: ${{ secrets.GAR_NAME_API }}
-          SERVICE_NAME: '${{ secrets.SERVICE_NAME_API }}'
-          SERVICE_REGION: '${{ secrets.SERVICE_REGION_API }}'
+          SERVICE_NAME: "${{ secrets.SERVICE_NAME_API }}"
+          SERVICE_REGION: "${{ secrets.SERVICE_REGION_API }}"
 
         with:
-          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}' 
+          args: run services update '${{ env.SERVICE_NAME }}' --image='${{ env.GAR_LOCATION }}'-docker.pkg.dev/'${{ env.PROJECT_ID }}'/'${{ env.GAR_NAME }}'/${{ steps.getversion.outputs.version }}:${{ github.sha }} --region='${{ env.SERVICE_REGION }}' --project='${{ env.PROJECT_ID }}'
 
       - name: Run Notification
         id: runnotificationsent

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -137,7 +137,7 @@ class ScanFileUpload implements ShouldQueue
             )->post(env('CLAMAV_API_URL', 'http://clamav:3001') . '/scan_file');
 
             if (!$response->successful()) {
-                if ($response->getStatusCode() === Response::HTTP_UNAUTHORIZED) {
+                if ($response->status() === Response::HTTP_UNAUTHORIZED) {
                     \Log::info('Malware scan not authorized.', $this->loggingContext);
                     throw new Exception('Malware scan not authorized.');
                 }

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -138,7 +138,8 @@ class ScanFileUpload implements ShouldQueue
 
             if (!$response->successful()) {
                 if ($response->getStatusCode() === Response::HTTP_UNAUTHORIZED) {
-                    \Log::info('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', '') . ' ' . $response->json(), $this->loggingContext);
+                    \Log::info('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', ''), $this->loggingContext);
+                    \Log::info($response->json(), $this->loggingContext);
                     throw new Exception('Malware scan not authorized.');
                 }
                 else {

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -131,8 +131,8 @@ class ScanFileUpload implements ShouldQueue
                 ]),
                 'application/json',
             )->withBasicAuth(
-                env('CLAMAV_BASIC_AUTH_USERNAME', 'user1'), // bite me
-                env('CLAMAV_BASIC_AUTH_PASSWORD', 'passw0rd'),
+                env('CLAMAV_BASIC_AUTH_USERNAME', ''),
+                env('CLAMAV_BASIC_AUTH_PASSWORD', ''),
             )->post(env('CLAMAV_API_URL', 'http://clamav:3001') . '/scan_file');
 
             $response = $response->json();

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -138,8 +138,7 @@ class ScanFileUpload implements ShouldQueue
 
             if (!$response->successful()) {
                 if ($response->getStatusCode() === Response::HTTP_UNAUTHORIZED) {
-                    \Log::info('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', ''), $this->loggingContext);
-                    \Log::info($response->json(), $this->loggingContext);
+                    \Log::info('Malware scan not authorized.', $this->loggingContext);
                     throw new Exception('Malware scan not authorized.');
                 }
                 else {

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -130,6 +130,9 @@ class ScanFileUpload implements ShouldQueue
                     'storage' => $this->fileSystem,
                 ]),
                 'application/json',
+            )->withBasicAuth(
+                env('CLAMAV_BASIC_AUTH_USERNAME', 'user1'), // bite me
+                env('CLAMAV_BASIC_AUTH_PASSWORD', 'passw0rd'),
             )->post(env('CLAMAV_API_URL', 'http://clamav:3001') . '/scan_file');
 
             $response = $response->json();

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -137,6 +137,8 @@ class ScanFileUpload implements ShouldQueue
 
             $response = $response->json();
 
+            \Log::info('Malware scan response', $response);
+
             $isError = isset($response['isError']) ? $response['isError'] : false;
 
             if ($isError === true) {

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -139,7 +139,7 @@ class ScanFileUpload implements ShouldQueue
             if (!$response->successful()) {
                 if ($response->getStatusCode() === Response::HTTP_UNAUTHORIZED) {
                     \Log::info('Malware scan not authorized.', $this->loggingContext);
-                    throw new Exception('Malware scan not authorized.');
+                    throw new Exception('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', ''));
                 }
                 else {
                     \Log::info('Malware scan not available.', $this->loggingContext);

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -137,7 +137,7 @@ class ScanFileUpload implements ShouldQueue
 
             $response = $response->json();
 
-            \Log::info('Malware scan response', $response);
+            \Log::info('Malware scan response ', $response);
 
             $isError = isset($response['isError']) ? $response['isError'] : false;
 

--- a/app/Jobs/ScanFileUpload.php
+++ b/app/Jobs/ScanFileUpload.php
@@ -138,8 +138,8 @@ class ScanFileUpload implements ShouldQueue
 
             if (!$response->successful()) {
                 if ($response->getStatusCode() === Response::HTTP_UNAUTHORIZED) {
-                    \Log::info('Malware scan not authorized.', $this->loggingContext);
-                    throw new Exception('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', ''));
+                    \Log::info('Malware scan not authorized. ' . $response->getStatusCode() . ' ' . env('CLAMAV_BASIC_AUTH_USERNAME', '') . ' ' . env('CLAMAV_BASIC_AUTH_PASSWORD', '') . ' ' . $response->json(), $this->loggingContext);
+                    throw new Exception('Malware scan not authorized.');
                 }
                 else {
                     \Log::info('Malware scan not available.', $this->loggingContext);


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Handle passing basic credentials to ClamAV scanner service

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7864

## Environment / Configuration changes (if applicable)
Must set 
`CLAMAV_BASIC_AUTH_USERNAME` and `CLAMAV_BASIC_AUTH_PASSWORD` here to match (on the clamav-scanner service) `BASIC_USERNAME` and `BASIC_PASSWORD`.

This should be merged ahead of/with the paired commit in the clamav-scanner repo.

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
