### PR TITLE
fix!(GAT-7985): Added validation that the requested file belongs to the application id

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -666,7 +666,7 @@ class TeamDataAccessApplicationController extends Controller
             $file = Upload::where('id', $fileId)->first();
 
             // Check the file belongs to the application
-            if ($file->entity_id !== $id) {
+            if ($file->entity_id !== $id || $file->entity_type !== 'dataAccessApplication') {
                 throw new UnauthorizedException("File does not belong to this application.");
             }
 

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -658,9 +658,6 @@ class TeamDataAccessApplicationController extends Controller
         try {
             $this->checkTeamAccess($teamId, $id, 'view');
             $application = DataAccessApplication::where('id', $id)->first();
-            \Log::info($id);
-            \Log::info($application->id);
-            // Check the file belongs to the application
 
             $isDraft = $application['submission_status'] === 'DRAFT';
             if ($isDraft) {
@@ -668,6 +665,7 @@ class TeamDataAccessApplicationController extends Controller
             }
             $file = Upload::where('id', $fileId)->first();
 
+            // Check the file belongs to the application
             if ($file->entity_id !== $id) {
                 throw new UnauthorizedException("File does not belong to this application.");
             }

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -658,12 +658,19 @@ class TeamDataAccessApplicationController extends Controller
         try {
             $this->checkTeamAccess($teamId, $id, 'view');
             $application = DataAccessApplication::where('id', $id)->first();
+            \Log::info($id);
+            \Log::info($application->id);
+            // Check the file belongs to the application
 
             $isDraft = $application['submission_status'] === 'DRAFT';
             if ($isDraft) {
                 throw new Exception('Files associated with a data access request cannot be downloaded when the request is still a draft.');
             }
             $file = Upload::where('id', $fileId)->first();
+
+            if ($file->entity_id !== $id) {
+                throw new UnauthorizedException("File does not belong to this application.");
+            }
 
             if ($file) {
                 Auditor::log([


### PR DESCRIPTION
## Screenshots (if relevant)
https://github.com/user-attachments/assets/5949509a-b313-4100-979e-c0628b8504a8
Ignore the file_size error, it's just because the file doesn't exist in docker.

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7985

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
