### PR TITLE
feat(GAT-7767): Bug - Incorrect template being used for enquiry replies

### DIFF
--- a/app/Console/Commands/UpdateDarMessagesGat7767.php
+++ b/app/Console/Commands/UpdateDarMessagesGat7767.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EmailTemplate;
+use Illuminate\Console\Command;
+
+class UpdateDarMessagesGat7767 extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:update-dar-messages-gat7767';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+         DB::table('email_templates')
+            ->where([
+                'identifier' => 'dar.notifymessage'
+            ])
+            ->update([
+                'subject' => 'New Data Access Enquiry reply from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+                'body' => '
+                    <mjml>
+                        <mj-head>
+                            <mj-html-attributes>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
+                                    Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
+                                </mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
+                            </mj-html-attributes>
+                            <mj-style >.main-button {
+                                padding:10px;
+                                width:auto;
+                                -webkit-border-radius:5px;
+                                -moz-border-radius:5px;
+                                border-radius:5px;
+                                color:#FFFFFF;
+                                }
+                            </mj-style>
+                            <mj-breakpoint width="480px" />
+                            <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
+                            <mj-attributes>
+                                <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
+                                <mj-text font-size="14px" />
+                                <mj-text color="#000000" />
+                                <mj-text line-height="1.7" />
+                                <mj-text font-weight="400" />
+                            </mj-attributes>
+                        </mj-head>
+                        <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
+                            <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
+                                    </mj-image>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
+                                text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
+                                    <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >New comment on the Data Access Request for [[PROJECT_TITLE]].</mj-text>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[RECIPIENT_NAME]],<br><br>
+                                        You have received a response to the dataset access enquiry [[PROJECT_TITLE]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
+                                        Submitted information:
+                                        <div>[[MESSAGE_BODY]]</div>
+                                    </mj-text>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-text align="center" padding="10px 25px 10px 25px" >
+                                        <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
+                                    </mj-text>
+                                    <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
+                                </mj-column>
+                            </mj-section>
+                        </mj-body>
+                    </mjml>
+                '
+            ]);
+
+
+        EmailTemplate::where([
+            'identifier' => 'dar.firstmessage',
+        ])->update([
+                'subject' => 'New Data Access Enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+                'body' => '
+                    <mjml>
+                        <mj-head>
+                            <mj-html-attributes>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
+                                    Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
+                                </mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
+                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
+                            </mj-html-attributes>
+                            <mj-style >.main-button {
+                                padding:10px;
+                                width:auto;
+                                -webkit-border-radius:5px;
+                                -moz-border-radius:5px;
+                                border-radius:5px;
+                                color:#FFFFFF;
+                                }
+                            </mj-style>
+                            <mj-breakpoint width="480px" />
+                            <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
+                            <mj-attributes>
+                                <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
+                                <mj-text font-size="14px" />
+                                <mj-text color="#000000" />
+                                <mj-text line-height="1.7" />
+                                <mj-text font-weight="400" />
+                            </mj-attributes>
+                        </mj-head>
+                        <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
+                            <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
+                                    </mj-image>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
+                                text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
+                                    <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >Dataset Access Enquiry received.</mj-text>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[TEAM_NAME]],<br><br>
+                                        You have received a dataset access enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
+                                        Submitted information:
+                                        <div>[[MESSAGE_BODY]]</div>
+                                    </mj-text>
+                                </mj-column>
+                            </mj-section>
+                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                    <mj-text align="center" padding="10px 25px 10px 25px" >
+                                        <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
+                                    </mj-text>
+                                    <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
+                                </mj-column>
+                            </mj-section>
+                        </mj-body>
+                    </mjml>
+                '
+            ]);
+    }
+}

--- a/app/Console/Commands/UpdateDarMessagesGat7767.php
+++ b/app/Console/Commands/UpdateDarMessagesGat7767.php
@@ -26,149 +26,147 @@ class UpdateDarMessagesGat7767 extends Command
      */
     public function handle()
     {
-         DB::table('email_templates')
-            ->where([
-                'identifier' => 'dar.notifymessage'
-            ])
-            ->update([
-                'subject' => 'New Data Access Enquiry reply from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
-                'body' => '
-                    <mjml>
-                        <mj-head>
-                            <mj-html-attributes>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
-                                    Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
-                                </mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
-                            </mj-html-attributes>
-                            <mj-style >.main-button {
-                                padding:10px;
-                                width:auto;
-                                -webkit-border-radius:5px;
-                                -moz-border-radius:5px;
-                                border-radius:5px;
-                                color:#FFFFFF;
-                                }
-                            </mj-style>
-                            <mj-breakpoint width="480px" />
-                            <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
-                            <mj-attributes>
-                                <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
-                                <mj-text font-size="14px" />
-                                <mj-text color="#000000" />
-                                <mj-text line-height="1.7" />
-                                <mj-text font-weight="400" />
-                            </mj-attributes>
-                        </mj-head>
-                        <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
-                            <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
-                                    </mj-image>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
-                                text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
-                                    <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >New comment on the Data Access Request for [[PROJECT_TITLE]].</mj-text>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[RECIPIENT_NAME]],<br><br>
-                                        You have received a response to the dataset access enquiry [[PROJECT_TITLE]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
-                                        Submitted information:
-                                        <div>[[MESSAGE_BODY]]</div>
-                                    </mj-text>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-text align="center" padding="10px 25px 10px 25px" >
-                                        <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
-                                    </mj-text>
-                                    <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
-                                </mj-column>
-                            </mj-section>
-                        </mj-body>
-                    </mjml>
-                '
-            ]);
+        EmailTemplate::where([
+            'identifier' => 'dar.notifymessage'
+        ])->update([
+            'subject' => 'New Data Access Enquiry reply from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+            'body' => '
+                <mjml>
+                    <mj-head>
+                        <mj-html-attributes>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
+                                Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
+                            </mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
+                        </mj-html-attributes>
+                        <mj-style >.main-button {
+                            padding:10px;
+                            width:auto;
+                            -webkit-border-radius:5px;
+                            -moz-border-radius:5px;
+                            border-radius:5px;
+                            color:#FFFFFF;
+                            }
+                        </mj-style>
+                        <mj-breakpoint width="480px" />
+                        <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
+                        <mj-attributes>
+                            <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
+                            <mj-text font-size="14px" />
+                            <mj-text color="#000000" />
+                            <mj-text line-height="1.7" />
+                            <mj-text font-weight="400" />
+                        </mj-attributes>
+                    </mj-head>
+                    <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
+                        <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
+                                </mj-image>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
+                            text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
+                                <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >New comment on the Data Access Request for [[PROJECT_TITLE]].</mj-text>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[RECIPIENT_NAME]],<br><br>
+                                    You have received a response to the dataset access enquiry [[PROJECT_TITLE]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
+                                    Submitted information:
+                                    <div>[[MESSAGE_BODY]]</div>
+                                </mj-text>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-text align="center" padding="10px 25px 10px 25px" >
+                                    <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
+                                </mj-text>
+                                <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
+                            </mj-column>
+                        </mj-section>
+                    </mj-body>
+                </mjml>
+            '
+        ]);
 
 
         EmailTemplate::where([
             'identifier' => 'dar.firstmessage',
         ])->update([
-                'subject' => 'New Data Access Enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
-                'body' => '
-                    <mjml>
-                        <mj-head>
-                            <mj-html-attributes>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
-                                    Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
-                                </mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
-                                <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
-                            </mj-html-attributes>
-                            <mj-style >.main-button {
-                                padding:10px;
-                                width:auto;
-                                -webkit-border-radius:5px;
-                                -moz-border-radius:5px;
-                                border-radius:5px;
-                                color:#FFFFFF;
-                                }
-                            </mj-style>
-                            <mj-breakpoint width="480px" />
-                            <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
-                            <mj-attributes>
-                                <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
-                                <mj-text font-size="14px" />
-                                <mj-text color="#000000" />
-                                <mj-text line-height="1.7" />
-                                <mj-text font-weight="400" />
-                            </mj-attributes>
-                        </mj-head>
-                        <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
-                            <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
-                                    </mj-image>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
-                                text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
-                                    <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >Dataset Access Enquiry received.</mj-text>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[TEAM_NAME]],<br><br>
-                                        You have received a dataset access enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
-                                        Submitted information:
-                                        <div>[[MESSAGE_BODY]]</div>
-                                    </mj-text>
-                                </mj-column>
-                            </mj-section>
-                            <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
-                                <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
-                                    <mj-text align="center" padding="10px 25px 10px 25px" >
-                                        <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
-                                    </mj-text>
-                                    <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
-                                </mj-column>
-                            </mj-section>
-                        </mj-body>
-                    </mjml>
-                '
-            ]);
+            'subject' => 'New Data Access Enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+            'body' => '
+                <mjml>
+                    <mj-head>
+                        <mj-html-attributes>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="text-color" text-color="#000000"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-family" font-family="-apple-system, BlinkMacSystemFont,
+                                Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif">
+                            </mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-size" font-size="14px"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="line-height" line-height="1.7"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="font-weight" font-weight="400"></mj-html-attribute>
+                            <mj-html-attribute class="easy-email" multiple-attributes="false" attribute-name="responsive" responsive="true"></mj-html-attribute>
+                        </mj-html-attributes>
+                        <mj-style >.main-button {
+                            padding:10px;
+                            width:auto;
+                            -webkit-border-radius:5px;
+                            -moz-border-radius:5px;
+                            border-radius:5px;
+                            color:#FFFFFF;
+                            }
+                        </mj-style>
+                        <mj-breakpoint width="480px" />
+                        <mj-font name="Museo Sans Rounded" href="https://fonts.cdnfonts.com/css/museo-sans-rounded" />
+                        <mj-attributes>
+                            <mj-all font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans,Helvetica Neue, sans-serif" />
+                            <mj-text font-size="14px" />
+                            <mj-text color="#000000" />
+                            <mj-text line-height="1.7" />
+                            <mj-text font-weight="400" />
+                        </mj-attributes>
+                    </mj-head>
+                    <mj-body background-color="#FFFFFF" width="600px" style="font-family:Museo Sans Rounded,sans-serif;font-size:14px; color:#3C3C3B" >
+                        <mj-section padding="20px 0px 20px 0px" border="none" direction="ltr" text-align="center" background-repeat="repeat" background-size="auto" background-position="top center" background-color="#ffffff" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-image align="center" height="auto" src="https://storage.googleapis.com/public_files_dev/hdruk_logo_email.jpg" href="https://web.www.healthdatagateway.org" width="226px" padding="10px 0px 10px 0px" >
+                                </mj-image>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="no-repeat" background-size="cover" background-position="top center" border="none" direction="ltr"
+                            text-align="center" background-url="https://storage.googleapis.com/public_files_dev/hdruk_header_email.jpg" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" width="100%" padding="0px 0px 0px 0px" >
+                                <mj-text align="center" color="#fff" font-size="24px" padding="30px 0px 30px 0px" >Dataset Access Enquiry received.</mj-text>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-text align="left" color="#3C3C3B" font-family="Museo Sans Rounded,sans-serif" padding="10px 25px 10px 25px" >Dear [[TEAM_NAME]],<br><br>
+                                    You have received a dataset access enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]], details of which can be found in the thread below. You can respond by using the reply button within your email client.<br><br>
+                                    Submitted information:
+                                    <div>[[MESSAGE_BODY]]</div>
+                                </mj-text>
+                            </mj-column>
+                        </mj-section>
+                        <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="center" padding="20px 0px 20px 0px" >
+                            <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
+                                <mj-text align="center" padding="10px 25px 10px 25px" >
+                                    <a style="text-decoration:none" href="https://web.www.healthdatagateway.org">www.healthdatagateway.org</a>
+                                </mj-text>
+                                <mj-text align="center" color="#3C3C3B" padding="10px 25px 10px 25px" >@HDR UK [[CURRENT_YEAR]]. All rights reserved.</mj-text>
+                            </mj-column>
+                        </mj-section>
+                    </mj-body>
+                </mjml>
+            '
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -241,7 +241,6 @@ class EnquiryThreadController extends Controller
             $teamConfig = $this->getTeamConfiguration($input, $payload['thread']['datasets']);
 
             $payload['thread']['dataCustodians'] = $teamConfig['data_custodians'] ?? [];
-            $payload['message']['message_body']['[[TEAM_NAME]]'] = array_unique($teamConfig['team_names'] ?? []);
 
             // For each dataset we need to determine if teams are responsible for the data providing
             // if not, then a separate enquiry thread and message are created for that team also.
@@ -328,7 +327,6 @@ class EnquiryThreadController extends Controller
             'message' => [
                 'from' => $input['from'],
                 'message_body' => [
-                    '[[TEAM_NAME]]' => [],
                     '[[USER_FIRST_NAME]]' => $user->firstname,
                     '[[USER_LAST_NAME]]' => $user->lastname,
                     '[[USER_ORGANISATION]]' => $user->organisation ?? $input['organisation'],

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -265,7 +265,12 @@ class DatasetController extends Controller
             if (!$dataset) {
                 return response()->json(['message' => 'Dataset not found'], 404);
             }
-            $dataset = $this->getDatasetDetails($dataset, $request);
+            list($dataset, $response) = $this->getDatasetDetails($dataset, $request);
+
+            if ($response) {
+                return $response;
+            }
+
             $latestVersionId = $dataset->latestVersionID($id);
 
             if ($exportStructuralMetadata === 'structuralMetadata') {

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -317,7 +317,11 @@ class TeamDatasetController extends Controller
                 return response()->json(['message' => 'Dataset not found'], 404);
             }
 
-            $dataset = $this->getDatasetDetails($dataset, $request);
+            list($dataset, $response) = $this->getDatasetDetails($dataset, $request);
+
+            if ($response) {
+                return $response;
+            }
 
             if ($exportStructuralMetadata === 'structuralMetadata') {
                 $arrayDataset = $dataset->toArray();

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -75,10 +75,10 @@ trait DatasetsV2Helpers
                 $withLinks['metadata'] = json_encode(['metadata' => $translated['metadata']]);
                 $dataset->setAttribute('versions', [$withLinks]);
             } else {
-                return response()->json([
+                return [null, response()->json([
                     'message' => 'failed to translate',
                     'details' => $translated
-                ], 400);
+                ], 400)];
             }
         } elseif ($outputSchemaModel) {
             throw new Exception('You have given a schema_model but not a schema_version');
@@ -89,7 +89,7 @@ trait DatasetsV2Helpers
         $teamPublishedDARTemplates = DataAccessTemplate::where([['team_id', $dataset['team']['id']], ['published', 1]])->pluck('id');
         $dataset['team']['has_published_dar_template'] = !$teamPublishedDARTemplates->isEmpty();
 
-        return $dataset;
+        return [$dataset, null];
     }
 
     /**

--- a/app/Http/Traits/EnquiriesTrait.php
+++ b/app/Http/Traits/EnquiriesTrait.php
@@ -276,7 +276,7 @@ trait EnquiriesTrait
             $str .= 'Potential research benefits: ' . $in['message']['message_body']['[[PUBLIC_BENEFIT]]'] . '<br/>';
             $str .= 'This enquiry has also been sent to the following Data Custodians: ' . $dataCustodiansStr . '<br/>';
         } elseif ($in['thread']['is_general_enquiry']) {
-            $str .= 'Enquiry: ' . $in['message']['message_body']['[[QUERY]]'] . '<br/>';
+            $str .= 'Enquiry:<br/>' . $in['message']['message_body']['[[QUERY]]'] . '<br/><br/>';
             $str .= 'This enquiry has also been sent to the following Data Custodians: ' . $dataCustodiansStr . '<br/>';
         } elseif ($in['thread']['is_dar_dialogue']) {
             $str .= $in['message']['message_body']['[[MESSAGE]]'] . '<br/>';

--- a/app/Http/Traits/EnquiriesTrait.php
+++ b/app/Http/Traits/EnquiriesTrait.php
@@ -27,6 +27,7 @@ trait EnquiriesTrait
         $selectRoles = ['custodian.dar.manager'];
         $roles = Role::whereIn('name', $selectRoles)->select(['id'])->get()->toArray();
         $roleIds = convertArrayToArrayWithKeyName($roles, 'id');
+
         foreach ($teamIds as $teamId) {
             $team = Team::where('id', $teamId)->first();
             if (is_null($team)) {
@@ -188,7 +189,6 @@ trait EnquiriesTrait
 
             $replacements = [
                 '[[CURRENT_YEAR]]' => $threadDetail['message']['message_body']['[[CURRENT_YEAR]]'],
-                '[[TEAM_NAME]]' => '',
                 '[[SENDER_NAME]]' => $threadDetail['message']['message_body']['[[SENDER_NAME]]'] ?? '',
                 '[[USER_FIRST_NAME]]' => $threadDetail['message']['message_body']['[[USER_FIRST_NAME]]'],
                 '[[USER_LAST_NAME]]' => $threadDetail['message']['message_body']['[[USER_LAST_NAME]]'],

--- a/app/Services/AliasReplyScannerService.php
+++ b/app/Services/AliasReplyScannerService.php
@@ -115,7 +115,7 @@ class AliasReplyScannerService
             "thread_id" => $threadId,
         ]);
 
-        $this->notifyDarManagesOfNewMessage($threadId);
+        $this->notifyDarManagersOfNewMessage($threadId);
         $this->notifyUserOfDarResponse($threadId);
 
         unset($body);
@@ -176,7 +176,7 @@ class AliasReplyScannerService
 
     }
 
-    public function notifyDarManagesOfNewMessage($threadId)
+    public function notifyDarManagersOfNewMessage($threadId)
     {
         $usersToNotify = [];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Update the required message templates.

Also:
- Remove [[TEAM_NAME]] from message_body since it's never used from there.
- fix an issue with `getDatasetDetails()` if traser translation fails. We now handle the result gracefully. This _may_ be related to 50-minute hanging calls to `v2/datasets/{id}` but I'm not certain it will fix them.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7767

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Run `app:update-dar-messages-gat7767`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
