### PR TITLE
fix(GAT-8013): when fail in traser, throw error

### DIFF
--- a/app/Models/Federation.php
+++ b/app/Models/Federation.php
@@ -64,6 +64,7 @@ class Federation extends Model
         'endpoint_datasets',
         'endpoint_dataset',
         'run_time_hour',
+        'run_time_minute',
         'enabled',
         'tested',
         'pid',

--- a/app/Services/GatewayMetadataIngestionService.php
+++ b/app/Services/GatewayMetadataIngestionService.php
@@ -7,7 +7,7 @@ use Carbon\Carbon;
 use App\Models\Team;
 use App\Models\Federation;
 use App\Http\Traits\MetadataOnboard;
-
+use Exception;
 use Illuminate\Database\Eloquent\Collection;
 
 class GatewayMetadataIngestionService

--- a/app/Services/GatewayMetadataIngestionService.php
+++ b/app/Services/GatewayMetadataIngestionService.php
@@ -41,10 +41,8 @@ class GatewayMetadataIngestionService
             return true;
         }
 
-        return [
-            'message' => 'metadata cannot be validated',
-            'details' => $metadataResult['response'],
-        ];
+
+        throw new Exception('metadata cannot be validated');
     }
 
     public function getActiveFederations(): Collection


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
When failing in traser we just ignore the error and say its created the dataset. Here we need to throw which will be caught in the callers catche.
## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8013
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
