### PR TITLE
fix(GAT-1234): Make search controller robust to datasets missing versions.

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -205,7 +205,13 @@ class SearchController extends Controller
                     continue;
                 }
 
-                $model['metadata'] = $model->latestVersion()['metadata']['metadata'];
+                $latestVersion = $model->latestVersion();
+                if (is_null($latestVersion)) {
+                    \Log::warning('No version found for dataset id=' . $matchedId);
+                    continue;
+                }
+
+                $model['metadata'] = $latestVersion['metadata']['metadata'];
 
                 $metadata = $model['metadata'];
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -143,19 +143,23 @@ class Dataset extends Model
     /**
      * The very latest version of a DatasetVersion object that corresponds to this dataset.
      **/
-    public function latestVersion(?array $fields = null): DatasetVersion
+    public function latestVersion(?array $fields = null): DatasetVersion | null
     {
         $version = DatasetVersion::where('dataset_id', $this->id)
             ->select(['version','id'])
             ->latest('version')
-            ->first()
-            ->id;
+            ->first();
+
+        if (!$version) {
+            return null;
+        }
+
         return DatasetVersion::when(
             $fields,
             function ($query, $fields) {
                 return $query->select($fields);
             }
-        )->findOrFail($version);
+        )->findOrFail($version->id);
     }
 
     public function latestVersionID(int $datasetId): null|int


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
On dev, we have issues with dirty data with datasets with no associated versions. This causes regular issues with the SearchController::datasets() call. This PR pragmatically dismisses datasets without versions, allowing the search controller to continue to present the remaining results rather than than fall over due to a single dataset error.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
