### PR TITLE
fix(GAT-7861): Simplify and correct messaging logic

### DIFF
--- a/app/Console/Commands/UpdateDarMessagesGat7767.php
+++ b/app/Console/Commands/UpdateDarMessagesGat7767.php
@@ -29,7 +29,7 @@ class UpdateDarMessagesGat7767 extends Command
         EmailTemplate::where([
             'identifier' => 'dar.notifymessage'
         ])->update([
-            'subject' => 'New Data Access Enquiry reply from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+            'subject' => 'New Data Access Request reply from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
             'body' => '
                 <mjml>
                     <mj-head>
@@ -101,7 +101,7 @@ class UpdateDarMessagesGat7767 extends Command
         EmailTemplate::where([
             'identifier' => 'dar.firstmessage',
         ])->update([
-            'subject' => 'New Data Access Enquiry from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
+            'subject' => 'New Data Access Request from [[USER_FIRST_NAME]] [[USER_LAST_NAME]]: [[PROJECT_TITLE]]',
             'body' => '
                 <mjml>
                     <mj-head>

--- a/app/Http/Controllers/Api/V1/EnquiryThreadController.php
+++ b/app/Http/Controllers/Api/V1/EnquiryThreadController.php
@@ -177,8 +177,8 @@ class EnquiryThreadController extends Controller
     /**
      * @OA\Post(
      *      path="/api/v1/enquiry_threads",
-     *      summary="Create a new EnquiryThread",
-     *      description="Creates a new EnquiryThread",
+     *      summary="Create one or more new EnquiryThreads",
+     *      description="Creates one or more new EnquiryThreads",
      *      tags={"EnquiryThread"},
      *      summary="EnquiryThread@store",
      *      security={{"bearerAuth":{}}},

--- a/app/Http/Traits/EnquiriesTrait.php
+++ b/app/Http/Traits/EnquiriesTrait.php
@@ -94,6 +94,10 @@ trait EnquiriesTrait
             }
         }
 
+        // If (in a reply scenario) the original enquirer is also in one of the teams that should receive replies, then
+        // ensure the email is sent to the email address they selected in the enquiry form, not their usually preferred address.
+        // This _will_ mean that such a user will receive the email twice - once to this address and once to their default email -
+        // but that's an unlikely scenario outside of testing.
         if ($currUserId) {
             $user = User::where('id', $currUserId)
                         ->select(['id', 'name', 'firstname', 'lastname', 'email', 'secondary_email', 'preferred_email'])
@@ -217,14 +221,14 @@ trait EnquiriesTrait
                     $to = [
                         'to' => [
                             'email' => ($currentUserPreferredEmail === 'primary') ? $user['user']['email'] : $user['user']['secondary_email'],
-                            'name' => $user['user']['firstname'] . ' ' . $user['user']['lastname'],
+                            'name' => $user['user']['firstname'] ? $user['user']['firstname'] . ' ' . $user['user']['lastname'] : $user['user']['name'],
                         ],
                     ];
                 } else {
                     $to = [
                         'to' => [
                             'email' => ($user['user']['preferred_email'] === 'primary') ? $user['user']['email'] : $user['user']['secondary_email'],
-                            'name' => $user['user']['firstname'] . ' ' . $user['user']['lastname'],
+                            'name' => $user['user']['firstname'] ? $user['user']['firstname'] . ' ' . $user['user']['lastname'] : $user['user']['name'],
                         ],
                     ];
                 }

--- a/app/Jobs/AliasReplyScannerJob.php
+++ b/app/Jobs/AliasReplyScannerJob.php
@@ -83,7 +83,7 @@ class AliasReplyScannerJob implements ShouldQueue
     {
         return [
             'alias_reply_scanner',
-            'no_of_messages_found:' . $this->noMessagesFound,
+            'no_of_messages_found:' . $this->noMessagesFound, //Bug: this value doesn't get updated before the tag is published, so it's always 0
         ];
     }
 }

--- a/app/Services/AliasReplyScannerService.php
+++ b/app/Services/AliasReplyScannerService.php
@@ -135,7 +135,7 @@ class AliasReplyScannerService
         // Get all custodian users
         $allUsersToNotify = $this->getUsersByTeamIds([$enquiryThread->team_id], $enquiryThread->user_id, $enquiryThread->user_preferred_email);
 
-        if (empty($usersToNotify)) {
+        if (empty($allUsersToNotify)) {
             $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
             \Log::info(
                 'EnquiryThread exists, but no custodian.dar.managers found to notify for thread ' . $threadId,
@@ -151,7 +151,7 @@ class AliasReplyScannerService
 
         $user->preferred_email = $enquiryThread->user_preferred_email;
 
-        $usersToNotify[] = [
+        $allUsersToNotify[] = [
             'user' => $user->toArray(),
             'team' => null,
         ];

--- a/app/Services/AliasReplyScannerService.php
+++ b/app/Services/AliasReplyScannerService.php
@@ -157,7 +157,7 @@ class AliasReplyScannerService
         ];
 
         // Don't send an email to any user if it is their own message
-        $usersToNotify = array_filter($allUsersToNotify, function($entry) {
+        $usersToNotify = array_filter($allUsersToNotify, function($entry) use ($senderEmail) {
             $emailToUse = ($entry['user']['preferred_email'] === 'primary') ? $entry['user']['email'] : $entry['user']['secondary_email'];
             return $emailToUse !== $senderEmail;
         });


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
A number of fixes in messaging logic:
- Fix subject line in 2 templates
- If `user.firstname` is not set, default to `user.name`
- Combine `notifyUserOfDarResponse()` and `notifyDarManagersOfNewMessage()` into one function `notifyAllOfNewMessage()`. 
- Don't send an email to whichever user (enquirer or custodian) who sent the message. This stops users receiving their own replies as emails, reducing confusion.
- Respect email preferences in replies.
- Some initial work towards supporting multiple templates for replies to different enquiry types. This will require further work once template designs have been drawn up.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7861

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
`php artisan app:update-dar-messages-gat7767`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
