### PR TITLE
fix(GAT-1537): Comment out ValidateRequest middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -25,7 +25,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\ProfileRequest::class,
         \App\Http\Middleware\HstsMiddleware::class,
         \App\Http\Middleware\DefineFeatureFlags::class,
-        \App\Http\Middleware\ValidateRequestID::class,
+        //\App\Http\Middleware\ValidateRequestID::class,
         \App\Http\Middleware\LogRequestResponse::class,
     ];
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
When the app is first hit middleware.ts will run on web, it will check if a session id has been set if not serve one back up as part of the response as a cookie in the header. The server calls are made before this is served up so they wont always have a session id. We will need to revisit this.
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
