### PR TITLE
fix(GAT-8082): remove dataset with no metadata before trim

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1376,9 +1376,6 @@ class DatasetController extends Controller
                     if (empty($rowDetails['metadata']) || !isset($rowDetails['metadata'])) {
                         // this needs refactoring to mark the metadata as corrupt or missing and
                         // then set them as draft and alert the FE
-
-                        // if your missing a dataset on the FE, its because this geezer
-                        // this has been put in to stop the BE blowing up on missing metadata.
                         unset($results[$key]);
                         continue;
                     }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1372,7 +1372,16 @@ class DatasetController extends Controller
                 fputcsv($handle, $headerRow);
 
                 // add the given number of rows to the file.
-                foreach ($results as $rowDetails) {
+                foreach ($results as $key => $rowDetails) {
+                    if (empty($rowDetails['metadata']) || !isset($rowDetails['metadata'])) {
+                        // this needs refactoring to mark the metadata as corrupt or missing and
+                        // then set them as draft and alert the FE
+
+                        // if your missing a dataset on the FE, its because this geezer
+                        // this has been put in to stop the BE blowing up on missing metadata.
+                        unset($results[$key]);
+                        continue;
+                    }
                     $metadata = $rowDetails['metadata']['metadata'];
 
                     $publisherName = $metadata['metadata']['summary']['publisher'];

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -109,7 +109,6 @@ class TeamDatasetController extends Controller
 
         try {
             $withMetadata = $request->boolean('with_metadata', true);
-            \Log::info('here <<<<');
 
             $perPage = request('per_page', Config::get('constants.per_page'));
 
@@ -117,7 +116,6 @@ class TeamDatasetController extends Controller
 
             $teamDatasetIds = Dataset::where(['team_id' => $teamId, 'status' => strtoupper($status)])->pluck("id");
             $datasetIds = [];
-            \Log::info('here1 <<<<');
             // If we've received a 'title' for the search, then only return
             // datasets that match that title
             if (!empty($filterTitle)) {
@@ -134,7 +132,6 @@ class TeamDatasetController extends Controller
             } else {
                 $datasetIds = $teamDatasetIds;
             }
-            \Log::info('here2 <<<<');
             // Fetch metadata
             $datasets = Dataset::whereIn("id", $datasetIds)
                 ->when($withMetadata, fn ($query) => $query->with('latestMetadata'))
@@ -169,7 +166,6 @@ class TeamDatasetController extends Controller
                 'action_name' => class_basename($this) . '@'.__FUNCTION__,
                 'description' => 'Team Dataset get all by status',
             ]);
-            \Log::info('here5 <<<<');
             return response()->json(
                 $datasets
             );

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -141,6 +141,9 @@ class TeamDatasetController extends Controller
 
             foreach ($datasets as $key => &$d) {
                 if (empty($d->latestMetadata) || !isset($d->latestMetadata['metadata'])) {
+                    // this needs refactoring to mark the metadata as corrupt or missing and
+                    // then set them as draft and alert the FE
+
                     // if your missing a dataset on the FE, its because this geezer
                     // this has been put in to stop the BE blowing up on missing metadata.
                     unset($datasets[$key]);

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -143,9 +143,6 @@ class TeamDatasetController extends Controller
                 if (empty($d->latestMetadata) || !isset($d->latestMetadata['metadata'])) {
                     // this needs refactoring to mark the metadata as corrupt or missing and
                     // then set them as draft and alert the FE
-
-                    // if your missing a dataset on the FE, its because this geezer
-                    // this has been put in to stop the BE blowing up on missing metadata.
                     unset($datasets[$key]);
                     continue;
                 }

--- a/app/Http/Requests/Search/PublicationSearch.php
+++ b/app/Http/Requests/Search/PublicationSearch.php
@@ -6,7 +6,6 @@ use App\Http\Requests\BaseFormRequest;
 
 class PublicationSearch extends BaseFormRequest
 {
-
     /**
      * Add Query parameters to the FormRequest.
      *

--- a/app/Http/Requests/Search/Search.php
+++ b/app/Http/Requests/Search/Search.php
@@ -6,7 +6,6 @@ use App\Http\Requests\BaseFormRequest;
 
 class Search extends BaseFormRequest
 {
-
     // SC: removing since this removes spaces from search queries
 
     // protected function prepareForValidation(): void

--- a/database/migrations/2023_11_15_090700_remove_id_column_from_team_user_has_roles.php
+++ b/database/migrations/2023_11_15_090700_remove_id_column_from_team_user_has_roles.php
@@ -11,7 +11,7 @@ return new class () extends Migration {
     public function up(): void
     {
         // Create a new table without a primary key constraint
-         Schema::create('team_user_has_roles_tmp', function (Blueprint $table) {
+        Schema::create('team_user_has_roles_tmp', function (Blueprint $table) {
             $table->bigInteger('team_has_user_id')->unsigned();
             $table->bigInteger('role_id')->unsigned();
 

--- a/tests/Feature/CustomerSatisfactionTest.php
+++ b/tests/Feature/CustomerSatisfactionTest.php
@@ -7,7 +7,6 @@ use Tests\TestCase;
 
 class CustomerSatisfactionTest extends TestCase
 {
-
     /**
      * Test creating a CustomerSatisfaction entry.
      *

--- a/tests/Feature/DatasetIntegrationTest.php
+++ b/tests/Feature/DatasetIntegrationTest.php
@@ -15,7 +15,6 @@ use App\Models\ApplicationHasPermission;
 
 class DatasetIntegrationTest extends TestCase
 {
-    
     use Authorization;
     use MockExternalApis {
         setUp as commonSetUp;

--- a/tests/Feature/HubspotTest.php
+++ b/tests/Feature/HubspotTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Config;
 use Tests\TestCase;
 use App\Services\Hubspot;
 use Illuminate\Support\Facades\Http;

--- a/tests/Feature/Observers/DurObserverTest.php
+++ b/tests/Feature/Observers/DurObserverTest.php
@@ -158,7 +158,7 @@ class DurObserverTest extends TestCase
             'status' => Dur::STATUS_ACTIVE,
         ]);
 
-        
+
         $this->observer->shouldReceive('deleteDurFromElastic')->once()->with($countInitialDur + 1);
 
         $dur->update(['status' => Dur::STATUS_ARCHIVED]);

--- a/tests/Feature/VerifySecondaryEmailTest.php
+++ b/tests/Feature/VerifySecondaryEmailTest.php
@@ -10,7 +10,6 @@ use Tests\TestCase;
 
 class VerifySecondaryEmailTest extends TestCase
 {
-
     public function test_successful_secondary_email_verification()
     {
         $user = User::factory()->create();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,7 +22,7 @@ abstract class TestCase extends BaseTestCase
         $this->disableObservers();
 
         $this->liteSetUp();
-        
+
         $this->enableObservers();
 
         if ($this->shouldFakeQueue) {

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -7,7 +7,6 @@ use Tests\TestCase;
 
 class UserTest extends TestCase
 {
-
     public function test_that_user_emails_are_unique()
     {
         $user = User::create([


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Remove datasets where there is no metadata
<img width="1428" height="222" alt="image" src="https://github.com/user-attachments/assets/4da02aca-9275-47ab-9a28-eeb3f18c287e" />

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8082
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
