### PR TITLE
fix(GAT-8128): incorrect date for updated on team datasets

### DIFF
--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -139,12 +139,18 @@ class TeamDatasetController extends Controller
                 ->paginate((int) $perPage, ['*'], 'page');
 
 
-            foreach ($datasets as $key => &$d) {
+            foreach ($datasets as $key => & $d) {
+
                 if (empty($d->latestMetadata) || !isset($d->latestMetadata['metadata'])) {
                     // this needs refactoring to mark the metadata as corrupt or missing and
                     // then set them as draft and alert the FE
                     unset($datasets[$key]);
                     continue;
+                }
+
+                $latestVersion = $d->latestVersion(['updated_at']);
+                if ($latestVersion) {
+                    $d->updated_at = $latestVersion->updated_at;
                 }
 
                 $miniMetadata = $this->trimDatasets($d->latestMetadata['metadata'], [


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1074" height="262" alt="image" src="https://github.com/user-attachments/assets/b2549cef-1fc1-40ea-a1a9-5a4671e4e4fe" />

## Describe your changes
Datasets last activity on teams page goes off of the dataset last updated, but it should come from the versions.
## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8128
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
