### PR TITLE
fix(GAT-8176): cannot approve users in cohort panel

### DIFF
--- a/config/cohort.php
+++ b/config/cohort.php
@@ -2,8 +2,8 @@
 
 return [
     'cohort_access_expiry_warning_times_in_days' => env('COHORT_ACCESS_EXPIRY_WARNING_TIMES_IN_DAYS', '1,7,14'),
-    'cohort_access_expiry_time_in_days' => env('COHORT_ACCESS_EXPIRY_TIME_IN_DAYS', 180),
-    'cohort_nhse_sde_access_expiry_time_in_days' => env('COHORT_NHSE_SDE_ACCESS_EXPIRY_TIME_IN_DAYS', 180),
+    'cohort_access_expiry_time_in_days' => (int) env('COHORT_ACCESS_EXPIRY_TIME_IN_DAYS', 180),
+    'cohort_nhse_sde_access_expiry_time_in_days' => (int) env('COHORT_NHSE_SDE_ACCESS_EXPIRY_TIME_IN_DAYS', 180),
     'cohort_discovery_access_url' => env('COHORT_DISCOVERY_ACCESS_URL', '#'),
     'cohort_discovery_using_url' => env('COHORT_DISCOVERY_USING_URL', '#'),
     'cohort_discovery_renew_url' => env('COHORT_DISCOVERY_RENEW_URL', '#'),


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Carbon in latest update is stricter, it will no longer accept strings '10' envs are inferred as strings so cast them as ints
## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
