### PR TITLE
feat(GAT-8198): Custodian network landing page load speed

### DIFF
--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -582,7 +582,7 @@ class DataCustodianNetworksController extends Controller
      *                  @OA\Property(property="img_url", type="string", example="http://placeholder"),
      *                  @OA\Property(property="url", type="string", example="http://placeholder.url"),
      *                  @OA\Property(property="summary", type="string", example="Summary"),
-     *.                 @OA\Property(property="enabled", type="boolean", example="true"),
+     *                  @OA\Property(property="enabled", type="boolean", example="true"),
      *                  @OA\Property(property="service", type="string", example="https://example"),
      *              )
      *          ),

--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -259,7 +259,7 @@ class DataCustodianNetworksController extends Controller
     public function showSummary(Request $request, int $id): JsonResponse
     {
         try {
-            $dpc = DataProviderColl::select('id', 'name', 'img_url', 'enabled', 'url', 'service')
+            $dpc = DataProviderColl::select('id', 'name', 'img_url', 'enabled', 'url', 'service', 'summary')
                 ->with('teams')
                 ->where([
                     'id' => $id,

--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -319,16 +319,8 @@ class DataCustodianNetworksController extends Controller
      *              @OA\Property(property="message", type="string"),
      *              @OA\Property(property="data", type="object",
      *                  @OA\Property(property="id", type="integer", example=1),
-     *                  @OA\Property(property="name", type="string", example="Name"),
-     *                  @OA\Property(property="img_url", type="string", example="http://placeholder"),
-     *                  @OA\Property(property="url", type="string", example="http://placeholder.url"),
-     *                  @OA\Property(property="summary", type="string", example="Summary"),
      *                  @OA\Property(property="datasets", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="durs", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="tools", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="publications", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="collections", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *                  @OA\Property(property="datasets_total", type="integer", example=1),
      *              )
      *          ),
      *      ),
@@ -428,16 +420,14 @@ class DataCustodianNetworksController extends Controller
      *              @OA\Property(property="message", type="string"),
      *              @OA\Property(property="data", type="object",
      *                  @OA\Property(property="id", type="integer", example=1),
-     *                  @OA\Property(property="name", type="string", example="Name"),
-     *                  @OA\Property(property="img_url", type="string", example="http://placeholder"),
-     *                  @OA\Property(property="url", type="string", example="http://placeholder.url"),
-     *                  @OA\Property(property="summary", type="string", example="Summary"),
-     *                  @OA\Property(property="datasets", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="durs_total", type="integer", example=1),
      *                  @OA\Property(property="durs", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="tools_total", type="integer", example=1),
      *                  @OA\Property(property="tools", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="publications_total", type="integer", example=1),
      *                  @OA\Property(property="publications", type="array", example="{}", @OA\Items()),
+     *                  @OA\Property(property="collections_total", type="integer", example=1),
      *                  @OA\Property(property="collections", type="array", example="{}", @OA\Items()),
-     *                  @OA\Property(property="service", type="string", example="https://example"),
      *              )
      *          ),
      *      ),
@@ -563,6 +553,49 @@ class DataCustodianNetworksController extends Controller
         }
     }
 
+    /**
+     * @OA\Get(
+     *      path="/api/v2/data_custodian_networks/{id}/info",
+     *      description="Return a single DataCustodianNetwork - basic information",
+     *      tags={"DataCustodianNetworks"},
+     *      summary="DataCustodianNetworks@showInfoSummary",
+     *      security={{"bearerAuth":{}}},
+     *      @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         description="DataCustodianNetwork ID - summary",
+     *         required=true,
+     *         example="1",
+     *         @OA\Schema(
+     *            type="integer",
+     *            description="DataCustodianNetwork ID - summary",
+     *         ),
+     *      ),
+     *      @OA\Response(
+     *          response=200,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string"),
+     *              @OA\Property(property="data", type="object",
+     *                  @OA\Property(property="id", type="integer", example=1),
+     *                  @OA\Property(property="name", type="string", example="Name"),
+     *                  @OA\Property(property="img_url", type="string", example="http://placeholder"),
+     *                  @OA\Property(property="url", type="string", example="http://placeholder.url"),
+     *                  @OA\Property(property="summary", type="string", example="Summary"),
+     *.                 @OA\Property(property="enabled", type="boolean", example="true"),
+     *                  @OA\Property(property="service", type="string", example="https://example"),
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=404,
+     *          description="Not found response",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="not found"),
+     *          )
+     *      )
+     * )
+     */
     public function showInfoSummary(Request $request, int $id): JsonResponse
     {
         try {

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -193,7 +193,7 @@ class Dataset extends Model
     /** @return HasOne<DatasetVersion, $this> */
     public function latestMetadata(): HasOne
     {
-        return $this->hasOne(DatasetVersion::class, 'dataset_id')->withTrashed()
+        return $this->hasOne(DatasetVersion::class, 'dataset_id')
             ->orderBy('version', 'desc');
     }
 

--- a/config/routes_v2.php
+++ b/config/routes_v2.php
@@ -1112,6 +1112,17 @@ return [
             'id' => '[0-9]+',
         ],
     ],
+     [
+        'name' => 'data_custodian_networks.get.one.datasetssummary',
+        'method' => 'get',
+        'path' => '/data_custodian_networks/{id}/datasets_summary',
+        'methodController' => 'DataCustodianNetworksController@showDatasetsSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
     [
         'name' => 'data_custodian_networks.get.one.entitiessummary',
         'method' => 'get',

--- a/config/routes_v2.php
+++ b/config/routes_v2.php
@@ -1102,10 +1102,32 @@ return [
         ],
     ],
     [
-        'name' => 'data_custodian_networks.get.one.summary',
+        'name' => 'data_custodian_networks.get.one.custodianssummary',
         'method' => 'get',
-        'path' => '/data_custodian_networks/{id}/summary',
-        'methodController' => 'DataCustodianNetworksController@showSummary',
+        'path' => '/data_custodian_networks/{id}/custodians_summary',
+        'methodController' => 'DataCustodianNetworksController@showCustodiansSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.get.one.entitiessummary',
+        'method' => 'get',
+        'path' => '/data_custodian_networks/{id}/entities_summary',
+        'methodController' => 'DataCustodianNetworksController@showEntitiesSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [],
+        'constraint' => [
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'data_custodian_networks.get.one.info',
+        'method' => 'get',
+        'path' => '/data_custodian_networks/{id}/info',
+        'methodController' => 'DataCustodianNetworksController@showInfoSummary',
         'namespaceController' => 'App\Http\Controllers\Api\V2',
         'middleware' => [],
         'constraint' => [

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -85,10 +85,10 @@ class DataCustodianNetworkTest extends TestCase
         $this->assertTrue(($countTeams === 1));
     }
 
-    public function test_get_data_custodian_network_summary_with_success()
+    public function test_get_data_custodian_network_info_with_success()
     {
         $id = DataProviderColl::where(['enabled' => 1])->first()->id;
-        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/summary', [], $this->header);
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/info', [], $this->header);
 
         $response->assertStatus(200)
             ->assertJsonStructure([
@@ -99,6 +99,20 @@ class DataCustodianNetworkTest extends TestCase
                     'summary',
                     'service',
                     'enabled',
+
+                ],
+            ]);
+    }
+
+    public function test_get_data_custodian_network_custodians_summary_with_success()
+    {
+        $id = DataProviderColl::where(['enabled' => 1])->first()->id;
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/custodians_summary', [], $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
                     'teams_counts' => [
                         0 => [
                             'name',
@@ -110,6 +124,19 @@ class DataCustodianNetworkTest extends TestCase
                             'collections_count'
                         ]
                     ],
+                ],
+            ]);
+    }
+
+    public function test_get_data_custodian_network_entities_summary_with_success()
+    {
+        $id = DataProviderColl::where(['enabled' => 1])->first()->id;
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/entities_summary', [], $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
                     'datasets_total',
                     'datasets',
                     'durs_total',

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -126,7 +126,7 @@ class DataCustodianNetworkTest extends TestCase
     public function test_get_data_custodian_network_datasets_summary_with_success()
     {
         $id = DataProviderColl::where(['enabled' => 1])->first()->id;
-        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/entities_summary', [], $this->header);
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/datasets_summary', [], $this->header);
 
         $response->assertStatus(200)
             ->assertJsonStructure([

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -115,15 +115,25 @@ class DataCustodianNetworkTest extends TestCase
                     'id',
                     'teams_counts' => [
                         0 => [
-                            'name',
                             'id',
-                            'datasets_count',
-                            'tools_count',
-                            'durs_count',
-                            'publications_count',
-                            'collections_count'
+                            'teams_counts',
                         ]
                     ],
+                ],
+            ]);
+    }
+
+    public function test_get_data_custodian_network_datasets_summary_with_success()
+    {
+        $id = DataProviderColl::where(['enabled' => 1])->first()->id;
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/entities_summary', [], $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'datasets_total',
+                    'datasets',
                 ],
             ]);
     }
@@ -137,8 +147,6 @@ class DataCustodianNetworkTest extends TestCase
             ->assertJsonStructure([
                 'data' => [
                     'id',
-                    'datasets_total',
-                    'datasets',
                     'durs_total',
                     'durs',
                     'tools_total',
@@ -147,6 +155,25 @@ class DataCustodianNetworkTest extends TestCase
                     'publications',
                     'collections_total',
                     'collections',
+                ],
+            ]);
+    }
+
+    public function test_get_data_custodian_network_info_summary_with_success()
+    {
+        $id = DataProviderColl::where(['enabled' => 1])->first()->id;
+        $response = $this->json('GET', self::TEST_URL . '/' . $id . '/info', [], $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'name',
+                    'img_url',
+                    'summary',
+                    'enabled',
+                    'url',
+                    'service',
                 ],
             ]);
     }

--- a/tests/Feature/V2/DataCustodianNetworkTest.php
+++ b/tests/Feature/V2/DataCustodianNetworkTest.php
@@ -116,7 +116,12 @@ class DataCustodianNetworkTest extends TestCase
                     'teams_counts' => [
                         0 => [
                             'id',
-                            'teams_counts',
+                            'name',
+                            'datasets_count',
+                            'durs_count',
+                            'publications_count',
+                            'tools_count',
+                            'collections_count',
                         ]
                     ],
                 ],


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Split up calculation of DCNetwork information into 4 calls, and optimise the queries within them. Supports https://github.com/HDRUK/gateway-web/pull/1377

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8198

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
