### PR TITLE
feat(GAT-8200):  Data custodian landing page endpoints

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -829,10 +829,6 @@ class TeamController extends Controller
     public function showDatasetsSummary(Request $request, int $id): JsonResponse
     {
         try {
-            $timing = false;
-            if ($timing) {
-                $startTime = microtime(true);
-            }
             $team = Team::select('id', 'name', 'member_of', 'is_provider', 'introduction', 'url', 'service', 'team_logo')
                 ->where([
                     'id' => $id,
@@ -841,11 +837,7 @@ class TeamController extends Controller
                     $query->select(['id', 'name']);
                 }
                 ])->first();
-            if ($timing) {
-                $endTime = microtime(true);
-                var_dump('Team fetch time: ' . ($endTime - $startTime) . ' seconds');
-                $startTime = microtime(true);
-            }
+
             if (!$team) {
                 throw new NotFoundException();
             }

--- a/config/routes.php
+++ b/config/routes.php
@@ -578,8 +578,41 @@ return [
     [
         'name' => 'teams',
         'method' => 'get',
+        'path' => '/teams/{teamId}/info',
+        'methodController' => 'TeamController@showInfoSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'teams',
+        'method' => 'get',
         'path' => '/teams/{teamId}/summary',
         'methodController' => 'TeamController@showSummary',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'teams',
+        'method' => 'get',
+        'path' => '/teams/{teamId}/datasets_cohort_discovery',
+        'methodController' => 'TeamController@showCohortDiscovery',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'teams',
+        'method' => 'get',
+        'path' => '/teams/{teamId}/datasets_summary',
+        'methodController' => 'TeamController@showDatasetsSummary',
         'namespaceController' => 'App\Http\Controllers\Api\V1',
         'middleware' => [],
         'constraint' => [

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -187,6 +187,31 @@ class TeamTest extends TestCase
     }
 
     /**
+     * Show info of a team.
+     *
+     * @return void
+     */
+    public function test_the_application_can_show_team_info()
+    {
+        $id = Team::where(['enabled' => 1])->first()->id;
+        $response = $this->get('api/v1/teams/' . $id . '/info', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'is_provider',
+                    'team_logo',
+                    'url',
+                    'service',
+                    'name',
+                    'member_of',
+                    'introduction',
+                    'aliases',
+                ],
+            ]);
+    }
+        /**
      * Show summary of a team.
      *
      * @return void
@@ -204,11 +229,48 @@ class TeamTest extends TestCase
                     'is_provider',
                     'team_logo',
                     'introduction',
-                    'datasets',
                     'durs',
                     'tools',
                     'publications',
                     'collections',
+                ],
+            ]);
+    }
+
+    /**
+     * Show datasets summary of a team.
+     *
+     * @return void
+     */
+    public function test_the_application_can_show_team_datasets_summary()
+    {
+        $id = Team::where(['enabled' => 1])->first()->id;
+        $response = $this->get('api/v1/teams/' . $id . '/datasets_summary', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'datasets',
+                ],
+            ]);
+    }
+
+    /**
+     * Show cohort discovery summary of a team.
+     *
+     * @return void
+     */
+    public function test_the_application_can_show_team_cohort_discovery_summary()
+    {
+        $id = Team::where(['enabled' => 1])->first()->id;
+        $response = $this->get('api/v1/teams/' . $id . '/datasets_cohort_discovery', $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'supportsCohortDiscovery',
                 ],
             ]);
     }


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Splits the original `/api/v1/teams/{id}/summary` call into several endpoints to enable instant page load with skeletons

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8200

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
