### PR TITLE
fix(GAT-8247): Archive datasets in federation

### DIFF
--- a/app/Jobs/ProcessFederation.php
+++ b/app/Jobs/ProcessFederation.php
@@ -87,9 +87,9 @@ class ProcessFederation implements ShouldQueue
         // Refresh our potentially mutated list of local items
         $localItems = $this->getLocalDatasetsForFederatedTeam($this->gmi);
 
-        $deleted = $this->deleteLocalDatasetsNotInRemoteCatalogue($localItems, $remoteItems, $this->gmi);
+        $archived = $this->archiveLocalDatasetsNotInRemoteCatalogue($localItems, $remoteItems, $this->gmi);
 
-        $this->log('info', "metadata ingestion completed for team {$this->gmi->getTeam()} - created: {$created}, updated: {$updated}, deleted: {$deleted}");
+        $this->log('info', "metadata ingestion completed for team {$this->gmi->getTeam()} - created: {$created}, updated: {$updated}, archived: {$archived}");
 
         return;
     }

--- a/app/Traits/GatewayMetadataIngestionTrait.php
+++ b/app/Traits/GatewayMetadataIngestionTrait.php
@@ -87,20 +87,20 @@ trait GatewayMetadataIngestionTrait
         ])->get())->keyBy('pid');
     }
 
-    public function deleteLocalDatasetsNotInRemoteCatalogue(
+    public function archiveLocalDatasetsNotInRemoteCatalogue(
         Collection $localItems,
         Collection $remoteItems,
         GatewayMetadataIngestionService $gmi
     ): int {
-        $this->log('info', 'testing REMOTE collection for LOCAL deletions');
+        $this->log('info', 'testing REMOTE collection for LOCAL archive');
 
-        $deletedCount = 0;
+        $archivedCount = 0;
 
-        $toDelete = $localItems->keys()->diff($remoteItems->keys());
+        $toArchive = $localItems->keys()->diff($remoteItems->keys());
 
-        foreach ($toDelete as $pid) {
+        foreach ($toArchive as $pid) {
             try {
-                $this->log('info', "dataset {$pid} detected LOCALLY, but NOT in REMOTE collection - DELETING");
+                $this->log('info', "dataset {$pid} detected LOCALLY, but NOT in REMOTE collection - ARCHIVING");
                 $teamId = $gmi->getTeam();
                 $ds = Dataset::where([
                     'pid' => $pid,
@@ -109,37 +109,24 @@ trait GatewayMetadataIngestionTrait
                 ])->first();
                 
                 if (!$ds) {
-                    $this->log('info', "dataset with PID {$pid} was expected locally but not found in DB — skipping deletion. This is likely a missmatch of team ids, team id on the incoming dataset: {$teamId}");
+                    $this->log('info', "dataset with PID {$pid} was expected locally but not found in DB — skipping archive. This is likely a missmatch of team ids, team id on the incoming dataset: {$teamId}");
                     continue;
                 }
                 $dsId = $ds->id;
 
-                $this->log('info', 'dataset for deletion ' . $dsId);
-
-                $dsv = DatasetVersion::where('dataset_id', $dsId)->first();
-                if ($dsv) {
-                    $this->log('info', 'dataset_version for deletion ' . $dsId);
-                    // Due to constraints, delete spatial coverage first.
-                    $dsvhsc = DatasetVersionHasSpatialCoverage::where('dataset_version_id', $dsId)->forceDelete();
-                    $dsv->forceDelete();
-
-                    unset($dsvhsc);
-                    unset($dsv);
-                } else {
-                    $this->log('warning', "no dataset_version found for dataset {$dsId} - skipping deletion");
-                }
-
-                $ds->forceDelete();
-                $this->log('info', "dataset {$dsId} deleted");
+                $this->log('info', 'dataset for archiving ' . $dsId);
+                $ds->status = Dataset::STATUS_ARCHIVED;
+                $ds->save();
+                $this->log('info', "dataset {$dsId} archived");
 
                 unset($ds);
-                $deletedCount++;
+                $archivedCount++;
             } catch (\Exception $e) {
                 $this->log('error', 'encountered internal error: ' . json_encode($e->getMessage()));
             }
         }
 
-        return $deletedCount;
+        return $archivedCount;
     }
 
     public function createLocalDatasetsMissingFromRemoteCatalogue(


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1552" height="372" alt="image" src="https://github.com/user-attachments/assets/86f0d1b5-171f-4fbb-9873-6cc988454a15" />

## Describe your changes
Due to the many constraints on datasets such as dataset_version_has_spatial_coverage, enquiry_thread_has_dataset_version, dar_application_has_dataset rather than delete these historical records we will archive the dataset. 
## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8247
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
