### PR TITLE
fix(GAT-8248): Fix missing URLs for publications on Data Custodian Network pages

### DIFF
--- a/app/Http/Controllers/Api/V1/DataProviderCollController.php
+++ b/app/Http/Controllers/Api/V1/DataProviderCollController.php
@@ -287,6 +287,7 @@ class DataProviderCollController extends Controller
                 'publication_type',
                 'publication_type_mk1',
                 'status',
+                'url',
                 'created_at',
                 'updated_at'
             )->whereIn('id', $this->publications)->where('status', 'ACTIVE')->get()->toArray();

--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -498,7 +498,7 @@ class DataCustodianNetworksController extends Controller
             );
 
             $linkedPublicationsColl = DB::select(
-                'SELECT DISTINCT p.id, p.paper_title, p.authors, p.publication_type, p.publication_type_mk1, p.status, p.created_at, p.updated_at
+                'SELECT DISTINCT p.id, p.paper_title, p.authors, p.publication_type, p.publication_type_mk1, p.status, p.created_at, p.updated_at, p.url
                 FROM datasets ds
                 JOIN dataset_versions dv ON dv.dataset_id = ds.id
                 JOIN publication_has_dataset_version phdv ON dv.id = phdv.dataset_version_id


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
So far as I can tell, this has never been present in v1 or v2 payloads.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8248

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
