### PR TITLE
feat(GAT-1234): Add custodian.team.cohortAdmin role

### DIFF
--- a/app/Console/Commands/AddCustodianTeamCohortAdminRole.php
+++ b/app/Console/Commands/AddCustodianTeamCohortAdminRole.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DataProviderColl;
+use App\Models\DataProviderCollHasTeam;
+use App\Models\Role;
+use Illuminate\Console\Command;
+
+class AddCustodianTeamCohortAdminRole extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:add-custodian-team-cohort-admin-role';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add custodian.team.cohortAdmin role to roles table';
+
+    private $csvData = [];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        Role::create([
+            'name' => 'custodian.team.cohortAdmin',
+        
+            'full_name' => 'Team Cohort Discovery Admin',
+            'enabled' => 1,
+        ]);
+    }
+}

--- a/app/Http/Controllers/JwtController.php
+++ b/app/Http/Controllers/JwtController.php
@@ -69,10 +69,7 @@ class JwtController extends Controller
             $user->workgroups->makeHidden('pivot');
 
             if (Config::get('services.cohort_discovery.add_teams_to_jwt')) {
-                $user->load(['adminTeams' => function ($query) {
-                    $query->select('teams.id', 'teams.name');
-                }]);
-                $user->adminTeams->makeHidden('pivot');
+                $user->cohortAdminTeams->setVisible(['id', 'name']);
             }
 
             $token = $this->config->builder()

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -253,7 +253,8 @@ class Team extends Model
         return $this->hasManyThrough(Permission::class, TeamHasUser::class);
     }
 
-    public function teamUserRoles(): HasManyThrough
+    /** @return \Staudenmeir\EloquentHasManyDeep\HasManyDeep<Role, $this> */
+    public function teamUserRoles(): \Staudenmeir\EloquentHasManyDeep\HasManyDeep
     {
         return $this->hasManyDeep(
             Role::class,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -152,7 +152,7 @@ class User extends Authenticatable
     public function adminTeams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class, 'team_has_users', 'user_id', 'team_id')
-            ->whereHas('teamUsersRoles', fn ($q) => $q->where(['name' => 'custodian.team.admin', 'user_id' => $this->id]));
+            ->whereHas('teamUserRoles', fn ($q) => $q->where(['name' => 'custodian.team.admin', 'user_id' => $this->id]));
     }
 
     public function cohortAdminTeams(): BelongsToMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -152,7 +152,13 @@ class User extends Authenticatable
     public function adminTeams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class, 'team_has_users', 'user_id', 'team_id')
-            ->whereHas('teamUsers.roles', fn ($q) => $q->where('name', 'custodian.team.admin'));
+            ->whereHas('teamUsersRoles', fn ($q) => $q->where(['name' => 'custodian.team.admin', 'user_id' => $this->id]));
+    }
+
+    public function cohortAdminTeams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class, 'team_has_users', 'user_id', 'team_id')
+            ->whereHas('teamUserRoles', fn ($q) => $q->where(['name' => 'custodian.team.cohortAdmin', 'user_id' => $this->id]));
     }
 
     public function notifications(): BelongsToMany

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -205,6 +205,11 @@ class RoleSeeder extends Seeder
                     'papers.delete',
                 ],
             ],
+            'custodian.team.cohortAdmin' => [
+                'full_name' => 'Team Cohort Discovery Admin',
+                'permissions' => [
+                ],
+            ],
             'developer' => [
                 'full_name' => 'Developer',
                 'permissions' => [


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
`custodian.team.cohortAdmin` is a new role for more tightly focussed responsibility for cohort discovery admin tasks.

This PR adds the role but doesn't add any FE/BE to allow this role to be managed or assigned, so for now it will require manual DB wrangling to assign to users.

Add `custodian.team.cohortAdmin` role via Seeder and Command. Use it in the JWT to send to cohort. 
And fix logic of adminTeams.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Run `php artisan app:add-custodian-team-cohort-admin-role`

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
