### PR TITLE
feat(GAT-0000): Silence events in GMI dataset linkages fix

### DIFF
--- a/app/Console/Commands/FixGMILinkages.php
+++ b/app/Console/Commands/FixGMILinkages.php
@@ -101,11 +101,13 @@ class FixGMILinkages extends Command
                     'dataset_version_id' => $newId,
                     'user_id'=> $linkage->user_id,
                 ] , true));
-                DurHasDatasetVersion::updateOrCreate([
-                    'dur_id' => $linkage->dur_id,
-                    'dataset_version_id' => $newId,
-                    'user_id'=> $linkage->user_id,
-                ]);
+                DurHasDatasetVersion::withoutEvents(function () use ($linkage, $newId) {
+                    DurHasDatasetVersion::updateOrCreate([
+                        'dur_id' => $linkage->dur_id,
+                        'dataset_version_id' => $newId,
+                        'user_id'=> $linkage->user_id,
+                    ]);
+                });
             }
         }
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Silences events in the command so we don't reindex 6046 times in quick succession.

Will require manual reindexing of DURs and Datasets on prod afterwards

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
