### PR TITLE
fix(GAT-7839): Follow up can't be > 10 years due to HTML encoding

### DIFF
--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -672,7 +672,6 @@ class DatasetController extends Controller
 
         $team = Team::where('id', $teamId)->first()->toArray();
 
-        // dd($input['metadata']);
         $input['metadata'] = $this->extractMetadata($input['metadata']);
         $input['status'] = $status;
         $input['user_id'] = $userId;
@@ -683,7 +682,6 @@ class DatasetController extends Controller
         $inputVersion = $request->query('input_version', null);
 
         // Ensure title is present for creating a dataset
-        // dd($input['metadata']['metadata']);
         if (empty($input['metadata']['metadata']['summary']['title'])) {
             return response()->json([
                 'message' => 'Title is required to save a dataset',

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -123,7 +123,6 @@ trait DatasetsV2Helpers
             $metadata = $tmpMetadata;
         }
         if (is_array($metadata) && array_key_exists("metadata", $metadata)) {
-            // Remove HTML encoding from fields that will be validated by traser
             $this->decodeMetadataHTML($metadata['metadata']);
         }
 
@@ -132,6 +131,8 @@ trait DatasetsV2Helpers
 
     private function decodeMetadataHTML(array &$metadataArr)
     {
+        // coverage.followUp can contain >, which will be encoded by the BE
+        // traser will reject this so we need to decode it
         if (Arr::has($metadataArr, 'coverage.followUp')) {
             $metadataArr['coverage']['followUp'] = html_entity_decode($metadataArr['coverage']['followUp']);
         }

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -123,7 +123,18 @@ trait DatasetsV2Helpers
             $metadata = $tmpMetadata;
         }
 
+        // Metadata should not contain HTML encodings
+        $this->decodeMetadataHTML($metadata['metadata']);
         return $metadata;
     }
 
+    private function decodeMetadataHTML(Array &$metadataArr) {
+        foreach ($metadataArr as $key => &$value) {
+            if (is_array($value)) {
+                $this->decodeMetadataHTML($value); 
+            } else {
+                $metadataArr[$key] = html_entity_decode($value);
+            }
+        }
+    }
 }

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -131,10 +131,13 @@ trait DatasetsV2Helpers
 
     private function decodeMetadataHTML(array &$metadataArr)
     {
-        // coverage.followUp can contain >, which will be encoded by the BE
-        // traser will reject this so we need to decode it
-        if (Arr::has($metadataArr, 'coverage.followUp')) {
-            $metadataArr['coverage']['followUp'] = html_entity_decode($metadataArr['coverage']['followUp']);
+        // Some fields may be html encoded by middleware and so will not pass
+        // the schema checks. We need to remove this HTML encoding
+        foreach (Config::get("metadata.html_decode_fields") as $field) {
+            if (Arr::has($metadataArr, $field)) {
+                $val = html_entity_decode(Arr::get($metadataArr, $field));
+                Arr::set($metadataArr, $field, $val);
+            }
         }
     }
 }

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -123,7 +123,7 @@ trait DatasetsV2Helpers
             $metadata = $tmpMetadata;
         }
         if (is_array($metadata) && array_key_exists("metadata", $metadata)) {
-            // Metadata should not contain HTML encodings
+            // Remove HTML encoding from fields that will be validated by traser
             $this->decodeMetadataHTML($metadata['metadata']);
         }
 
@@ -132,12 +132,8 @@ trait DatasetsV2Helpers
 
     private function decodeMetadataHTML(array &$metadataArr)
     {
-        foreach ($metadataArr as $key => &$value) {
-            if (is_array($value)) {
-                $this->decodeMetadataHTML($value);
-            } else {
-                $metadataArr[$key] = html_entity_decode($value);
-            }
+        if (Arr::has($metadataArr, 'coverage.followUp')) {
+            $metadataArr['coverage']['followUp'] = html_entity_decode($metadataArr['coverage']['followUp']);
         }
     }
 }

--- a/app/Http/Traits/DatasetsV2Helpers.php
+++ b/app/Http/Traits/DatasetsV2Helpers.php
@@ -122,16 +122,19 @@ trait DatasetsV2Helpers
             unset($metadata['metadata']);
             $metadata = $tmpMetadata;
         }
+        if (is_array($metadata) && array_key_exists("metadata", $metadata)) {
+            // Metadata should not contain HTML encodings
+            $this->decodeMetadataHTML($metadata['metadata']);
+        }
 
-        // Metadata should not contain HTML encodings
-        $this->decodeMetadataHTML($metadata['metadata']);
         return $metadata;
     }
 
-    private function decodeMetadataHTML(Array &$metadataArr) {
+    private function decodeMetadataHTML(array &$metadataArr)
+    {
         foreach ($metadataArr as $key => &$value) {
             if (is_array($value)) {
-                $this->decodeMetadataHTML($value); 
+                $this->decodeMetadataHTML($value);
             } else {
                 $metadataArr[$key] = html_entity_decode($value);
             }

--- a/config/metadata.php
+++ b/config/metadata.php
@@ -8,4 +8,5 @@ return [
     'google_secrets_credentials' => env('GOOGLE_APPLICATION_CREDENTIALS', ''),
     'google_project_path' => env('GOOGLE_APPLICATION_PROJECT_PATH', ''),
     'system_user_id' => env('GATEWAY_API_USER_ID'),
+    "html_decode_fields" => ["coverage.followUp"]
 ];

--- a/config/metadata.php
+++ b/config/metadata.php
@@ -8,5 +8,5 @@ return [
     'google_secrets_credentials' => env('GOOGLE_APPLICATION_CREDENTIALS', ''),
     'google_project_path' => env('GOOGLE_APPLICATION_PROJECT_PATH', ''),
     'system_user_id' => env('GATEWAY_API_USER_ID'),
-    "html_decode_fields" => ["coverage.followUp"]
+    "permitted_characeters" => [">"]
 ];

--- a/tests/Feature/DatasetsV2HelpersTest.php
+++ b/tests/Feature/DatasetsV2HelpersTest.php
@@ -56,4 +56,12 @@ class DatasetsV2HelpersTest extends TestCase
         $result = $this->extractMetadata($input);
         $this->assertEquals($input, $result);
     }
+
+    public function test_it_handles_html_encoding()
+    {
+        $input = ['metadata' => ['foo' => 'bar &gt;']];
+        $output = ['metadata' => ['foo' => 'bar >']];
+        $result = $this->extractMetadata($input);
+        $this->assertEquals($output, $result);
+    }
 }

--- a/tests/Feature/DatasetsV2HelpersTest.php
+++ b/tests/Feature/DatasetsV2HelpersTest.php
@@ -60,7 +60,7 @@ class DatasetsV2HelpersTest extends TestCase
     public function test_it_handles_html_encoding()
     {
         $input = ['metadata' => ['coverage' => ['followUp' => 'bar &gt;']]];
-        $input = ['metadata' => ['coverage' => ['followUp' => 'bar >']]];
+        $output = ['metadata' => ['coverage' => ['followUp' => 'bar >']]];
         $result = $this->extractMetadata($input);
         $this->assertEquals($output, $result);
     }

--- a/tests/Feature/DatasetsV2HelpersTest.php
+++ b/tests/Feature/DatasetsV2HelpersTest.php
@@ -59,8 +59,8 @@ class DatasetsV2HelpersTest extends TestCase
 
     public function test_it_handles_html_encoding()
     {
-        $input = ['metadata' => ['foo' => 'bar &gt;']];
-        $output = ['metadata' => ['foo' => 'bar >']];
+        $input = ['metadata' => ['coverage' => ['followUp' => 'bar &gt;']]];
+        $input = ['metadata' => ['coverage' => ['followUp' => 'bar >']]];
         $result = $this->extractMetadata($input);
         $this->assertEquals($output, $result);
     }


### PR DESCRIPTION
## Screenshots (if relevant)
https://github.com/user-attachments/assets/8269e7da-b28b-4b37-a18e-3127b9100bcd

## Describe your changes
Laravel was encoding > to &gt;, which traser was then rejecting. > is now allowed in the metadata to solve this

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7839

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
