### PR TITLE
fix(GAT-8426): Better handling of nulls for form hydration

### DIFF
--- a/app/Http/Controllers/Api/V1/FormHydrationController.php
+++ b/app/Http/Controllers/Api/V1/FormHydrationController.php
@@ -221,7 +221,7 @@ class FormHydrationController extends Controller
         $values = array();
         foreach ($datasets as $dataset) {
             $v = $this->getValueFromPath($dataset, $path);
-            $values[] = is_null($v) ? '' : $this->getValueFromPath($dataset, $path);
+            $values[] = is_scalar($v) ? (string)$v : '';
         }
 
         $countMap = array_count_values($values);
@@ -235,7 +235,7 @@ class FormHydrationController extends Controller
         }
     }
 
-    public function getValueFromPath(array $item, string $path)
+    public function getValueFromPath(array $item, string $path): mixed
     {
         $keys = explode('.', $path);
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

There was some weird code that lead to a bug for UCLH. Pure edge-case, but the code itself wasn't overly friendly. Previously it was:

```php
            $v = $this->getValueFromPath($dataset, $path);
            $values[] = is_null($v) ? '' : $this->getValueFromPath($dataset, $path);
```

...which is perfectly valid, but wasteful, and potentially includes some weird recursion we hadn't expected. So, it's been changed to:

```php
            $v = $this->getValueFromPath($dataset, $path);
            $values[] = is_scalar($v) ? (string)$v : '';
```

...which removes the recursive aspect and uses `is_scalar` to avoid calling `array_count_values` with anything other than a string (being that `array_count_values` only works with strings and ints).

This fixes the issue and was tested against a db backup of preprod, against UCLH dataset in question.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
