### PR TITLE
fix(GAT-0000): Fix issue with data access seeder

### DIFF
--- a/database/seeders/DataAccessTemplateSeeder.php
+++ b/database/seeders/DataAccessTemplateSeeder.php
@@ -6,6 +6,7 @@ use App\Models\DataAccessTemplate;
 use App\Models\DataAccessTemplateHasQuestion;
 use App\Models\QuestionBank;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DataAccessTemplateSeeder extends Seeder
 {
@@ -14,9 +15,12 @@ class DataAccessTemplateSeeder extends Seeder
      */
     public function run(): void
     {
-        DataAccessTemplate::query()->delete();
-        DataAccessTemplateHasQuestion::query()->delete();
-        DataAccessTemplate::factory(3)->create();
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        DataAccessTemplate::truncate();
+        DataAccessTemplateHasQuestion::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        DataAccessTemplate::factory(3)->create();        
 
         DataAccessTemplate::all()->each(function ($model) {
 

--- a/database/seeders/DataAccessTemplateSeeder.php
+++ b/database/seeders/DataAccessTemplateSeeder.php
@@ -14,8 +14,8 @@ class DataAccessTemplateSeeder extends Seeder
      */
     public function run(): void
     {
-        DataAccessTemplate::truncate();
-        DataAccessTemplateHasQuestion::truncate();
+        DataAccessTemplate::query()->delete();
+        DataAccessTemplateHasQuestion::query()->delete();
         DataAccessTemplate::factory(3)->create();
 
         DataAccessTemplate::all()->each(function ($model) {

--- a/database/seeders/DataAccessTemplateSeeder.php
+++ b/database/seeders/DataAccessTemplateSeeder.php
@@ -15,10 +15,14 @@ class DataAccessTemplateSeeder extends Seeder
      */
     public function run(): void
     {
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
-        DataAccessTemplate::truncate();
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        }
         DataAccessTemplateHasQuestion::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        DataAccessTemplate::truncate();        
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }        
 
         DataAccessTemplate::factory(3)->create();        
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Fix issue with data access seeder

When running the seeder on a fresh db, errors with 

```
Cannot truncate a table referenced in a foreign key constraint (`db`.`dar_template_has_files`, CONSTRAINT `dar_template_has_files_template_id_foreign`) (Connection: mysql, SQL: truncate table `dar_templates`)
```

using query delete, ignores the fk

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
