### PR TITLE
fix(GAT-0000): Fix CollectionHasUserSeeder

### DIFF
--- a/database/seeders/CollectionHasUserSeeder.php
+++ b/database/seeders/CollectionHasUserSeeder.php
@@ -19,7 +19,7 @@ class CollectionHasUserSeeder extends Seeder
         foreach ($collections as $collection) {
             $userId = User::all()->random()->id;
 
-            CollectionHasUser::create([
+            CollectionHasUser::updateOrCreate([
                 'collection_id' => $collection->id,
                 'user_id' => $userId,
                 'role' => 'CREATOR',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
CollectionHasUserSeeder sometimes failed after picking the same user twice, with 

`
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '6-22' for key 'collection_has_users.collection_has_users_collection_id_user_id_unique' (Connection: mysql, Host: 127.0.0.1, Port: 3306, Database: db, SQL: insert into collection_has_users (collection_id, user_id, role) values (6, 22, CREATOR))
`


## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
