### PR TITLE
fix(GAT-8109): Data Use Register entries not matching Gateway dataset titles at first creation

### DIFF
--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -126,7 +126,7 @@ class DatasetController extends Controller
                 ->pluck('id')
                 ->toArray();
 
-            if (!is_null($filterTitle) || !empty($filterTitle)) {
+            if (!empty($filterTitle)) {
                 $matches = DatasetVersion::whereIn('dataset_id', $matches)
                     ->filterTitle($filterTitle)
                     ->select('dataset_id', 'version')

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -126,7 +126,7 @@ class DatasetController extends Controller
                 ->pluck('id')
                 ->toArray();
 
-            if (!empty($filterTitle)) {
+            if (!is_null($filterTitle) || !empty($filterTitle)) {
                 $matches = DatasetVersion::whereIn('dataset_id', $matches)
                     ->filterTitle($filterTitle)
                     ->select('dataset_id', 'version')

--- a/app/Jobs/ExtractDatasetFromDur.php
+++ b/app/Jobs/ExtractDatasetFromDur.php
@@ -55,6 +55,7 @@ class ExtractDatasetFromDur implements ShouldQueue
         $dur = Dur::findOrFail($durId);
         $nonGatewayDatasets = array_filter(array_map('trim', $dur['non_gateway_datasets'] ?? [])) ?? [];
         $unmatched = array();
+
         foreach ($nonGatewayDatasets as $nonGatewayDataset) {
             $nonDataset = trim($nonGatewayDataset);
 
@@ -79,10 +80,9 @@ class ExtractDatasetFromDur implements ShouldQueue
                 }
             }
 
-            $datasetVersion = DatasetVersion::whereRaw(
-                'LOWER(short_title) LIKE ?',
-                ['%' . strtolower($nonDataset) . '%']
-            )->latest('version')->first();
+            $datasetVersion = DatasetVersion::whereRaw('LOWER(short_title) LIKE ?', ['%' . strtolower($nonDataset) . '%'])
+                                ->latest('version')
+                                ->first();
             if ($datasetVersion) {
                 DurHasDatasetVersion::create([
                     'dur_id' => $durId,

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -194,7 +194,7 @@ class Dataset extends Model
     public function latestMetadata(): HasOne
     {
         return $this->hasOne(DatasetVersion::class, 'dataset_id')
-            ->orderBy('version', 'desc');
+            ->latestOfMany('version');
     }
 
     /**

--- a/app/Observers/DurHasDatasetVersionObserver.php
+++ b/app/Observers/DurHasDatasetVersionObserver.php
@@ -59,9 +59,12 @@ class DurHasDatasetVersionObserver
             'id' => $durId,
             'status' => Dur::STATUS_ACTIVE,
         ])->select('id')->first();
-        if (!is_null($dur)) {
-            $this->indexElasticDur($dur->id);
+
+        if (is_null($dur)) {
+            return;
         }
+
+        $this->indexElasticDur($dur->id);
 
         $datasetVersionId = $durHasDatasetVersion->dataset_version_id;
         $datasetVersion = DatasetVersion::where([
@@ -72,7 +75,7 @@ class DurHasDatasetVersionObserver
             $dataset = Dataset::where([
                 'id' => $datasetVersion->dataset_id,
                 'status' => Dataset::STATUS_ACTIVE,
-            ])->select('id')->first();
+            ])->select(['id', 'team_id'])->first();
 
             if (!is_null($dataset)) {
                 $this->reindexElastic($dataset->id);

--- a/app/Observers/DurObserver.php
+++ b/app/Observers/DurObserver.php
@@ -29,7 +29,7 @@ class DurObserver
      */
     public function updating(Dur $dur)
     {
-        $dur->prevStatus = $dur->getOriginal('status'); // 'status' before updating
+        $dur->prevStatus = (string) $dur->getOriginal('status'); // 'status' before updating
     }
 
     /**
@@ -60,7 +60,7 @@ class DurObserver
      */
     public function deleting(Dur $dur)
     {
-        $dur->prevStatus = $dur->getOriginal('status'); // 'status' before deleting
+        $dur->prevStatus = (string) $dur->getOriginal('status'); // 'status' before deleting
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
