### PR TITLE
fix(GAT-9999): Fixes (DP-492) issues surrounding auth sometimes failing

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1509,11 +1509,17 @@ class CohortRequestController extends Controller
             throw new Exception('Cannot find cohort service oauth client');
         }
 
-        return config('app.url').
-            '/oauth2/authorize?response_type=code'.
-            "&client_id={$cohortClient->id}".
-            '&scope=openid email profile rquestroles cohort_discovery_roles'.
-            "&redirect_uri={$cohortClient->redirect}";
+        $nonce = bin2hex(random_bytes(16));
+
+        $query = http_build_query([
+            'response_type' => 'code',
+            'client_id' => $cohortClient->id,
+            'scope' => 'openid email profile rquestroles cohort_discovery_roles',
+            'redirect_uri' => $cohortClient->redirect,
+            'nonce' => $nonce,
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        return config('app.url').'/oauth2/authorize?'.$query;
     }
 
     private function sendEmail($cohortId, $admin = null)

--- a/app/Http/Controllers/SSO/OAuth2Controller.php
+++ b/app/Http/Controllers/SSO/OAuth2Controller.php
@@ -33,16 +33,22 @@ class OAuth2Controller extends Controller
         Request $request,
         ClientRepository $clients,
     ) {
-        $userId = session('cr_uid') ?? config('passport.cr_uid_debug');
+        $userId = $request->session()->get('cr_uid') ?? null;
 
         if (!$userId) {
             abort(401, 'User not authenticated');
         }
 
-        OAuthUser::updateOrCreate([
-            'user_id' => $userId,
-            'nonce' => '123456789',
-        ]);
+        $nonce = $request->query('nonce');
+
+        if (!is_string($nonce) || trim($nonce) === '') {
+            abort(400, 'Missing nonce');
+        }
+
+        OauthUser::updateOrCreate(
+            ['user_id' => $userId],
+            ['nonce' => $nonce]
+        );
 
         return $this->withErrorHandling(function () use ($psrRequest, $userId) {
             $authRequest = $this->server->validateAuthorizationRequest($psrRequest);


### PR DESCRIPTION
## Screenshots (if relevant)
N/A

## Describe your changes
Updates the Auth controllers to correctly set and pass nonce and session against the request, not session itself. Allows for more controlled ferrying.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
