### PR TITLE
fix(GAT-8579): NHS SDE approval is wrong

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,23 +4,23 @@ namespace App\Models;
 
 // use Laravel\Sanctum\HasApiTokens;
 use App\Http\Traits\WithJwtUser;
-use Laravel\Passport\HasApiTokens;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Passport\HasApiTokens;
 
 class User extends Authenticatable
 {
+    use HasApiTokens;
     use HasFactory;
     use Notifiable;
     use SoftDeletes;
     use WithJwtUser;
-    use HasApiTokens;
 
     /**
      * The attributes that are mass assignable.
@@ -75,14 +75,12 @@ class User extends Authenticatable
         'is_nhse_sde_approval' => 'boolean',
     ];
 
-
     public function sector(): BelongsTo
     {
         return $this->belongsTo(Sector::class);
     }
 
-
-    protected $appends = ['rquestroles', 'cohort_discovery_roles'];
+    protected $appends = ['rquestroles', 'cohort_discovery_roles', 'cohort_discovery_nhs_sde'];
 
     public function getCohortDiscoveryRolesAttribute()
     {
@@ -93,12 +91,12 @@ class User extends Authenticatable
             'request_status' => 'APPROVED',
         ])->first();
 
-        if (!$cohortRequest) {
+        if (! $cohortRequest) {
             return [];
         }
 
         $cohortRequestRoleIds = CohortRequestHasPermission::where([
-            'cohort_request_id' => $cohortRequest->id
+            'cohort_request_id' => $cohortRequest->id,
         ])->pluck('permission_id')->toArray();
 
         $cohortRequestRoles = Permission::whereIn('id', $cohortRequestRoleIds)->pluck('name')->toArray();
@@ -115,17 +113,32 @@ class User extends Authenticatable
             'request_status' => 'APPROVED',
         ])->first();
 
-        if (!$cohortRequest) {
+        if (! $cohortRequest) {
             return [];
         }
 
         $cohortRequestRoleIds = CohortRequestHasPermission::where([
-            'cohort_request_id' => $cohortRequest->id
+            'cohort_request_id' => $cohortRequest->id,
         ])->pluck('permission_id')->toArray();
 
         $cohortRequestRoles = Permission::whereIn('id', $cohortRequestRoleIds)->pluck('name')->toArray();
 
         return $cohortRequestRoles;
+    }
+
+    public function getCohortDiscoveryNhsSdeAttribute()
+    {
+        $id = $this->id;
+
+        $nhsSdeApproved = CohortRequest::where([
+            'user_id' => $id,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+        ])
+            ->whereNull('nhse_sde_request_expire_at')
+            ->exists();
+
+        return $nhsSdeApproved;
     }
 
     /**


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

The JWT token has:
```
"is_nhse_sde_approval": false,
```

Which is getting this data from the User table. This is wrong/redundant. We need to get it from the CohortRequest, if it is not expired. 

This change adds the following to the JWT.
```
"cohort_discovery_nhs_sde": true,
```

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8579

## Environment / Configuration changes (if applicable)

None

## Requires migrations being run?

No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
