### PR TITLE
feat(GAT-0000): Optimising auth login from ~3s to < 1s

### DIFF
--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -201,17 +201,14 @@ class UserController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
-            $users = User::where([
-                'id' => $id,
-            ])->get();
+            $userTeam = User::where('id', $id)->with(
+                'roles',
+                'roles.permissions',
+                'teams',
+                'notifications'
+            )->get()->toArray();
 
-            if ($users->count()) {
-                $userTeam = User::where('id', $id)->with(
-                    'roles',
-                    'roles.permissions',
-                    'teams',
-                    'notifications'
-                )->get()->toArray();
+            if (count($userTeam)) {
 
                 Auditor::log([
                     'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Middleware/JwtMiddleware.php
+++ b/app/Http/Middleware/JwtMiddleware.php
@@ -59,13 +59,7 @@ class JwtMiddleware
 
             $request->merge(
                 [
-                    'jwt_user' => [
-                        'id' => $user->id,
-                        'name' => $user->name,
-                        'email' => $user->email,
-                        'is_admin' => $user->is_admin,
-                        'role_perms' => $this->getUserRolePerms($user->id),
-                    ],
+                    'jwt_user' => $this->buildJwtUserPayload($request, $user),
                 ],
             );
 
@@ -131,13 +125,7 @@ class JwtMiddleware
 
                 $request->merge(
                     [
-                        'jwt_user' => [
-                            'id' => $user->id,
-                            'name' => $user->name,
-                            'email' => $user->email,
-                            'is_admin' => $user->is_admin,
-                            'role_perms' => $this->getUserRolePerms($user->id),
-                        ],
+                        'jwt_user' => $this->buildJwtUserPayload($request, $user),
                     ],
                 );
                 return $next($request);
@@ -151,5 +139,42 @@ class JwtMiddleware
     private function validateUserId(int $userId)
     {
         return User::find($userId);
+    }
+
+    private function buildJwtUserPayload(Request $request, User $user): array
+    {
+        $jwtUser = [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'is_admin' => $user->is_admin,
+        ];
+
+        if ($this->routeRequiresRolePerms($request)) {
+            $jwtUser['role_perms'] = $this->getUserRolePerms($user->id);
+        }
+
+        return $jwtUser;
+    }
+
+    private function routeRequiresRolePerms(Request $request): bool
+    {
+        $route = $request->route();
+        if (!$route) {
+            return true;
+        }
+
+        $controllerAction = (string) ($route->getAction()['controller'] ?? '');
+        if ($controllerAction === 'App\\Http\\Controllers\\Api\\V1\\UserController@show') {
+            return false;
+        }
+
+        foreach ($route->gatherMiddleware() as $middleware) {
+            if ($middleware === 'check.access' || str_starts_with($middleware, 'check.access:')) {
+                return true;
+            }
+        }
+
+        return true;
     }
 }

--- a/app/Http/Traits/UserTransformation.php
+++ b/app/Http/Traits/UserTransformation.php
@@ -17,6 +17,62 @@ trait UserTransformation
     public function getUsers(array $users): array
     {
         $response = [];
+        $teamRolesByPivotId = [];
+        $notificationsByUserId = [];
+
+        $teamHasUserIds = [];
+        foreach ($users as $user) {
+            if (!isset($user['teams']) || !is_array($user['teams'])) {
+                continue;
+            }
+
+            foreach ($user['teams'] as $team) {
+                if (isset($team['pivot']['id'])) {
+                    $teamHasUserIds[] = (int) $team['pivot']['id'];
+                }
+            }
+        }
+
+        $teamHasUserIds = array_values(array_unique($teamHasUserIds));
+        if ($teamHasUserIds) {
+            $teamUsers = TeamHasUser::whereIn('id', $teamHasUserIds)->with('roles')->get();
+            foreach ($teamUsers as $teamUser) {
+                $teamRolesByPivotId[(int) $teamUser->id] = $teamUser->roles->toArray();
+            }
+        }
+
+        $usersNeedNotificationLookup = false;
+        foreach ($users as $user) {
+            if (!array_key_exists('notifications', $user)) {
+                $usersNeedNotificationLookup = true;
+                break;
+            }
+        }
+
+        if ($usersNeedNotificationLookup) {
+            $userIds = array_values(array_unique(array_map(fn ($user) => (int) $user['id'], $users)));
+
+            if ($userIds) {
+                $userNotifications = UserHasNotification::whereIn('user_id', $userIds)->get(['user_id', 'notification_id']);
+                $notificationIds = array_values(array_unique($userNotifications->pluck('notification_id')->map(fn ($id) => (int) $id)->toArray()));
+
+                $notificationMap = [];
+                if ($notificationIds) {
+                    $notificationMap = Notification::whereIn('id', $notificationIds)->get()->keyBy('id');
+                }
+
+                foreach ($userNotifications as $userNotification) {
+                    $userId = (int) $userNotification->user_id;
+                    $notificationId = (int) $userNotification->notification_id;
+
+                    if (!isset($notificationMap[$notificationId])) {
+                        continue;
+                    }
+
+                    $notificationsByUserId[$userId][] = $notificationMap[$notificationId];
+                }
+            }
+        }
 
         foreach ($users as $user) {
             $tmpUser = [
@@ -66,11 +122,10 @@ trait UserTransformation
                 ];
 
                 $teamHasUserId = (int)$team['pivot']['id'];
-
-                $roles = TeamHasUser::where('id', $teamHasUserId)->with('roles')->get()->toArray();
+                $roles = $teamRolesByPivotId[$teamHasUserId] ?? [];
 
                 $tmpPerm = [];
-                foreach ($roles[0]['roles'] as $role) {
+                foreach ($roles as $role) {
                     $tmpPerm[] = $role;
                 }
                 $tmp['roles'] = $tmpPerm;
@@ -82,13 +137,11 @@ trait UserTransformation
             }
             $tmpUser['teams'] = $tmpTeam;
 
-            $notifications = UserHasNotification::where('user_id', $tmpUser['id'])->get()->toArray();
-            $tmpNotification = [];
-            foreach ($notifications as $value) {
-                $notification = Notification::where('id', $value['notification_id'])->firstOrFail();
-                $tmpNotification[] = $notification;
+            if (array_key_exists('notifications', $user)) {
+                $tmpUser['notifications'] = $user['notifications'];
+            } else {
+                $tmpUser['notifications'] = $notificationsByUserId[(int) $tmpUser['id']] ?? [];
             }
-            $tmpUser['notifications'] = $tmpNotification;
 
             // Added in to stop a singular /users/:id call returning an array for
             // the users part of the payload
@@ -100,8 +153,6 @@ trait UserTransformation
 
             unset($tmpTeam);
             unset($tmpUser);
-            unset($notifications);
-            unset($tmpNotification);
         }
 
         return $response;


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Optimises the Gateway authentication path. Details below:

1. `UserController@show` was wasting cycles calling `$user->count()` which runs subsequent queries, whereas `count($user)` does the same without additional db calls. 
2. `JwtMiddleware@handle` was rebuilding roles and perms already eagerly loaded by relations, for every single request. I've refactored this to batch this info.
3. `UserTransformation@getUsers` this entire thing needs refactoring, but for now I've refactored just this method to batch team and role lookups, instead of calling `TeamHasUser` for every single team. Also fixed an N+1 issue whereby `Notifications` were (again) already eagerly loaded, instead of re-querying `user_has_notifications` + `notifications` per user/per notification, which was _really heavy waste_!

*To note* - I've commented on this PR to highlight a specific intentional (but not long term) narrowing. Upon testing the refactor, there were a number of failed tests in completely unrelated areas. This is due to mixed logic requirements for data guarding. Some controllers only require `jwt.verify` middleware, but expect the same roles/perms to be available like in `check.access` - I don't have time to tackle this too, so the narrowing applies these changes just to auth flow.

## Issue ticket link
None. Technically part of DP-504 - and exposed when optimising and adding a loader.

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

```
composer run phpstan
> vendor/bin/phpstan analyse app  --memory-limit 512M
Note: Using configuration file /Users/lokisinclair/Development/HDRUK/gateway-api-2/phpstan.neon.
 730/730 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
                                                                                                                   
 [OK] No errors                                                                                                                                                             
```

```
  Tests:    600 passed (8896 assertions)
  Duration: 125.12s
  Parallel: 11 processes
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
