### PR TITLE
fix(GAT-7418): Command regenerate PIDs for all active datasets of a team

### DIFF
--- a/app/Console/Commands/RegeneratePidForTeam.php
+++ b/app/Console/Commands/RegeneratePidForTeam.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class RegeneratePidForTeam extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:regenerate-pid-for-team {teamId : The ID of the team}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command regenerate PIDs for all active datasets of a team';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $teamId = $this->argument('teamId');
+
+        if (!is_numeric($teamId) || (int) $teamId <= 0) {
+            $this->error('Invalid team ID provided.');
+            return Command::FAILURE;
+        }
+
+        $teamId = (int) $teamId;
+
+        $datasets = Dataset::where([
+            'team_id' => $teamId,
+            'status' => Dataset::STATUS_ACTIVE,
+            ])->get();
+
+        foreach ($datasets as $dataset) {
+            $newPid = (string) Str::uuid();
+            $dataset->pid = $newPid;
+            $dataset->save();
+
+            $this->info("Updated dataset ID {$dataset->id} with new PID: {$newPid}");
+
+            $latestDatasetVersion = DatasetVersion::where('dataset_id', $dataset->id)->latest('version')->select(['id'])->first();
+
+            $this->info("Latest dataset version ID for dataset ID {$dataset->id}: {$latestDatasetVersion->id}");
+
+            \DB::statement("
+                UPDATE dataset_versions 
+                SET metadata = JSON_SET(metadata, '$.metadata.required.gatewayPid', CAST(? AS CHAR))
+                WHERE id = ? 
+                LIMIT 1
+            ", [$newPid, $latestDatasetVersion->id]);
+
+            \DB::statement("
+                UPDATE dataset_versions 
+                SET metadata = JSON_SET(metadata, '$.original_metadata.identifier', CAST(? AS CHAR))
+                WHERE id = ? 
+                LIMIT 1
+            ", [$newPid, $latestDatasetVersion->id]);
+        }
+    }
+}

--- a/init/php.development.ini
+++ b/init/php.development.ini
@@ -1,7 +1,7 @@
 upload_max_filesize=40M
 post_max_size=40M
 opcache.enable=0
-memory_limit=256M
+memory_limit=512M
 # zend_extension=opcache.so
 # opcache.enable=1
 # opcache.enable_cli=1

--- a/init/php.development.ini
+++ b/init/php.development.ini
@@ -1,7 +1,7 @@
 upload_max_filesize=40M
 post_max_size=40M
 opcache.enable=0
-memory_limit=512M
+memory_limit=256M
 # zend_extension=opcache.so
 # opcache.enable=1
 # opcache.enable_cli=1


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-7418


## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
