### PR TITLE
feat(GAT-8246): Data Custodian Networks now return team_ids to help with filters

### DIFF
--- a/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
+++ b/app/Http/Controllers/Api/V2/DataCustodianNetworksController.php
@@ -466,12 +466,12 @@ class DataCustodianNetworksController extends Controller
             // Durs: get all active durs owned by the team and also active durs linked to (all versions of) datasets owned by the team
             $ownedDurs = Dur::where(['status' => Dur::STATUS_ACTIVE])
                 ->whereIn('team_id', $teamIds)
-                ->select(['id', 'project_title', 'organisation_name', 'status'])
+                ->select(['id', 'project_title', 'organisation_name', 'status', 'team_id'])
                 ->get()
                 ->toArray();
 
             $linkedDursColl = DB::select(
-                'SELECT DISTINCT d.id, d.project_title, d.organisation_name, d.status
+                'SELECT DISTINCT d.id, d.project_title, d.organisation_name, d.status, ds.team_id
                 FROM datasets ds
                 JOIN dataset_versions dv ON dv.dataset_id = ds.id
                 JOIN dur_has_dataset_version dhdv ON dv.id = dhdv.dataset_version_id
@@ -488,7 +488,7 @@ class DataCustodianNetworksController extends Controller
 
             // for each other entity type, get all that are linked to datasets owned by the teams in this DPC
             $linkedToolsColl = DB::select(
-                'SELECT DISTINCT t.id, t.name, t.enabled, t.status, t.created_at, t.updated_at
+                'SELECT DISTINCT t.id, t.name, t.enabled, t.status, t.created_at, t.updated_at, ds.team_id
                 FROM datasets ds
                 JOIN dataset_versions dv ON dv.dataset_id = ds.id
                 JOIN dataset_version_has_tool dvht ON dv.id = dvht.dataset_version_id
@@ -498,7 +498,7 @@ class DataCustodianNetworksController extends Controller
             );
 
             $linkedPublicationsColl = DB::select(
-                'SELECT DISTINCT p.id, p.paper_title, p.authors, p.publication_type, p.publication_type_mk1, p.status, p.created_at, p.updated_at, p.url
+                'SELECT DISTINCT p.id, p.paper_title, p.authors, p.publication_type, p.publication_type_mk1, p.status, p.created_at, p.updated_at, p.url, ds.team_id
                 FROM datasets ds
                 JOIN dataset_versions dv ON dv.dataset_id = ds.id
                 JOIN publication_has_dataset_version phdv ON dv.id = phdv.dataset_version_id
@@ -508,7 +508,7 @@ class DataCustodianNetworksController extends Controller
             );
 
             $linkedCollectionColl = DB::select(
-                'SELECT DISTINCT c.id, c.name, c.image_link, c.status, c.created_at, c.updated_at
+                'SELECT DISTINCT c.id, c.name, c.image_link, c.status, c.created_at, c.updated_at, ds.team_id
                 FROM datasets ds
                 JOIN dataset_versions dv ON dv.dataset_id = ds.id
                 JOIN collection_has_dataset_version chdv ON dv.id = chdv.dataset_version_id


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
FE PR: https://github.com/HDRUK/gateway-web/pull/1487

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8246
## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
