### PR TITLE
feat(GAT-8610): Fix access checks for scrambled open-athens emails

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1408,6 +1408,20 @@ class CohortRequestController extends Controller
         ], Config::get('statuscodes.STATUS_OK.code'));
     }
 
+    private function isScrambled(string $email) {
+        $indicatorsOfScrambled = [
+            "member@",
+            "staff@",
+            "student@",
+            "employee@",
+            "postgraduatetaught@",
+        ];
+
+        return array_any($indicatorsOfScrambled, function(string $item) use ($email) {
+            return str_contains(strtolower($email), $item);
+        });
+    }
+
     /**
      * Shared guard: validates JWT user, approved request, permissions, user+email,
      * clears oauth user, sets session, logs auditor.
@@ -1454,8 +1468,7 @@ class CohortRequestController extends Controller
             if (! $user) {
                 throw new Exception('Unauthorized for access :: The user not found');
             }
-
-            $email = ($user->provider === 'open-athens' || $user->preferred_email === 'secondary')
+            $email = (($user->provider === 'open-athens' && $this->isScrambled($user->email)) || $user->preferred_email === 'secondary')
                 ? $user->secondary_email
                 : $user->email;
 


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Add check for scrambledness of open-athens email addresses

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8610

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
