### PR TITLE
feat(GAT-0000): Refactoring to enable partner context for API operation for CRUK and others, and optimisations when noticed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Partner context controls which Resource classes are used to shape API responses.
+# See config/partners.php for the full resource map and instructions on adding
+# a new partner integration. The x-partner-context request header takes precedence
+# over this value if present.
+DEFAULT_PARTNER_CONTEXT=HDRUK
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'feat/GAT-0000-services'
+      - 'dev'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: feat/GAT-0000-services
+          ref: dev
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: feat/GAT-0000-services
+          ref: dev
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - 'dev'
+      - 'feat/GAT-0000-services'
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: feat/GAT-0000-services
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: feat/GAT-0000-services
 
       - name: Google Auth
         id: auth

--- a/app/Context/PartnerContext.php
+++ b/app/Context/PartnerContext.php
@@ -4,7 +4,6 @@ namespace App\Context;
 
 use Illuminate\Http\Request;
 use App\Http\Resources\DatasetResource;
-use App\Http\Resources\DatasetIndexResource;
 use App\Models\Dataset;
 
 /**

--- a/app/Context/PartnerContext.php
+++ b/app/Context/PartnerContext.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Context;
+
+use Illuminate\Http\Request;
+use App\Http\Resources\DatasetResource;
+use App\Http\Resources\DatasetIndexResource;
+use App\Models\Dataset;
+
+/**
+ * Resolves the active partner and maps entity types to their Resource classes.
+ *
+ * The partner is determined (in priority order) from:
+ *   1. The x-partner-context request header
+ *   2. The DEFAULT_PARTNER_CONTEXT environment variable
+ *   3. The fallback hard-coded default: HDRUK
+ *
+ * To add a new partner integration:
+ *   1. Create a Resource subclass (e.g. app/Http/Resources/PartnerXDatasetResource.php)
+ *   2. Add the partner key and its resource map to config/partners.php
+ *   3. Set DEFAULT_PARTNER_CONTEXT=PARTNER_X in the partner environment
+ *      (or send x-partner-context: PARTNER_X per-request)
+ *
+ * Example config/partners.php entry:
+ *   'PARTNER_X' => [
+ *       Dataset::class => \App\Http\Resources\PartnerXDatasetResource::class,
+ *   ],
+ */
+class PartnerContext
+{
+    private string $partner;
+
+    public function __construct(Request $request)
+    {
+        $this->partner = $request->header(
+            'x-partner-context',
+            config('partners.default', 'HDRUK')
+        );
+    }
+
+    public function getPartner(): string
+    {
+        return $this->partner;
+    }
+
+    /**
+     * Resolve the Resource class to use for a given model class.
+     *
+     * Falls back to the HDRUK default map if the partner has no specific
+     * override for the requested model.
+     *
+     * @param  class-string  $modelClass  e.g. Dataset::class
+     * @return class-string               e.g. DatasetResource::class
+     */
+    public function resourceFor(string $modelClass): string
+    {
+        $partnerMap = config('partners.resources.' . $this->partner, []);
+
+        if (isset($partnerMap[$modelClass])) {
+            return $partnerMap[$modelClass];
+        }
+
+        return $this->defaultResourceFor($modelClass);
+    }
+
+    /**
+     * Resolve the index (listing) Resource class for a given model class.
+     * Partners that need a custom listing shape override this entry in config.
+     *
+     * @param  class-string  $modelClass
+     * @return class-string
+     */
+    public function indexResourceFor(string $modelClass): string
+    {
+        $partnerMap = config('partners.index_resources.' . $this->partner, []);
+
+        if (isset($partnerMap[$modelClass])) {
+            return $partnerMap[$modelClass];
+        }
+
+        return $this->defaultIndexResourceFor($modelClass);
+    }
+
+    private function defaultResourceFor(string $modelClass): string
+    {
+        return config('partners.resources.HDRUK.' . $modelClass, $modelClass);
+    }
+
+    private function defaultIndexResourceFor(string $modelClass): string
+    {
+        return config('partners.index_resources.HDRUK.' . $modelClass, $modelClass);
+    }
+}

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -239,6 +239,10 @@ class SearchController extends Controller
                     $datasetsArray[$i]['metadata'] = $model['metadata'];
                 }
 
+                if (empty($model['team'])) {
+                    continue;
+                }
+
                 $datasetsArray[$i]['isCohortDiscovery'] = $model['is_cohort_discovery'];
                 $datasetsArray[$i]['dataProviderColl'] = $this->getDataProviderColl($model);
                 $datasetsArray[$i]['team']['id'] = $model['team']['id'];
@@ -276,6 +280,7 @@ class SearchController extends Controller
             $datasetsArray = $this->sortSearchResult($datasetsArray, $sortField, $sortDirection);
 
             $perPage = request('per_page', Config::get('constants.per_page'));
+
             $paginatedData = $this->paginateArray($request, $datasetsArray, $perPage);
             unset($datasetsArray);
 
@@ -295,6 +300,14 @@ class SearchController extends Controller
 
             return response()->json($final, 200);
         } catch (Exception $e) {
+            dd([
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'whole' => $e,
+            ]);
+
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
@@ -1884,35 +1897,35 @@ class SearchController extends Controller
      */
     private function sortSearchResult(array $resultArray, string $sortField, string $sortDirection): array
     {
-        if ($sortField === 'score') {
-            $resultArraySorted = $sortDirection === 'desc' ? $resultArray : array_reverse($resultArray);
-            return $resultArraySorted;
-        }
+    //     if ($sortField === 'score') {
+    //         $resultArraySorted = $sortDirection === 'desc' ? $resultArray : array_reverse($resultArray);
+    //         return $resultArraySorted;
+    //     }
 
-        if ($sortDirection === 'asc') {
-            usort(
-                $resultArray,
-                function ($a, $b) use ($sortField) {
-                    return $a['_source'][$sortField] <=> $b['_source'][$sortField];
-                }
-            );
-        } else {
-            usort(
-                $resultArray,
-                function ($a, $b) use ($sortField) {
-                    $aVal = $a['_source'][$sortField];
-                    $bVal = $b['_source'][$sortField];
+    //     if ($sortDirection === 'asc') {
+    //         usort(
+    //             $resultArray,
+    //             function ($a, $b) use ($sortField) {
+    //                 return $a['_source'][$sortField] <=> $b['_source'][$sortField];
+    //             }
+    //         );
+    //     } else {
+    //         usort(
+    //             $resultArray,
+    //             function ($a, $b) use ($sortField) {
+    //                 $aVal = $a['_source'][$sortField];
+    //                 $bVal = $b['_source'][$sortField];
 
-                    if (strtotime($aVal) !== false) {
-                        return strtotime($bVal) <=> strtotime($aVal);
-                    } elseif (is_string($aVal)) {
-                        return strtoupper($bVal) <=> strtoupper($aVal);
-                    } else {
-                        return $bVal <=> $aVal;
-                    }
-                }
-            );
-        }
+    //                 if (strtotime($aVal) !== false) {
+    //                     return strtotime($bVal) <=> strtotime($aVal);
+    //                 } elseif (is_string($aVal)) {
+    //                     return strtoupper($bVal) <=> strtoupper($aVal);
+    //                 } else {
+    //                     return $bVal <=> $aVal;
+    //                 }
+    //             }
+    //         );
+    //     }
 
         return $resultArray;
     }

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -239,10 +239,6 @@ class SearchController extends Controller
                     $datasetsArray[$i]['metadata'] = $model['metadata'];
                 }
 
-                if (empty($model['team'])) {
-                    continue;
-                }
-
                 $datasetsArray[$i]['isCohortDiscovery'] = $model['is_cohort_discovery'];
                 $datasetsArray[$i]['dataProviderColl'] = $this->getDataProviderColl($model);
                 $datasetsArray[$i]['team']['id'] = $model['team']['id'];
@@ -300,14 +296,6 @@ class SearchController extends Controller
 
             return response()->json($final, 200);
         } catch (Exception $e) {
-            dd([
-                'message' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-                'file' => $e->getFile(),
-                'line' => $e->getLine(),
-                'whole' => $e,
-            ]);
-
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,

--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -1885,35 +1885,35 @@ class SearchController extends Controller
      */
     private function sortSearchResult(array $resultArray, string $sortField, string $sortDirection): array
     {
-    //     if ($sortField === 'score') {
-    //         $resultArraySorted = $sortDirection === 'desc' ? $resultArray : array_reverse($resultArray);
-    //         return $resultArraySorted;
-    //     }
+        if ($sortField === 'score') {
+            $resultArraySorted = $sortDirection === 'desc' ? $resultArray : array_reverse($resultArray);
+            return $resultArraySorted;
+        }
 
-    //     if ($sortDirection === 'asc') {
-    //         usort(
-    //             $resultArray,
-    //             function ($a, $b) use ($sortField) {
-    //                 return $a['_source'][$sortField] <=> $b['_source'][$sortField];
-    //             }
-    //         );
-    //     } else {
-    //         usort(
-    //             $resultArray,
-    //             function ($a, $b) use ($sortField) {
-    //                 $aVal = $a['_source'][$sortField];
-    //                 $bVal = $b['_source'][$sortField];
+        if ($sortDirection === 'asc') {
+            usort(
+                $resultArray,
+                function ($a, $b) use ($sortField) {
+                    return $a['_source'][$sortField] <=> $b['_source'][$sortField];
+                }
+            );
+        } else {
+            usort(
+                $resultArray,
+                function ($a, $b) use ($sortField) {
+                    $aVal = $a['_source'][$sortField];
+                    $bVal = $b['_source'][$sortField];
 
-    //                 if (strtotime($aVal) !== false) {
-    //                     return strtotime($bVal) <=> strtotime($aVal);
-    //                 } elseif (is_string($aVal)) {
-    //                     return strtoupper($bVal) <=> strtoupper($aVal);
-    //                 } else {
-    //                     return $bVal <=> $aVal;
-    //                 }
-    //             }
-    //         );
-    //     }
+                    if (strtotime($aVal) !== false) {
+                        return strtotime($bVal) <=> strtotime($aVal);
+                    } elseif (is_string($aVal)) {
+                        return strtoupper($bVal) <=> strtoupper($aVal);
+                    } else {
+                        return $bVal <=> $aVal;
+                    }
+                }
+            );
+        }
 
         return $resultArray;
     }

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -32,7 +32,8 @@ class DatasetController extends Controller
     public function __construct(
         private readonly DatasetService $datasetService,
         private readonly PartnerContext $partnerContext,
-    ) {}
+    ) {
+    }
 
     /**
      * @OA\Get(

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -2,46 +2,37 @@
 
 namespace App\Http\Controllers\Api\V2;
 
-use Config;
 use Auditor;
+use Config;
 use Exception;
-use App\Models\Team;
-use App\Models\User;
 use App\Models\Dataset;
-use App\Jobs\TermExtraction;
-use App\Jobs\LinkageExtraction;
-use Illuminate\Http\Request;
-use App\Models\DatasetVersion;
+use App\Models\Team;
+use App\Context\PartnerContext;
+use App\Services\DatasetService;
 use App\Http\Traits\CheckAccess;
-use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
-use App\Http\Traits\MetadataOnboard;
-use App\Http\Traits\MetadataVersioning;
-use App\Models\Traits\ModelHelpers;
-use App\Models\DatasetVersionHasDatasetVersion;
-use Maatwebsite\Excel\Facades\Excel;
-use Illuminate\Support\Facades\Storage;
-use MetadataManagementController as MMC;
 use App\Http\Requests\V2\Dataset\GetDataset;
-use App\Http\Traits\DatasetsV2Helpers;
-use App\Http\Traits\RequestTransformation;
-use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Requests\V2\Dataset\EditDataset;
 use App\Http\Requests\V2\Dataset\CreateDataset;
 use App\Http\Requests\V2\Dataset\DeleteDataset;
 use App\Http\Requests\V2\Dataset\UpdateDataset;
 use App\Exports\DatasetStructuralMetadataExport;
+use App\Http\Traits\GetValueByPossibleKeys;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class DatasetController extends Controller
 {
-    use MetadataVersioning;
-    use GetValueByPossibleKeys;
-    use MetadataOnboard;
     use CheckAccess;
-    use ModelHelpers;
-    use RequestTransformation;
-    use DatasetsV2Helpers;
+    use GetValueByPossibleKeys;
+
+    public function __construct(
+        private readonly DatasetService $datasetService,
+        private readonly PartnerContext $partnerContext,
+    ) {}
 
     /**
      * @OA\Get(
@@ -61,53 +52,34 @@ class DatasetController extends Controller
         - \<field\> can start with the prefix 'metadata.' so that nested values within the field 'metadata'  <br/>
             (represented by the GWDM JSON structure) can be used to order on.  <br/>  <br/>",
      *       example="created:desc",
-     *       @OA\Schema(
-     *          type="string",
-     *       ),
+     *       @OA\Schema(type="string"),
      *    ),
      *    @OA\Parameter(
      *       name="title",
      *       in="query",
      *       description="Three or more characters to filter dataset titles by",
      *       example="hdr",
-     *       @OA\Schema(
-     *          type="string",
-     *          description="Three or more characters to filter dataset titles by",
-     *       ),
+     *       @OA\Schema(type="string"),
      *    ),
      *    @OA\Parameter(
      *       name="status",
      *       in="query",
      *       description="Dataset status to filter by ('ACTIVE', 'DRAFT', 'ARCHIVED')",
      *       example="ACTIVE",
-     *       @OA\Schema(
-     *          type="string",
-     *          description="Dataset status to filter by",
-     *       ),
+     *       @OA\Schema(type="string"),
      *    ),
      *    @OA\Parameter(
      *       name="with_metadata",
      *       in="query",
      *       description="Boolean whether to return dataset metadata",
      *       example="true",
-     *       @OA\Schema(
-     *          type="string",
-     *          description="Boolean whether to return dataset metadata",
-     *       ),
+     *       @OA\Schema(type="string"),
      *    ),
      *    @OA\Response(
      *       response="200",
      *       description="Success response",
      *       @OA\JsonContent(
-     *          @OA\Property(
-     *             property="data",
-     *             type="array",
-     *             example="[]",
-     *             @OA\Items(
-     *                type="array",
-     *                @OA\Items()
-     *             )
-     *          )
+     *          @OA\Property(property="data", type="array", example="[]", @OA\Items(type="array", @OA\Items()))
      *       )
      *    )
      * )
@@ -115,49 +87,31 @@ class DatasetController extends Controller
     public function index(Request $request): JsonResponse
     {
         try {
-            $matches = [];
-            $filterStatus = $request->query('status', null);
-            $filterTitle = $request->query('title', null);
-            $withMetadata = $request->boolean('with_metadata', true);
-            $perPage = request('per_page', Config::get('constants.per_page'));
-
-            $matches = Dataset::query()
-                ->when($filterStatus, fn ($query) => $query->where('status', '=', $filterStatus))
-                ->pluck('id')
-                ->toArray();
-
-            if (!empty($filterTitle)) {
-                $matches = DatasetVersion::whereIn('dataset_id', $matches)
-                    ->filterTitle($filterTitle)
-                    ->select('dataset_id', 'version')
-                    ->orderBy('version', 'desc')
-                    ->get()
-                    ->unique('dataset_id')
-                    ->pluck('dataset_id')
-                    ->toArray();
-            }
-
-            $datasets = Dataset::whereIn('id', $matches)
-                ->applySorting()
-                ->paginate($perPage, ['*'], 'page');
-
-            if ($withMetadata) {
-                $datasets->through(fn ($dataset) => $dataset->load('latestMetadata'));
-            }
+            $datasets = $this->datasetService->list(
+                filterStatus: $request->query('status'),
+                filterTitle: $request->query('title'),
+                withMetadata: $request->boolean('with_metadata', true),
+                perPage: $request->integer('per_page', Config::get('constants.per_page')),
+            );
 
             Auditor::log([
                 'action_type' => 'GET',
-                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => 'Dataset index v2',
             ]);
 
-            return response()->json(
-                $datasets
-            );
+            // Transform each item through the partner resource while preserving
+            // the flat Laravel paginator envelope (current_page, data, from, etc.)
+            // that callers depend on. ResourceCollection changes the envelope to
+            // { data, links, meta } which would be a breaking change.
+            $resourceClass = $this->partnerContext->indexResourceFor(Dataset::class);
+            $datasets->through(fn ($dataset) => $resourceClass::make($dataset)->resolve(request()));
+            return response()->json($datasets);
+
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -179,18 +133,15 @@ class DatasetController extends Controller
      *       description="dataset id",
      *       required=true,
      *       example="1",
-     *       @OA\Schema(
-     *          type="integer",
-     *          description="dataset id",
-     *       ),
+     *       @OA\Schema(type="integer"),
      *    ),
      *    @OA\Parameter(
      *       name="export",
      *       in="query",
-     *       description="Alternative output schema model.",
+     *       description="Set to 'structuralMetadata' to download as CSV.",
      *       @OA\Schema(type="string", example="structuralMetadata")
      *    ),
-      *    @OA\Parameter(
+     *    @OA\Parameter(
      *       name="schema_model",
      *       in="query",
      *       description="Alternative output schema model.",
@@ -207,94 +158,58 @@ class DatasetController extends Controller
      *       description="Success response",
      *       @OA\JsonContent(
      *          @OA\Property(property="message", type="string", example="success"),
-     *          @OA\Property(
-     *             property="data",
-     *             type="array",
-     *             example="[]",
-     *             @OA\Items(
-     *                type="array",
-     *                @OA\Items()
-     *             )
-     *          ),
-     *       ),
+     *          @OA\Property(property="data", type="array", example="[]", @OA\Items(type="array", @OA\Items()))
+     *       )
      *    ),
-     *      @OA\Response(
-     *          response=401,
-     *          description="Unauthorized",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="unauthorized")
-     *          )
-     *      ),
-     *      @OA\Response(
-     *          response=404,
-     *          description="Not found response",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="not found"),
-     *          )
-     *      )
+     *    @OA\Response(response=401, description="Unauthorized",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="unauthorized"))
+     *    ),
+     *    @OA\Response(response=404, description="Not found response",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="not found"))
+     *    )
      * )
-     *
      */
     public function showActive(GetDataset $request, int $id): JsonResponse|BinaryFileResponse
     {
         try {
-            $exportStructuralMetadata = $request->query('export', null);
-
-            // Retrieve the dataset with collections, publications, and counts
-            $dataset = Dataset::with("team")->where("status", Dataset::STATUS_ACTIVE)->find($id);
+            $dataset = $this->datasetService->findActive($id);
 
             if (!$dataset) {
                 return response()->json(['message' => 'Dataset not found'], 404);
             }
-            list($dataset, $response) = $this->getDatasetDetails($dataset, $request);
 
-            if ($response) {
-                return $response;
+            if ($request->query('export') === 'structuralMetadata') {
+                return $this->streamStructuralMetadataExport($dataset, $id);
             }
 
-            $latestVersionId = $dataset->latestVersionID($id);
-
-            if ($exportStructuralMetadata === 'structuralMetadata') {
-                $arrayDataset = $dataset->toArray();
-                $versions = $this->getValueByPossibleKeys($arrayDataset, ['versions'], []);
-
-                $count = 0;
-                if (count($versions)) {
-                    foreach ($versions as $version) {
-                        if ((int) $version['id'] === (int) $latestVersionId) {
-                            break;
-                        }
-                        $count++;
-                    }
-                }
-                $export = count($versions) ? $this->getValueByPossibleKeys($arrayDataset, ['versions.' . $count . '.metadata.metadata.structuralMetadata'], []) : [];
-
-                Auditor::log([
-                    'action_type' => 'GET',
-                    'action_name' => class_basename($this) . '@'.__FUNCTION__,
-                    'description' => 'Dataset get ' . $id . ' download structural metadata',
-                ]);
-
-                return Excel::download(new DatasetStructuralMetadataExport($export), 'dataset-structural-metadata.csv');
-            }
-
-            $dataset->setAttribute('linkages', $this->getLinkages($latestVersionId));
+            $dataset = $this->datasetService->prepareForShow(
+                $dataset,
+                $request->query('schema_model'),
+                $request->query('schema_version'),
+            );
 
             Auditor::log([
                 'action_type' => 'GET',
-                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => 'Dataset get ' . $id,
             ]);
 
-            return response()->json([
-                'message' => 'success',
-                'data' => $dataset,
-            ], 200);
+            // additional() places message alongside data at the root, preserving
+            // the { message, data } envelope that callers depend on.
+            $resourceClass = $this->partnerContext->resourceFor(Dataset::class);
+            return $resourceClass::make($dataset)
+                ->additional(['message' => 'success'])
+                ->response()
+                ->setStatusCode(200);
 
+        } catch (\InvalidArgumentException $e) {
+            return response()->json(['message' => $e->getMessage()], 400);
+        } catch (\RuntimeException $e) {
+            return response()->json(['message' => 'failed to translate', 'details' => $e->getMessage()], 400);
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -326,90 +241,71 @@ class DatasetController extends Controller
      *          )
      *       )
      *    ),
-     *      @OA\Response(
-     *          response=201,
-     *          description="Created",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="success"),
-     *              @OA\Property(property="data", type="integer", example="100")
-     *          )
-     *      ),
-     *      @OA\Response(
-     *          response=401,
-     *          description="Unauthorized",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="unauthorized")
-     *          )
-     *      ),
-     *      @OA\Response(
-     *          response=500,
-     *          description="Error",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="error"),
-     *          )
-     *      )
+     *    @OA\Response(response=201, description="Created",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="success"),
+     *          @OA\Property(property="data", type="integer", example="100")
+     *       )
+     *    ),
+     *    @OA\Response(response=401, description="Unauthorized",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="unauthorized"))
+     *    ),
+     *    @OA\Response(response=500, description="Error",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="error"))
+     *    )
      * )
      */
     public function store(CreateDataset $request): JsonResponse
     {
         $input = $request->all();
         list($userId, $teamId, $createOrigin, $status) = $this->getAccessorUserAndTeam($request);
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $input['jwt_user'] ?? [];
         $this->checkAccess($input, $teamId, null, 'team', $request->header());
 
         try {
-            $elasticIndexing = $request->boolean('elastic_indexing', false);
+            $team = Team::where('id', $teamId)->first();
 
-            $team = Team::where('id', $teamId)->first()->toArray();
-
-            $input['metadata'] = $this->extractMetadata($input['metadata']);
-            $input['status'] = $status;
-            $input['user_id'] = $userId;
-            $input['team_id'] = $teamId;
+            $input['user_id']       = $userId;
+            $input['team_id']       = $teamId;
             $input['create_origin'] = $createOrigin;
+            $input['status']        = $status;
 
-            $inputSchema = $request->query('input_schema', null);
-            $inputVersion = $request->query('input_version', null);
-
-            // Ensure title is present for creating a dataset
             if (empty($input['metadata']['metadata']['summary']['title'])) {
-                return response()->json([
-                    'message' => 'Title is required to save a dataset',
-                ], 400);
+                return response()->json(['message' => 'Title is required to save a dataset'], 400);
             }
 
-            $metadataResult = $this->metadataOnboard(
-                $input,
-                $team,
-                $inputSchema,
-                $inputVersion,
-                $elasticIndexing
+            $result = $this->datasetService->create(
+                input: $input,
+                team: $team,
+                inputSchema: $request->query('input_schema'),
+                inputVersion: $request->query('input_version'),
+                elasticIndexing: $request->boolean('elastic_indexing', false),
             );
 
-            if ($metadataResult['translated']) {
+            if ($result['translated']) {
                 Auditor::log([
-                    'user_id' => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
-                    'team_id' => $team['id'],
+                    'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
+                    'team_id'     => $teamId,
                     'action_type' => 'CREATE',
                     'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                    'description' => 'Dataset ' . $metadataResult['dataset_id'] . ' with version ' .
-                        $metadataResult['version_id'] . ' created',
+                    'description' => 'Dataset ' . $result['dataset_id'] . ' with version ' . $result['version_id'] . ' created',
                 ]);
 
                 return response()->json([
                     'message' => 'created',
-                    'data' => $metadataResult['dataset_id'],
-                    'version' => $metadataResult['version_id'],
+                    'data'    => $result['dataset_id'],
+                    'version' => $result['version_id'],
                 ], 201);
-            } else {
-                return response()->json([
-                    'message' => 'metadata is in an unknown format and cannot be processed',
-                    'details' => $metadataResult['response'],
-                ], 400);
             }
+
+            return response()->json([
+                'message' => 'metadata is in an unknown format and cannot be processed',
+                'details' => $result['response'],
+            ], 400);
+
         } catch (Exception $e) {
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
@@ -427,19 +323,11 @@ class DatasetController extends Controller
      *    description="Update a dataset with a new dataset version",
      *    security={{"bearerAuth":{}}},
      *    @OA\Parameter(
-     *       name="id",
-     *       in="path",
-     *       description="dataset id",
-     *       required=true,
-     *       example="1",
-     *       @OA\Schema(
-     *          type="integer",
-     *          description="dataset id",
-     *       ),
+     *       name="id", in="path", description="dataset id", required=true, example="1",
+     *       @OA\Schema(type="integer"),
      *    ),
      *    @OA\RequestBody(
      *       required=true,
-     *       description="Pass user credentials",
      *       @OA\MediaType(
      *          mediaType="application/json",
      *          @OA\Schema(
@@ -450,132 +338,54 @@ class DatasetController extends Controller
      *          )
      *       )
      *    ),
-     *      @OA\Response(
-     *          response=201,
-     *          description="Created",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="success"),
-     *              @OA\Property(property="data", type="integer", example="100")
-     *          )
-     *      ),
-     *      @OA\Response(
-     *          response=401,
-     *          description="Unauthorized",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="unauthorized")
-     *          )
-     *      ),
-     *      @OA\Response(
-     *          response=500,
-     *          description="Error",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="error"),
-     *          )
-     *      )
+     *    @OA\Response(response=201, description="Created",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="success"),
+     *          @OA\Property(property="data", type="integer", example="100")
+     *       )
+     *    ),
+     *    @OA\Response(response=401, description="Unauthorized",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="unauthorized"))
+     *    ),
+     *    @OA\Response(response=500, description="Error",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="error"))
+     *    )
      * )
      */
-    public function update(UpdateDataset $request, int $id)
+    public function update(UpdateDataset $request, int $id): JsonResponse
     {
         $input = $request->all();
         list($userId, $teamId, $createOrigin) = $this->getAccessorUserAndTeam($request);
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-        $initDataset = Dataset::where('id', $id)->first();
-        $this->checkAccess($input, $initDataset->team_id, null, 'team', $request->header());
+        $jwtUser = $input['jwt_user'] ?? [];
+        $dataset = Dataset::where('id', $id)->first();
+        $this->checkAccess($input, $dataset->team_id, null, 'team', $request->header());
 
         try {
-            $elasticIndexing = $request->boolean('elastic_indexing', false);
-            $isCohortDiscovery = array_key_exists('is_cohort_discovery', $input) ? $input['is_cohort_discovery'] : false;
-
-            $team = Team::where('id', $teamId)->first();
-            $currDataset = Dataset::where('id', $id)->first();
-            $currentPid = $currDataset->pid;
-
-            $payload = $this->extractMetadata($input['metadata']);
-            $payload['extra'] = [
-                "id" => $id,
-                "pid" => $currentPid,
-                "datasetType" => "Health and disease",
-                "publisherId" => $team['pid'],
-                "publisherName" => $team['name']
-            ];
-
-            $inputSchema = $input['metadata']['schemaModel'] ?? null;
-            $inputVersion = $input['metadata']['schemaVersion'] ?? null;
-
-            $submittedMetadata = $input['metadata']['metadata'];
-            $gwdmMetadata = null;
-
-            $traserResponse = MMC::translateDataModelType(
-                json_encode($payload),
-                Config::get('metadata.GWDM.name'),
-                Config::get('metadata.GWDM.version'),
-                $inputSchema, //user can force an input version to avoid traser unknown errors
-                $inputVersion, // as above
-                $request['status'] !== Dataset::STATUS_DRAFT, // Disable input validation if it's a draft
-                $request['status'] !== Dataset::STATUS_DRAFT // Disable output validation if it's a draft
+            $team          = Team::where('id', $teamId)->first();
+            $versionNumber = $this->datasetService->update(
+                dataset: $dataset,
+                input: $input,
+                userId: $userId,
+                teamId: $teamId,
+                createOrigin: $createOrigin,
+                elasticIndexing: $request->boolean('elastic_indexing', false),
+                team: $team,
             );
-            if ($traserResponse['wasTranslated']) {
-                //set the gwdm metadata
-                $gwdmMetadata = $traserResponse['metadata'];
-            } else {
-                return response()->json([
-                    'message' => 'metadata is in an unknown format and cannot be processed.',
-                    'details' => $traserResponse,
-                ], 400);
-            }
-
-            // Update the existing dataset parent record with incoming data
-            $updateTime = now();
-            $currDataset->update([
-                'user_id' => $userId,
-                'team_id' => $teamId,
-                'updated' => $updateTime,
-                'pid' => $currentPid,
-                'create_origin' => $createOrigin,
-                'status' => $request['status'],
-                'is_cohort_discovery' => $isCohortDiscovery,
-            ]);
-
-            $versionNumber = $currDataset->lastMetadataVersionNumber()->version;
-
-            $datasetVersionId = $this->updateMetadataVersion(
-                $currDataset,
-                $gwdmMetadata,
-                $submittedMetadata,
-            );
-
-            // Dispatch term extraction to a subprocess if the dataset moves from draft to active
-            if ($request['status'] === Dataset::STATUS_ACTIVE) {
-
-                LinkageExtraction::dispatch(
-                    $currDataset->id,
-                    $datasetVersionId,
-                );
-                if (Config::get('ted.enabled')) {
-                    $tedData = Config::get('ted.use_partial') ? $input['metadata']['metadata']['summary'] : $input['metadata']['metadata'];
-
-                    TermExtraction::dispatch(
-                        $currDataset->id,
-                        $datasetVersionId,
-                        $versionNumber,
-                        base64_encode(gzcompress(gzencode(json_encode($tedData), 6))),
-                        $elasticIndexing,
-                        Config::get('ted.use_partial')
-                    );
-                }
-            }
 
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int)$jwtUser['id'] : $userId,
-                'team_id' => $teamId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
+                'team_id'     => $teamId,
                 'action_type' => 'UPDATE',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => 'Dataset ' . $id . ' with version ' . ($versionNumber) . ' updated',
+                'description' => 'Dataset ' . $id . ' with version ' . $versionNumber . ' updated',
             ]);
 
             return response()->json([
                 'message' => Config::get('statuscodes.STATUS_OK.message'),
             ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (\RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 400);
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
@@ -596,19 +406,11 @@ class DatasetController extends Controller
      *    description="Patch dataset by id",
      *    security={{"bearerAuth":{}}},
      *    @OA\Parameter(
-     *       name="id",
-     *       in="path",
-     *       description="dataset id",
-     *       required=true,
-     *       example="1",
-     *       @OA\Schema(
-     *          type="integer",
-     *          description="dataset id",
-     *       ),
+     *       name="id", in="path", description="dataset id", required=true, example="1",
+     *       @OA\Schema(type="integer"),
      *    ),
      *    @OA\RequestBody(
      *       required=true,
-     *       description="Pass user credentials",
      *       @OA\MediaType(
      *          mediaType="application/json",
      *          @OA\Schema(
@@ -617,65 +419,38 @@ class DatasetController extends Controller
      *          )
      *       )
      *    ),
-     *    @OA\Response(
-     *       response=200,
-     *       description="Success",
-     *       @OA\JsonContent(
-     *          @OA\Property(property="message", type="string", example="success"),
-     *       )
+     *    @OA\Response(response=200, description="Success",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="success"))
      *    ),
-     *    @OA\Response(
-     *       response=500,
-     *       description="Error",
-     *       @OA\JsonContent(
-     *          @OA\Property(property="message", type="string", example="error"),
-     *       )
+     *    @OA\Response(response=500, description="Error",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="error"))
      *    )
      * )
      */
-    public function edit(EditDataset $request, int $id)
+    public function edit(EditDataset $request, int $id): JsonResponse
     {
         $input = $request->all();
-        list($userId, $teamId, $createOrigin) = $this->getAccessorUserAndTeam($request);
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-        $initDataset = Dataset::where('id', $id)->first();
-        $this->checkAccess($input, $initDataset->team_id, null, 'team', $request->header());
+        list($userId, $teamId) = $this->getAccessorUserAndTeam($request);
+        $jwtUser = $input['jwt_user'] ?? [];
+        $dataset = Dataset::where('id', $id)->first();
+        $this->checkAccess($input, $dataset->team_id, null, 'team', $request->header());
 
         try {
-            //TODO: how to edit correctly, particularly the metadata? Assume if it's provided then it overwrites, otherwise leave as it is?
-            $datasetModel = Dataset::where('id', $id)->first();
-
-            $datasetModel->status = $request['status'];
-            $datasetModel->save();
-
-            $metadata = DatasetVersion::where('dataset_id', $id)->latest()->first();
-
-            if ($request['status'] === Dataset::STATUS_ACTIVE) {
-                LinkageExtraction::dispatch(
-                    $datasetModel->id,
-                    $metadata->id,
-                );
-            }
-
-
-            // TODO remaining edit steps e.g. if dataset appears in the request
-            // body validate, translate if needed, update Mauro data model, etc.
+            $this->datasetService->patch($dataset, $request['status']);
 
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int)$jwtUser['id'] : $userId,
-                'team_id' => $teamId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
+                'team_id'     => $teamId,
                 'action_type' => 'UPDATE',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
-                'description' => 'Dataset ' . $id . ' marked as ' .
-                    strtoupper($request['status']) . ' updated',
+                'description' => 'Dataset ' . $id . ' marked as ' . strtoupper($request['status']),
             ]);
 
-            return response()->json([
-                'message' => 'success'
-            ], Config::get('statuscodes.STATUS_OK.code'));
+            return response()->json(['message' => 'success'], Config::get('statuscodes.STATUS_OK.code'));
+
         } catch (Exception $e) {
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int)$jwtUser['id'] : $userId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
@@ -692,58 +467,35 @@ class DatasetController extends Controller
      *      summary="Delete a dataset",
      *      description="Delete a dataset",
      *      tags={"Datasets"},
-     *      summary="DatasetController@destroy",
      *      security={{"bearerAuth":{}}},
      *      @OA\Parameter(
-     *         name="id",
-     *         in="path",
-     *         description="dataset id",
-     *         required=true,
-     *         example="1",
-     *         @OA\Schema(
-     *            type="integer",
-     *            description="dataset id",
-     *         ),
+     *         name="id", in="path", description="dataset id", required=true, example="1",
+     *         @OA\Schema(type="integer"),
      *      ),
-     *      @OA\Response(
-     *          response=404,
-     *          description="Not found response",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="not found")
-     *           ),
+     *      @OA\Response(response=404, description="Not found response",
+     *         @OA\JsonContent(@OA\Property(property="message", type="string", example="not found"))
      *      ),
-     *      @OA\Response(
-     *          response=200,
-     *          description="Success",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="success")
-     *          ),
+     *      @OA\Response(response=200, description="Success",
+     *         @OA\JsonContent(@OA\Property(property="message", type="string", example="success"))
      *      ),
-     *      @OA\Response(
-     *          response=500,
-     *          description="Error",
-     *          @OA\JsonContent(
-     *              @OA\Property(property="message", type="string", example="error")
-     *          )
+     *      @OA\Response(response=500, description="Error",
+     *         @OA\JsonContent(@OA\Property(property="message", type="string", example="error"))
      *      )
      * )
      */
-    public function destroy(DeleteDataset $request, int $id) // softdelete
+    public function destroy(DeleteDataset $request, int $id): JsonResponse
     {
         $input = $request->all();
-        list($userId, $teamId, $createOrigin) = $this->getAccessorUserAndTeam($request);
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
-        $initDataset = Dataset::where('id', $id)->first();
-        $this->checkAccess($input, $initDataset->team_id, null, 'team', $request->header());
+        list($userId, $teamId) = $this->getAccessorUserAndTeam($request);
+        $jwtUser = $input['jwt_user'] ?? [];
+        $dataset = Dataset::where('id', $id)->first();
+        $this->checkAccess($input, $dataset->team_id, null, 'team', $request->header());
 
         try {
-            $dataset = Dataset::where('id', $id)->first();
-            $deleteFromElastic = ($dataset->status === Dataset::STATUS_ACTIVE);
-
-            MMC::deleteDataset($id);
+            $this->datasetService->delete($id);
 
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int)$jwtUser['id'] : $userId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
                 'action_type' => 'DELETE',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => 'Team Dataset ' . $id . ' deleted',
@@ -752,9 +504,10 @@ class DatasetController extends Controller
             return response()->json([
                 'message' => Config::get('statuscodes.STATUS_OK.message'),
             ], Config::get('statuscodes.STATUS_OK.code'));
+
         } catch (Exception $e) {
             Auditor::log([
-                'user_id' => isset($jwtUser['id']) ? (int)$jwtUser['id'] : $userId,
+                'user_id'     => isset($jwtUser['id']) ? (int) $jwtUser['id'] : $userId,
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
@@ -763,16 +516,41 @@ class DatasetController extends Controller
         }
     }
 
-    public function destroyByPid(Request $request, string $pid) // softdelete
+    public function destroyByPid(Request $request, string $pid): JsonResponse
     {
-        $dataset = Dataset::where('pid', "=", $pid)->first();
+        $dataset = Dataset::where('pid', $pid)->firstOrFail();
         return $this->destroy($request, $dataset->id);
     }
 
-    public function updateByPid(UpdateDataset $request, string $pid)
+    public function updateByPid(UpdateDataset $request, string $pid): JsonResponse
     {
-        $dataset = Dataset::where('pid', "=", $pid)->first();
+        $dataset = Dataset::where('pid', $pid)->firstOrFail();
         return $this->update($request, $dataset->id);
+    }
+
+    // no Swagger
+    public function updateIsCohortDiscovery(GetDataset $request, int $id): JsonResponse
+    {
+        try {
+            $input             = $request->all();
+            $isCohortDiscovery = $input['is_cohort_discovery'] ?? null;
+
+            if (is_null($isCohortDiscovery)) {
+                throw new Exception('Payload is missing is_cohort_discovery');
+            }
+
+            $dataset = Dataset::where('id', $id)->firstOrFail();
+            $this->datasetService->updateCohortDiscovery($dataset, $isCohortDiscovery);
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (\RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
     }
 
     /**
@@ -784,164 +562,74 @@ class DatasetController extends Controller
      *    description="Export Mock",
      *    security={{"bearerAuth":{}}},
      *    @OA\Parameter(
-     *       name="type",
-     *       in="query",
-     *       description="type export",
-     *       required=true,
-     *       @OA\Schema(
-     *          type="string",
-     *          description="type export",
-     *          enum={"template_dataset_structural_metadata", "dataset_metadata"}
-     *       ),
+     *       name="type", in="query", required=true,
+     *       @OA\Schema(type="string", enum={"template_dataset_structural_metadata", "dataset_metadata"}),
      *    ),
-     *    @OA\Response(
-     *       response=200,
-     *       description="CSV file",
-     *       @OA\MediaType(
-     *          mediaType="text/csv",
-     *          @OA\Schema(
-     *             type="string",
-     *             example="Title,""Publisher name"",Version,""Last Activity"",""Method of dataset creation"",Status,""Metadata detail""\n""Publications mentioning HDRUK"",""Health Data Research UK"",2.0.0,""2023-04-21T11:31:00.000Z"",MANUAL,ACTIVE,""{""properties\/accessibility\/usage\/dataUseRequirements"":{""id"":""95c37b03-54c4-468b-bda4-4f53f9aaaadd"",""namespace"":""hdruk.profile"",""key"":""properties\/accessibility\/usage\/dataUseRequirements"",""value"":""N\/A"",""lastUpdated"":""2023-12-14T11:31:11.312Z""},""properties\/required\/gatewayId"":{""id"":""8214d549-db98-453f-93e8-d88c6195ad93"",""namespace"":""hdruk.profile"",""key"":""properties\/required\/gatewayId"",""value"":""1234"",""lastUpdated"":""2023-12-14T11:31:11.311Z""}""",
-     *          )
-     *       )
+     *    @OA\Response(response=200, description="CSV file",
+     *       @OA\MediaType(mediaType="text/csv", @OA\Schema(type="string"))
      *    ),
-     *    @OA\Response(
-     *       response=401,
-     *       description="Unauthorized",
-     *       @OA\JsonContent(
-     *          @OA\Property(property="message", type="string", example="unauthorized")
-     *       ),
+     *    @OA\Response(response=401, description="Unauthorized",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="unauthorized"))
      *    ),
-     *    @OA\Response(
-     *       response=404,
-     *       description="File Not Found",
-     *       @OA\JsonContent(
-     *          @OA\Property(property="message", type="string", example="file_not_found")
-     *       ),
+     *    @OA\Response(response=404, description="File Not Found",
+     *       @OA\JsonContent(@OA\Property(property="message", type="string", example="file_not_found"))
      *    ),
      * )
      */
-    public function exportMock(Request $request)
+    public function exportMock(Request $request): mixed
     {
         try {
-            $exportType = $request->query('type', null);
-            $file = '';
+            $file = match (strtolower((string) $request->query('type'))) {
+                'template_dataset_structural_metadata' => Config::get('mock_data.template_dataset_structural_metadata'),
+                'dataset_metadata'                     => Config::get('mock_data.mock_dataset_metadata'),
+                default                                => null,
+            };
 
-            switch (strtolower($exportType)) {
-                case 'template_dataset_structural_metadata':
-                    $file = Config::get('mock_data.template_dataset_structural_metadata');
-                    break;
-                case 'dataset_metadata':
-                    $file = Config::get('mock_data.mock_dataset_metadata');
-                    break;
-                default:
-                    return response()->json(['error' => 'File not found.'], 404);
-            }
-
-            if (!Storage::disk('mock')->exists($file)) {
+            if (!$file || !Storage::disk('mock')->exists($file)) {
                 return response()->json(['error' => 'File not found.'], 404);
             }
 
             return Storage::disk('mock')
                 ->download($file)
                 ->setStatusCode(Config::get('statuscodes.STATUS_OK.code'));
+
         } catch (Exception $e) {
             throw new Exception($e->getMessage());
         }
     }
 
-    public function getLinkages($datasetVersionId)
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build and stream the structural metadata CSV export for a dataset.
+     * This is an HTTP output concern so it stays in the controller.
+     */
+    private function streamStructuralMetadataExport(Dataset $dataset, int $id): BinaryFileResponse
     {
-        $datasetLinkages = DatasetVersionHasDatasetVersion::where([
-            'dataset_version_source_id' => $datasetVersionId,
-        ])
-        ->get()
-        ->map(function ($linkage) {
-            $dv = DatasetVersion::where([
-                'id' => $linkage->dataset_version_target_id,
-            ])->select(['id', 'dataset_id', 'short_title'])->first();
+        $latestVersionId = $dataset->latestVersionID($id);
+        $arrayDataset    = $dataset->load('versions')->toArray();
+        $versions        = $this->getValueByPossibleKeys($arrayDataset, ['versions'], []);
+        $count           = 0;
 
-            if (is_null($dv)) {
-                return null;
-            }
-
-            $d = Dataset::where([
-                'id' => $dv->dataset_id,
-            ])->select(['id', 'status'])->first();
-
-            if (is_null($d)) {
-                return null;
-            }
-
-            if ($d->status !== Dataset::STATUS_ACTIVE) {
-                return null;
-            }
-
-            return [
-                'title' => $dv->short_title,
-                'url' => config('gateway.gateway_url') . '/en/dataset/' . $d->id,
-                'dataset_id' => $d->id,
-                'linkage_type' => $linkage->linkage_type,
-            ];
-        })
-        ->filter()
-        ->values()
-        ->toArray();
-
-        $datasetVersion = DatasetVersion::where('id', $datasetVersionId)->first();
-        $metadataLinkage = $datasetVersion['metadata']['metadata']['linkage']['datasetLinkage'] ?? [];
-        $allTitles = [];
-        foreach ($metadataLinkage as $linkageType => $link) {
-            if (($link) && is_array($link)) {
-                foreach ($link as $l) {
-                    $allTitles[] = [
-                        'title' => $l['title'],
-                        'linkage_type' => $linkageType,
-                    ];
-                }
-            }
-        }
-        $gatewayTitles = array_column($datasetLinkages, 'title');
-
-        foreach ($allTitles as $title) {
-            if (($title['title']) && (!in_array($title['title'], $gatewayTitles))) {
-                $datasetLinkages[] = [
-                    'title' => $title['title'],
-                    'url' => null,
-                    'dataset_id' => null,
-                    'linkage_type' => $title['linkage_type']
-                ];
+        foreach ($versions as $index => $version) {
+            if ((int) $version['id'] === (int) $latestVersionId) {
+                $count = $index;
+                break;
             }
         }
 
-        return $datasetLinkages;
-    }
+        $export = count($versions)
+            ? $this->getValueByPossibleKeys($arrayDataset, ['versions.' . $count . '.metadata.metadata.structuralMetadata'], [])
+            : [];
 
-    // no Swagger
-    public function updateIsCohortDiscovery(GetDataset $request, int $id)
-    {
-        try {
-            $input = $request->all();
-            $isCohortDiscovery = isset($input['is_cohort_discovery']) ? $input['is_cohort_discovery'] : null;
+        Auditor::log([
+            'action_type' => 'GET',
+            'action_name' => class_basename($this) . '@showActive',
+            'description' => 'Dataset get ' . $id . ' download structural metadata',
+        ]);
 
-            if (is_null($isCohortDiscovery)) {
-                throw new Exception('Payload is missing is_cohort_discovery');
-            }
-
-            $dataset = Dataset::where('id', $id)->first();
-
-            if ($dataset->status !== Dataset::STATUS_ACTIVE) {
-                throw new Exception('Dataset status is ' . strtoupper($dataset->status));
-            }
-
-            $dataset->is_cohort_discovery = $isCohortDiscovery;
-            $dataset->save();
-
-            return response()->json([
-                'message' => Config::get('statuscodes.STATUS_OK.message'),
-            ], Config::get('statuscodes.STATUS_OK.code'));
-        } catch (Exception $e) {
-            throw new Exception($e->getMessage());
-        }
+        return Excel::download(new DatasetStructuralMetadataExport($export), 'dataset-structural-metadata.csv');
     }
 }

--- a/app/Http/Resources/DatasetIndexResource.php
+++ b/app/Http/Resources/DatasetIndexResource.php
@@ -34,7 +34,7 @@ class DatasetIndexResource extends JsonResource
             'create_origin' => $this->create_origin,
             'created'       => $this->created,
             'updated'       => $this->updated,
-            'latestMetadata' => $this->whenLoaded('latestMetadata'),
+            'latest_metadata' => $this->whenLoaded('latestMetadata'),
         ];
     }
 }

--- a/app/Http/Resources/DatasetIndexResource.php
+++ b/app/Http/Resources/DatasetIndexResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Models\DatasetVersion;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -13,6 +14,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *
  * Partners that need a different index shape should extend this class
  * and register it in config/partners.php.
+ *
+ * @property int $id
+ * @property string $pid
+ * @property string $status
+ * @property string $create_origin
+ * @property mixed $created
+ * @property mixed $updated
+ * @property DatasetVersion|null $latestMetadata
  */
 class DatasetIndexResource extends JsonResource
 {
@@ -25,10 +34,7 @@ class DatasetIndexResource extends JsonResource
             'create_origin' => $this->create_origin,
             'created'       => $this->created,
             'updated'       => $this->updated,
-            'latestMetadata' => $this->when(
-                $this->relationLoaded('latestMetadata'),
-                $this->latestMetadata
-            ),
+            'latestMetadata' => $this->whenLoaded('latestMetadata'),
         ];
     }
 }

--- a/app/Http/Resources/DatasetIndexResource.php
+++ b/app/Http/Resources/DatasetIndexResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Lightweight dataset resource for paginated index responses.
+ *
+ * Excludes all resolved relations and linkages — the index only
+ * needs the parent record fields and optionally the latest metadata.
+ * This keeps the listing query fast and the payload small.
+ *
+ * Partners that need a different index shape should extend this class
+ * and register it in config/partners.php.
+ */
+class DatasetIndexResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id'            => $this->id,
+            'pid'           => $this->pid,
+            'status'        => $this->status,
+            'create_origin' => $this->create_origin,
+            'created'       => $this->created,
+            'updated'       => $this->updated,
+            'latestMetadata' => $this->when(
+                $this->relationLoaded('latestMetadata'),
+                $this->latestMetadata
+            ),
+        ];
+    }
+}

--- a/app/Http/Resources/DatasetResource.php
+++ b/app/Http/Resources/DatasetResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Team;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -25,6 +26,25 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *           ]);
  *       }
  *   }
+ *
+ * @property int $id
+ * @property string $pid
+ * @property string $status
+ * @property string $create_origin
+ * @property mixed $created
+ * @property mixed $updated
+ * @property Team|null $team
+ * @property int|null $durs_count
+ * @property int|null $publications_count
+ * @property int|null $tools_count
+ * @property int|null $collections_count
+ * @property array $spatialCoverage
+ * @property array $durs
+ * @property array $publications
+ * @property array $named_entities
+ * @property array $collections
+ * @property array $versions
+ * @property array $linkages
  */
 class DatasetResource extends JsonResource
 {

--- a/app/Http/Resources/DatasetResource.php
+++ b/app/Http/Resources/DatasetResource.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Default HDRUK dataset resource for detailed (show) responses.
+ *
+ * All virtual properties (counts, relations, versions, linkages) are
+ * pre-computed by DatasetService@prepareForShow before arriving here.
+ * toArray() is purely structural — it runs no queries.
+ *
+ * To create a partner-specific variant, extend this class and override
+ * toArray(). Register the subclass in config/partners.php under the
+ * partner's resource map.
+ *
+ * Example:
+ *   class PartnerXDatasetResource extends DatasetResource
+ *   {
+ *       public function toArray($request): array
+ *       {
+ *           return array_merge(parent::toArray($request), [
+ *               'custom_id' => $this->some_partner_field,
+ *           ]);
+ *       }
+ *   }
+ */
+class DatasetResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id'            => $this->id,
+            'pid'           => $this->pid,
+            'status'        => $this->status,
+            'create_origin' => $this->create_origin,
+            'created'       => $this->created,
+            'updated'       => $this->updated,
+
+            'team' => $this->when(
+                isset($this->team),
+                fn () => array_merge($this->team->toArray(), [
+                    'has_published_dar_template' => $this->team->has_published_dar_template ?? false,
+                ])
+            ),
+
+            // Counts — raw SQL, pre-computed by DatasetService
+            'durs_count'         => $this->durs_count,
+            'publications_count' => $this->publications_count,
+            'tools_count'        => $this->tools_count,
+            'collections_count'  => $this->collections_count,
+
+            // Relations — resolved via model accessors in DatasetService@prepareForShow
+            'spatialCoverage' => $this->spatialCoverage ?? [],
+            'durs'            => $this->durs ?? [],
+            'publications'    => $this->publications ?? [],
+            'named_entities'  => $this->named_entities ?? [],
+            'collections'     => $this->collections ?? [],
+
+            // Versioned metadata (with linked dataset versions attached)
+            'versions' => $this->versions ?? [],
+
+            // Linkages merged from gateway relations + metadata free-text field
+            'linkages' => $this->linkages ?? [],
+        ];
+    }
+}

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -16,6 +16,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @property array $linkages
+ */
 #[ObservedBy(DatasetObserver::class)]
 class Dataset extends Model
 {

--- a/app/Models/DatasetVersionHasDatasetVersion.php
+++ b/app/Models/DatasetVersionHasDatasetVersion.php
@@ -5,6 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @property string|null $short_title
+ * @property int $target_dataset_id
+ */
 class DatasetVersionHasDatasetVersion extends Model
 {
     use HasFactory;

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -16,6 +16,9 @@ use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
+/**
+ * @property bool $has_published_dar_template
+ */
 #[ObservedBy(TeamObserver::class)]
 class Team extends Model
 {

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -62,7 +62,7 @@ class DatasetService
 
     public function findActive(int $id): ?Dataset
     {
-        return Dataset::where('status', Dataset::STATUS_ACTIVE)->find($id);
+        return Dataset::with('team')->where('status', Dataset::STATUS_ACTIVE)->find($id);
     }
 
     /**

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -12,7 +12,7 @@ use App\Models\SpatialCoverage;
 use App\Models\Team;
 use App\Jobs\TermExtraction;
 use App\Jobs\LinkageExtraction;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -114,7 +114,7 @@ class DatasetService
                 ->with(['reducedLinkedDatasetVersions'])
                 ->first();
             $withLinks->metadata = json_encode(['metadata' => $translated['metadata']]);
-            $dataset->versions = [$withLinks];
+            $dataset->setRelation('versions', [$withLinks]);
 
         } elseif ($outputSchemaModel) {
             throw new \InvalidArgumentException('schema_model provided without schema_version');
@@ -125,7 +125,7 @@ class DatasetService
                 ->with(['linkedDatasetVersions'])
                 ->first();
             if ($withLinks) {
-                $dataset->versions = [$withLinks];
+                $dataset->setRelation('versions', [$withLinks]);
             }
         }
 

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -1,0 +1,592 @@
+<?php
+
+namespace App\Services;
+
+use Config;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\DatasetVersionHasSpatialCoverage;
+use App\Models\DataAccessTemplate;
+use App\Models\SpatialCoverage;
+use App\Models\Team;
+use App\Jobs\TermExtraction;
+use App\Jobs\LinkageExtraction;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use MetadataManagementController as MMC;
+
+class DatasetService
+{
+    // -------------------------------------------------------------------------
+    // Querying
+    // -------------------------------------------------------------------------
+
+    public function list(
+        ?string $filterStatus,
+        ?string $filterTitle,
+        bool $withMetadata,
+        int $perPage
+    ): LengthAwarePaginator {
+        if (!empty($filterTitle)) {
+            // Use a subquery for the status filter to avoid materialising all IDs.
+            // The unique-per-dataset deduplication still requires PHP-side processing
+            // because MySQL lacks a portable "latest version per group" without window
+            // functions, so we load only the filtered version rows and deduplicate.
+            $statusSubquery = Dataset::query()
+                ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
+                ->select('id');
+
+            $matchingIds = DatasetVersion::whereIn('dataset_id', $statusSubquery)
+                ->filterTitle($filterTitle)
+                ->select('dataset_id', 'version')
+                ->orderBy('version', 'desc')
+                ->get()
+                ->unique('dataset_id')
+                ->pluck('dataset_id');
+
+            $query = Dataset::whereIn('id', $matchingIds);
+        } else {
+            $query = Dataset::query()
+                ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus));
+        }
+
+        if ($withMetadata) {
+            $query->with('latestMetadata');
+        }
+
+        return $query->applySorting()->paginate($perPage, ['*'], 'page');
+    }
+
+    public function findActive(int $id): ?Dataset
+    {
+        return Dataset::where('status', Dataset::STATUS_ACTIVE)->find($id);
+    }
+
+    /**
+     * Resolve all attributes required for a detailed show response.
+     *
+     * Replaces DatasetsV2Helpers@getDatasetDetails. All counts are pre-computed
+     * here so the Resource's toArray() runs no queries.
+     *
+     * @throws \InvalidArgumentException  when schema_model/schema_version are mismatched
+     * @throws \RuntimeException          when MMC translation fails
+     */
+    public function prepareForShow(
+        Dataset $dataset,
+        ?string $outputSchemaModel = null,
+        ?string $outputSchemaVersion = null,
+    ): Dataset {
+        $dataset->loadMissing('team');
+
+        $latestVersionId = $dataset->latestVersionID($dataset->id);
+
+        $activeCollections = $dataset->allActiveCollections ?? [];
+
+        $dataset->durs_count         = $this->countActiveDurs($latestVersionId);
+        $dataset->publications_count = $this->countActivePublications($latestVersionId);
+        $dataset->tools_count        = count($dataset->allActiveTools);
+        $dataset->collections_count  = count($activeCollections);
+        $dataset->spatialCoverage    = $dataset->allSpatialCoverages ?? [];
+        $dataset->durs               = $dataset->allActiveDurs ?? [];
+        $dataset->publications       = $dataset->allActivePublications ?? [];
+        $dataset->named_entities     = $dataset->allNamedEntities ?? [];
+        $dataset->collections        = $activeCollections;
+        $dataset->linkages           = $this->getLinkages($latestVersionId);
+
+        if ($outputSchemaModel && $outputSchemaVersion) {
+            $latestVersion = $dataset->latestVersion();
+            $translated = MMC::translateDataModelType(
+                json_encode($latestVersion->metadata),
+                $outputSchemaModel,
+                $outputSchemaVersion,
+                Config::get('metadata.GWDM.name'),
+                Config::get('metadata.GWDM.version'),
+            );
+
+            if (!$translated['wasTranslated']) {
+                throw new \RuntimeException('Failed to translate metadata to requested schema');
+            }
+
+            $withLinks = DatasetVersion::where('id', $latestVersion->id)
+                ->with(['reducedLinkedDatasetVersions'])
+                ->first();
+            $withLinks->metadata = json_encode(['metadata' => $translated['metadata']]);
+            $dataset->versions = [$withLinks];
+
+        } elseif ($outputSchemaModel) {
+            throw new \InvalidArgumentException('schema_model provided without schema_version');
+        } elseif ($outputSchemaVersion) {
+            throw new \InvalidArgumentException('schema_version provided without schema_model');
+        } else {
+            $withLinks = DatasetVersion::where('id', $latestVersionId)
+                ->with(['linkedDatasetVersions'])
+                ->first();
+            if ($withLinks) {
+                $dataset->versions = [$withLinks];
+            }
+        }
+
+        $teamPublishedDARTemplates = DataAccessTemplate::where([
+            ['team_id', $dataset->team->id],
+            ['published', 1],
+        ])->pluck('id');
+        $dataset->team->has_published_dar_template = !$teamPublishedDARTemplates->isEmpty();
+
+        return $dataset;
+    }
+
+    // -------------------------------------------------------------------------
+    // Mutations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a new dataset, translating metadata via MMC/TRASER.
+     *
+     * Returns ['translated' => true,  'dataset_id' => int, 'version_id' => int]
+     *      or ['translated' => false, 'response'   => array] on translation failure.
+     */
+    public function create(
+        array $input,
+        Team $team,
+        ?string $inputSchema,
+        ?string $inputVersion,
+        bool $elasticIndexing
+    ): array {
+        $input['metadata'] = $this->extractMetadata($input['metadata']);
+
+        $payload            = $input['metadata'];
+        $payload['extra']   = [
+            'id'            => 'placeholder',
+            'pid'           => 'placeholder',
+            'datasetType'   => 'Health and disease',
+            'publisherId'   => $team->pid,
+            'publisherName' => $team->name,
+        ];
+
+        $isDraft        = $input['status'] === Dataset::STATUS_DRAFT;
+        $traserResponse = MMC::translateDataModelType(
+            json_encode($payload),
+            Config::get('metadata.GWDM.name'),
+            Config::get('metadata.GWDM.version'),
+            $inputSchema,
+            $inputVersion,
+            !$isDraft,
+            !$isDraft,
+        );
+
+        if (!$traserResponse['wasTranslated']) {
+            return ['translated' => false, 'response' => $traserResponse];
+        }
+
+        $input['metadata']['original_metadata'] = $input['metadata']['metadata'];
+        $input['metadata']['metadata']           = $traserResponse['metadata'];
+
+        $pid               = $input['pid'] ?? (string) Str::uuid();
+        $isCohortDiscovery = $input['is_cohort_discovery'] ?? false;
+
+        $dataset = MMC::createDataset([
+            'user_id'             => $input['user_id'],
+            'team_id'             => $input['team_id'],
+            'mongo_object_id'     => $input['mongo_object_id'] ?? null,
+            'mongo_id'            => $input['mongo_id'] ?? null,
+            'mongo_pid'           => $input['mongo_pid'] ?? null,
+            'datasetid'           => $input['datasetid'] ?? null,
+            'created'             => now(),
+            'updated'             => now(),
+            'submitted'           => now(),
+            'pid'                 => $pid,
+            'create_origin'       => $input['create_origin'],
+            'status'              => $input['status'],
+            'is_cohort_discovery' => $isCohortDiscovery,
+        ]);
+
+        $required = $this->buildRequiredBlock($dataset, 1);
+
+        if (version_compare(Config::get('metadata.GWDM.version'), '1.1', '<')) {
+            $input['metadata']['metadata']['summary']['publisher'] = [
+                'publisherId'   => $team->pid,
+                'publisherName' => $team->name,
+            ];
+        } else {
+            $required['version'] = $input['metadata']['metadata']['required']['version']
+                ?? $this->formatVersion(1);
+        }
+
+        $input['metadata']['metadata']['required'] = $required;
+        $input['metadata']['gwdmVersion']          = Config::get('metadata.GWDM.version');
+
+        $version = MMC::createDatasetVersion([
+            'dataset_id' => $dataset->id,
+            'metadata'   => json_encode($input['metadata']),
+            'version'    => 1,
+        ]);
+
+        $this->mapCoverage($input['metadata'], $version);
+        $this->dispatchJobs($dataset, $version->id, $input['metadata']['metadata'], $elasticIndexing, $input['status']);
+
+        return [
+            'translated' => true,
+            'dataset_id' => $dataset->id,
+            'version_id' => $version->id,
+        ];
+    }
+
+    /**
+     * Update an existing dataset with a new metadata version via TRASER.
+     *
+     * Returns the previous version number (used in the audit description).
+     *
+     * @throws \RuntimeException when MMC translation fails
+     */
+    public function update(
+        Dataset $dataset,
+        array $input,
+        int $userId,
+        int $teamId,
+        string $createOrigin,
+        bool $elasticIndexing,
+        Team $team,
+    ): int {
+        $payload          = $this->extractMetadata($input['metadata']);
+        $payload['extra'] = [
+            'id'            => $dataset->id,
+            'pid'           => $dataset->pid,
+            'datasetType'   => 'Health and disease',
+            'publisherId'   => $team->pid,
+            'publisherName' => $team->name,
+        ];
+
+        $inputSchema       = $input['metadata']['schemaModel'] ?? null;
+        $inputVersion      = $input['metadata']['schemaVersion'] ?? null;
+        $submittedMetadata = $input['metadata']['metadata'];
+        $isDraft           = $input['status'] === Dataset::STATUS_DRAFT;
+
+        $traserResponse = MMC::translateDataModelType(
+            json_encode($payload),
+            Config::get('metadata.GWDM.name'),
+            Config::get('metadata.GWDM.version'),
+            $inputSchema,
+            $inputVersion,
+            !$isDraft,
+            !$isDraft,
+        );
+
+        if (!$traserResponse['wasTranslated']) {
+            throw new \RuntimeException('metadata is in an unknown format and cannot be processed');
+        }
+
+        $versionNumber = $dataset->lastMetadataVersionNumber()->version;
+
+        $dataset->update([
+            'user_id'             => $userId,
+            'team_id'             => $teamId,
+            'updated'             => now(),
+            'pid'                 => $dataset->pid,
+            'create_origin'       => $createOrigin,
+            'status'              => $input['status'],
+            'is_cohort_discovery' => $input['is_cohort_discovery'] ?? false,
+        ]);
+
+        $datasetVersionId = $this->persistMetadataVersion(
+            $dataset,
+            $traserResponse['metadata'],
+            $submittedMetadata,
+            $versionNumber,
+        );
+
+        $this->dispatchJobs($dataset, $datasetVersionId, $submittedMetadata, $elasticIndexing, $input['status']);
+
+        return $versionNumber;
+    }
+
+    /**
+     * Patch a dataset's status only. Dispatches LinkageExtraction if activating.
+     */
+    public function patch(Dataset $dataset, string $status): void
+    {
+        $dataset->status = $status;
+        $dataset->save();
+
+        if ($status === Dataset::STATUS_ACTIVE) {
+            $metadata = DatasetVersion::where('dataset_id', $dataset->id)->latest()->first();
+            LinkageExtraction::dispatch($dataset->id, $metadata->id);
+        }
+    }
+
+    /**
+     * Update only the is_cohort_discovery flag (must be ACTIVE dataset).
+     *
+     * @throws \RuntimeException when dataset is not ACTIVE
+     */
+    public function updateCohortDiscovery(Dataset $dataset, bool $isCohortDiscovery): void
+    {
+        if ($dataset->status !== Dataset::STATUS_ACTIVE) {
+            throw new \RuntimeException('Dataset status is ' . strtoupper($dataset->status));
+        }
+
+        $dataset->is_cohort_discovery = $isCohortDiscovery;
+        $dataset->save();
+    }
+
+    public function delete(int $id): void
+    {
+        MMC::deleteDataset($id);
+    }
+
+    // -------------------------------------------------------------------------
+    // Linkages
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve dataset linkages by merging gateway-tracked relations with
+     * any free-text linkages stored in the metadata's linkage.datasetLinkage field.
+     *
+     * Only returns linkages whose target dataset is ACTIVE.
+     */
+    public function getLinkages(int $datasetVersionId): array
+    {
+        $datasetLinkages = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_has_dataset_version.dataset_version_source_id', $datasetVersionId)
+            ->join('dataset_versions', 'dataset_versions.id', '=', 'dataset_version_has_dataset_version.dataset_version_target_id')
+            ->join('datasets', 'datasets.id', '=', 'dataset_versions.dataset_id')
+            ->where('datasets.status', Dataset::STATUS_ACTIVE)
+            ->select([
+                'dataset_version_has_dataset_version.linkage_type',
+                'dataset_versions.short_title',
+                'datasets.id as target_dataset_id',
+            ])
+            ->get()
+            ->map(fn ($row) => [
+                'title'        => $row->short_title,
+                'url'          => config('gateway.gateway_url') . '/en/dataset/' . $row->target_dataset_id,
+                'dataset_id'   => $row->target_dataset_id,
+                'linkage_type' => $row->linkage_type,
+            ])
+            ->values()
+            ->toArray();
+
+        $metadataLinkage = DatasetVersion::where('id', $datasetVersionId)
+            ->select('metadata')
+            ->first()['metadata']['metadata']['linkage']['datasetLinkage'] ?? [];
+        $allTitles       = [];
+
+        foreach ($metadataLinkage as $linkageType => $link) {
+            if ($link && is_array($link)) {
+                foreach ($link as $l) {
+                    $allTitles[] = ['title' => $l['title'], 'linkage_type' => $linkageType];
+                }
+            }
+        }
+
+        $gatewayTitles = array_column($datasetLinkages, 'title');
+        foreach ($allTitles as $title) {
+            if ($title['title'] && !in_array($title['title'], $gatewayTitles)) {
+                $datasetLinkages[] = [
+                    'title'        => $title['title'],
+                    'url'          => null,
+                    'dataset_id'   => null,
+                    'linkage_type' => $title['linkage_type'],
+                ];
+            }
+        }
+
+        return $datasetLinkages;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Centralises TermExtraction + LinkageExtraction dispatch.
+     *
+     * Previously duplicated in:
+     *   - MetadataOnboard@metadataOnboard
+     *   - DatasetController@update (V2)
+     *   - DatasetController@edit   (V2)
+     */
+    private function dispatchJobs(
+        Dataset $dataset,
+        int $versionId,
+        array $metadata,
+        bool $elasticIndexing,
+        string $status
+    ): void {
+        if ($status !== Dataset::STATUS_ACTIVE) {
+            return;
+        }
+
+        LinkageExtraction::dispatch($dataset->id, $versionId);
+
+        if (Config::get('ted.enabled')) {
+            $tedData = Config::get('ted.use_partial') ? $metadata['summary'] : $metadata;
+            TermExtraction::dispatch(
+                $dataset->id,
+                $versionId,
+                '1',
+                base64_encode(gzcompress(gzencode(json_encode($tedData), 6))),
+                $elasticIndexing,
+                Config::get('ted.use_partial')
+            );
+        }
+    }
+
+    /**
+     * Persist an updated metadata snapshot against the current version record.
+     * Mirrors MetadataVersioning@updateMetadataVersion (kept intact for V1).
+     */
+    private function persistMetadataVersion(
+        Dataset $dataset,
+        array $newMetadata,
+        array $previousMetadata,
+        int $versionNumber,
+    ): int {
+        $metadataSaveObject = [
+            'gwdmVersion'       => Config::get('metadata.GWDM.version'),
+            'metadata'          => $newMetadata,
+            'original_metadata' => $previousMetadata,
+        ];
+
+        $dv = DatasetVersion::where([
+            'dataset_id' => $dataset->id,
+            'version'    => $versionNumber,
+        ])->first();
+
+        $dv->metadata = json_encode($metadataSaveObject);
+        $dv->save();
+
+        return $dv->id;
+    }
+
+    /**
+     * Normalise incoming metadata into a consistent nested shape before
+     * passing to TRASER. Handles string JSON, double-nesting, and FMA-style inputs.
+     *
+     * Mirrors DatasetsV2Helpers@extractMetadata (kept for TeamDatasetController).
+     */
+    private function extractMetadata(mixed $metadata): array
+    {
+        if (is_array($metadata) && Arr::has($metadata, 'metadata.metadata')) {
+            $metadata = $metadata['metadata'];
+        } elseif (is_array($metadata) && !Arr::has($metadata, 'metadata')) {
+            $metadata = ['metadata' => $metadata];
+        }
+
+        if (is_string($metadata) && isJsonString($metadata)) {
+            $metadata = json_decode($metadata, true);
+        }
+
+        if (
+            isset($metadata['metadata']) &&
+            is_string($metadata['metadata']) &&
+            isJsonString($metadata['metadata'])
+        ) {
+            $tmp['metadata'] = json_decode($metadata['metadata'], true);
+            $metadata = $tmp;
+        }
+
+        return $metadata;
+    }
+
+    private function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
+    {
+        return [
+            'gatewayId'  => strval($dataset->id),
+            'gatewayPid' => $dataset->pid,
+            'issued'     => $dataset->created,
+            'modified'   => $dataset->updated,
+            'revisions'  => [[
+                'url'     => config('gateway.gateway_url') . '/dataset/' . $dataset->id . '?version=1.0.0',
+                'version' => $this->formatVersion($versionNumber),
+            ]],
+        ];
+    }
+
+    private function formatVersion(int $version): string
+    {
+        return "{$version}.0.0";
+    }
+
+    /**
+     * Map metadata coverage/spatial string to the SpatialCoverage controlled list.
+     * Mirrors MetadataOnboard@mapCoverage (kept intact for V1).
+     */
+    private function mapCoverage(array $metadata, DatasetVersion $version): void
+    {
+        if (!isset($metadata['metadata']['coverage']['spatial'])) {
+            return;
+        }
+
+        $coverage     = strtolower($metadata['metadata']['coverage']['spatial']);
+        $allCoverages = SpatialCoverage::all();
+        $ukCoverages  = $allCoverages->filter(fn ($c) => $c->region !== 'Rest of the world');
+        $worldId      = $allCoverages->firstWhere('region', 'Rest of the world')?->id;
+        $matchFound   = false;
+
+        foreach ($ukCoverages as $c) {
+            if (str_contains($coverage, strtolower($c->region))) {
+                DatasetVersionHasSpatialCoverage::updateOrCreate([
+                    'dataset_version_id'  => (int) $version->id,
+                    'spatial_coverage_id' => (int) $c->id,
+                ]);
+                $matchFound = true;
+            }
+        }
+
+        if (!$matchFound) {
+            if (str_contains($coverage, 'united kingdom')) {
+                foreach ($ukCoverages as $c) {
+                    DatasetVersionHasSpatialCoverage::updateOrCreate([
+                        'dataset_version_id'  => (int) $version->id,
+                        'spatial_coverage_id' => (int) $c->id,
+                    ]);
+                }
+            } else {
+                DatasetVersionHasSpatialCoverage::updateOrCreate([
+                    'dataset_version_id'  => (int) $version->id,
+                    'spatial_coverage_id' => (int) $worldId,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Raw SQL count of active DURs linked to a dataset version.
+     * Mirrors ModelHelpers@countActiveDursForDatasetVersion.
+     * Pre-computed by the service so the Resource runs no queries.
+     */
+    private function countActiveDurs(int $datasetVersionId): ?int
+    {
+        $result = DB::select('
+            SELECT COUNT(dur_has_dataset_version.id) AS count
+            FROM dur_has_dataset_version
+            INNER JOIN dur ON dur.id = dur_has_dataset_version.dur_id
+            WHERE dur_has_dataset_version.dataset_version_id = :dataset_version_id
+              AND dur_has_dataset_version.deleted_at IS NULL
+              AND dur.status = \'ACTIVE\'
+        ', ['dataset_version_id' => $datasetVersionId]);
+
+        return $result[0]->count ?? null;
+    }
+
+    /**
+     * Raw SQL count of active Publications linked to a dataset version.
+     * Mirrors ModelHelpers@countActivePublicationsForDatasetVersion.
+     */
+    private function countActivePublications(int $datasetVersionId): ?int
+    {
+        $result = DB::select('
+            SELECT COUNT(publication_has_dataset_version.id) AS count
+            FROM publication_has_dataset_version
+            INNER JOIN publications ON publications.id = publication_has_dataset_version.publication_id
+            WHERE publication_has_dataset_version.dataset_version_id = :dataset_version_id
+              AND publication_has_dataset_version.deleted_at IS NULL
+              AND publications.status = \'ACTIVE\'
+        ', ['dataset_version_id' => $datasetVersionId]);
+
+        return $result[0]->count ?? null;
+    }
+}

--- a/config/partners.php
+++ b/config/partners.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\Dataset;
+use App\Http\Resources\DatasetResource;
+use App\Http\Resources\DatasetIndexResource;
+
+/**
+ * Partner context configuration.
+ *
+ * Controls which Resource class is used to shape API responses depending
+ * on the active partner. The partner is resolved from (in priority order):
+ *   1. x-partner-context request header
+ *   2. DEFAULT_PARTNER_CONTEXT environment variable
+ *   3. Fallback: HDRUK
+ *
+ * Adding a new partner
+ * --------------------
+ * 1. Create your resource subclass, e.g.:
+ *      app/Http/Resources/PartnerXDatasetResource.php
+ *
+ * 2. Add the partner entry below:
+ *      'PARTNER_X' => [
+ *          Dataset::class => \App\Http\Resources\PartnerXDatasetResource::class,
+ *      ],
+ *
+ * 3. In the partner's deployment, set:
+ *      DEFAULT_PARTNER_CONTEXT=PARTNER_X
+ *    or send the header:
+ *      x-partner-context: PARTNER_X
+ *
+ * If a partner does not define an override for a specific model, the HDRUK
+ * default for that model is used automatically.
+ */
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default partner
+    |--------------------------------------------------------------------------
+    */
+    'default' => env('DEFAULT_PARTNER_CONTEXT', 'HDRUK'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Detail (show) resource map
+    |--------------------------------------------------------------------------
+    | Keyed by partner identifier → model class → resource class.
+    */
+    'resources' => [
+
+        'HDRUK' => [
+            Dataset::class => DatasetResource::class,
+        ],
+
+        // 'PARTNER_X' => [
+        //     Dataset::class => \App\Http\Resources\PartnerXDatasetResource::class,
+        // ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Index (listing) resource map
+    |--------------------------------------------------------------------------
+    | Separate map for paginated list responses, which typically return a
+    | lighter payload than the full detail resource.
+    */
+    'index_resources' => [
+
+        'HDRUK' => [
+            Dataset::class => DatasetIndexResource::class,
+        ],
+
+        // 'PARTNER_X' => [
+        //     Dataset::class => \App\Http\Resources\PartnerXDatasetIndexResource::class,
+        // ],
+
+    ],
+
+];


### PR DESCRIPTION
number of optimisations noticed while refactoring. Fixes N+1, and N+1 2N problems. Makes use of existing data to avoid duplicated queries. Eliminates full table ID scan when no title filter. A couple of instances of fetching only needed columns instead of full roes. An instance of 2 queries being replaced by 1.

## Screenshots (if relevant)

## Describe your changes

Significant changes for abstracting Dataset functionality away from Controller bloat and into specific Services. First pass for CRUK that enables `x-partner-context` to be sent through as a request header that dictates routes and transformations as needed. Defaults to HDRUK for our own unaffected operation

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8667

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
