### PR TITLE
fix(GAT-8752): Add is_cohort_discovery field to DatasetResource

### DIFF
--- a/app/Http/Resources/DatasetResource.php
+++ b/app/Http/Resources/DatasetResource.php
@@ -33,6 +33,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  * @property string $create_origin
  * @property mixed $created
  * @property mixed $updated
+ * @property boolean $is_cohort_discovery
  * @property Team|null $team
  * @property int|null $durs_count
  * @property int|null $publications_count

--- a/app/Http/Resources/DatasetResource.php
+++ b/app/Http/Resources/DatasetResource.php
@@ -51,12 +51,13 @@ class DatasetResource extends JsonResource
     public function toArray($request): array
     {
         return [
-            'id'            => $this->id,
-            'pid'           => $this->pid,
-            'status'        => $this->status,
-            'create_origin' => $this->create_origin,
-            'created'       => $this->created,
-            'updated'       => $this->updated,
+            'id'                  => $this->id,
+            'pid'                 => $this->pid,
+            'status'              => $this->status,
+            'create_origin'       => $this->create_origin,
+            'created'             => $this->created,
+            'updated'             => $this->updated,
+            'is_cohort_discovery' => $this->is_cohort_discovery,
 
             'team' => $this->when(
                 isset($this->team),


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Adds missing `is_cohort_discovery` field to DatasetResource since this was missing

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8752

## Environment / Configuration changes (if applicable)

None

## Requires migrations being run?

No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
