### PR TITLE
fix(GAT-8785): Make elastic indexing calls async to avoid gmi falling…

### DIFF
--- a/app/Jobs/DeindexDataset.php
+++ b/app/Jobs/DeindexDataset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use App\Http\Traits\IndexElastic;
+
+class DeindexDataset implements ShouldQueue
+{
+    use Queueable;
+    use IndexElastic;
+
+    public function __construct(
+        private readonly string $datasetId,
+        private readonly ?int $teamId
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $this->deleteDatasetFromElastic($this->datasetId);
+
+        if ($this->teamId) {
+            $this->reindexElasticDataProviderWithRelations($this->teamId, 'dataset');
+        }
+    }
+}

--- a/app/Observers/DatasetObserver.php
+++ b/app/Observers/DatasetObserver.php
@@ -2,14 +2,13 @@
 
 namespace App\Observers;
 
+use App\Jobs\DeindexDataset;
+use App\Jobs\IndexDataset;
 use App\Models\Dataset;
-use App\Http\Traits\IndexElastic;
 use App\Models\DatasetVersion;
 
 class DatasetObserver
 {
-    use IndexElastic;
-
     /**
      * Handle the Dataset "created" event.
      */
@@ -24,10 +23,7 @@ class DatasetObserver
             'dataset_id' => $dataset->id
         ])->select('id')->first();
         if ($dataset->status === Dataset::STATUS_ACTIVE && !is_null($datasetVersion)) {
-            $this->reindexElastic($dataset->id);
-            if ($dataset->team_id) {
-                $this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');
-            }
+            IndexDataset::dispatch($dataset->id);
         }
     }
 
@@ -54,21 +50,12 @@ class DatasetObserver
             'dataset_id' => $dataset->id
         ])->select('id')->first();
 
-        // TODO - Stop this from being synchronous calls. These are blocking
-        // and should be handed off to job queues.
-        //
         if ($prevStatus === Dataset::STATUS_ACTIVE && $dataset->status !== Dataset::STATUS_ACTIVE) {
-            $this->deleteDatasetFromElastic($dataset->id);
-            if ($dataset->team_id) {
-                $this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');
-            }
+            DeindexDataset::dispatch($dataset->id, $dataset->team_id ? (int) $dataset->team_id : null);
         }
 
         if ($dataset->status === Dataset::STATUS_ACTIVE && !is_null($datasetVersion)) {
-            $this->reindexElastic($dataset->id);
-            if ($dataset->team_id) {
-                $this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');
-            }
+            IndexDataset::dispatch($dataset->id);
         }
     }
 
@@ -88,10 +75,7 @@ class DatasetObserver
         $prevStatus = $dataset->prevStatus;
 
         if ($prevStatus === Dataset::STATUS_ACTIVE) {
-            $this->deleteDatasetFromElastic($dataset->id);
-            if ($dataset->team_id) {
-                $this->reindexElasticDataProviderWithRelations((int) $dataset->team_id, 'dataset');
-            }
+            DeindexDataset::dispatch($dataset->id, $dataset->team_id ? (int) $dataset->team_id : null);
         }
     }
 

--- a/tests/Feature/Observers/DatasetObserverTest.php
+++ b/tests/Feature/Observers/DatasetObserverTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature\Observers;
 
-use Mockery;
-use Tests\TestCase;
+use App\Jobs\DeindexDataset;
+use App\Jobs\IndexDataset;
 use App\Models\Dataset;
-use App\Models\TeamHasUser;
 use App\Models\DatasetVersion;
+use App\Models\TeamHasUser;
 use App\Observers\DatasetObserver;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
 use Tests\Traits\MockExternalApis;
 
 class DatasetObserverTest extends TestCase
@@ -17,22 +19,46 @@ class DatasetObserverTest extends TestCase
     }
 
     protected $metadata;
-    protected $metadataAlt;
 
     public function setUp(): void
     {
         $this->commonSetUp();
-
         DatasetVersion::flushEventListeners();
-
         $this->metadata = $this->getMetadata();
-        $this->initialCountDatasets = Dataset::count();
     }
 
-    public function testDatasetObserverReindexesElasticOnCreatedEeventIfActiveAndHasVersion()
+    private function makeActiveDatasetWithVersion(): Dataset
     {
-        $observer = Mockery::mock(DatasetObserver::class)->makePartial();
-        $observer->shouldReceive('reindexElastic')->with($this->initialCountDatasets + 1);
+        $teamHasUser = TeamHasUser::all()->random();
+        $dataset = Dataset::create([
+            'user_id' => $teamHasUser->user_id,
+            'team_id' => $teamHasUser->team_id,
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+        DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'provider_team_id' => $dataset->team_id,
+            'version' => 1,
+            'metadata' => $this->metadata,
+        ]);
+        return $dataset;
+    }
+
+    public function testDatasetObserverDispatchesIndexDatasetOnCreatedEventIfActiveAndHasVersion(): void
+    {
+        Queue::fake();
+
+        $dataset = $this->makeActiveDatasetWithVersion();
+
+        (new DatasetObserver())->created($dataset);
+
+        Queue::assertPushed(IndexDataset::class, fn ($job) => true);
+    }
+
+    public function testDatasetObserverDoesNotDispatchIndexDatasetOnCreatedEventIfNoVersion(): void
+    {
+        Queue::fake();
 
         $teamHasUser = TeamHasUser::all()->random();
         $dataset = Dataset::create([
@@ -42,30 +68,13 @@ class DatasetObserverTest extends TestCase
             'status' => Dataset::STATUS_ACTIVE,
         ]);
 
-        DatasetVersion::create([
-            'dataset_id' => $dataset->id,
-            'provider_team_id' => $dataset->team_id,
-            'version' => 1,
-            'metadata' => $this->metadata,
-        ]);
+        (new DatasetObserver())->created($dataset);
 
-        $observer->created($dataset);
-
-        $this->assertDatabaseHas('datasets', [
-            'user_id' => $teamHasUser->user_id,
-            'team_id' => $teamHasUser->team_id,
-            'create_origin' => Dataset::ORIGIN_MANUAL,
-            'status' => Dataset::STATUS_ACTIVE,
-        ]);
-        $this->assertDatabaseHas('dataset_versions', ['dataset_id' => $this->initialCountDatasets + 1]);
-
+        Queue::assertNotPushed(IndexDataset::class);
     }
 
-    public function testDatasetObserverSetsPreviousStatusOnUpdatingEvent()
+    public function testDatasetObserverSetsPreviousStatusOnUpdatingEvent(): void
     {
-        $observer = Mockery::mock(DatasetObserver::class)->makePartial();
-        $observer->shouldReceive('reindexElastic')->with($this->initialCountDatasets + 1);
-
         $teamHasUser = TeamHasUser::all()->random();
         $dataset = Dataset::create([
             'user_id' => $teamHasUser->user_id,
@@ -75,80 +84,71 @@ class DatasetObserverTest extends TestCase
         ]);
 
         $dataset->status = Dataset::STATUS_ACTIVE;
-        $observer->updating($dataset);
+        (new DatasetObserver())->updating($dataset);
 
         $this->assertEquals(Dataset::STATUS_DRAFT, $dataset->prevStatus);
     }
 
-    public function testDatasetObserverReindexesOrDeletesFromElasticOnUpdatedEventBasedOnStatusChange()
+    public function testDatasetObserverDispatchesDeindexDatasetWhenDatasetBecomesInactive(): void
     {
-        $observer = Mockery::mock(DatasetObserver::class)->makePartial();
-        $observer->shouldReceive('reindexElastic')->with($this->initialCountDatasets + 1);
-        $observer->shouldReceive('deleteDatasetFromElastic')->once()->with($this->initialCountDatasets + 1);
+        Queue::fake();
 
-        $teamHasUser = TeamHasUser::all()->random();
-        $dataset = Dataset::create([
-            'user_id' => $teamHasUser->user_id,
-            'team_id' => $teamHasUser->team_id,
-            'create_origin' => Dataset::ORIGIN_MANUAL,
-            'status' => Dataset::STATUS_ACTIVE,
-        ]);
-
-        DatasetVersion::factory()->create(['dataset_id' => $dataset->id]);
-
+        $dataset = $this->makeActiveDatasetWithVersion();
         $dataset->prevStatus = Dataset::STATUS_ACTIVE;
         $dataset->status = Dataset::STATUS_ARCHIVED;
 
-        $observer->updated($dataset);
+        (new DatasetObserver())->updated($dataset);
 
-        $this->assertEquals(Dataset::STATUS_ARCHIVED, $dataset->status);
+        Queue::assertPushed(DeindexDataset::class);
+        Queue::assertNotPushed(IndexDataset::class);
     }
 
-    public function testDatasetObserverReindexesElasticOnDeletedEvent()
+    public function testDatasetObserverDispatchesIndexDatasetWhenActiveDatasetIsUpdated(): void
     {
-        $observer = Mockery::mock(DatasetObserver::class)->makePartial();
-        $observer->shouldReceive('reindexElastic')->with($this->initialCountDatasets + 1);
-        $observer->shouldReceive('deleteDatasetFromElastic')->once()->with($this->initialCountDatasets + 1);
+        Queue::fake();
+
+        $dataset = $this->makeActiveDatasetWithVersion();
+        $dataset->prevStatus = Dataset::STATUS_ACTIVE;
+
+        (new DatasetObserver())->updated($dataset);
+
+        Queue::assertPushed(IndexDataset::class);
+    }
+
+    public function testDatasetObserverDispatchesDeindexDatasetOnDeletedEventWhenPreviouslyActive(): void
+    {
+        Queue::fake();
+
+        $dataset = $this->makeActiveDatasetWithVersion();
+        $dataset->prevStatus = Dataset::STATUS_ACTIVE;
+        $dataset->delete();
+
+        $deleted = Dataset::withTrashed()->find($dataset->id);
+        $deleted->prevStatus = Dataset::STATUS_ACTIVE;
+
+        (new DatasetObserver())->deleted($deleted);
+
+        Queue::assertPushed(DeindexDataset::class);
+    }
+
+    public function testDatasetObserverDoesNotDispatchDeindexDatasetOnDeletedEventWhenNotPreviouslyActive(): void
+    {
+        Queue::fake();
 
         $teamHasUser = TeamHasUser::all()->random();
         $dataset = Dataset::create([
             'user_id' => $teamHasUser->user_id,
             'team_id' => $teamHasUser->team_id,
             'create_origin' => Dataset::ORIGIN_MANUAL,
-            'status' => Dataset::STATUS_ACTIVE,
+            'status' => Dataset::STATUS_DRAFT,
         ]);
+        $dataset->delete();
 
-        DatasetVersion::factory()->create(['dataset_id' => $this->initialCountDatasets + 1]);
+        $deleted = Dataset::withTrashed()->find($dataset->id);
+        $deleted->prevStatus = Dataset::STATUS_DRAFT;
 
-        DatasetVersion::factory()->create([
-            'dataset_id' => $dataset->id,
-            'provider_team_id' => $dataset->team_id,
-            'version' => 1,
-            'metadata' => $this->metadata,
-        ]);
+        (new DatasetObserver())->deleted($deleted);
 
-        $observer->created($dataset);
-
-        $this->assertDatabaseHas('datasets', [
-            'user_id' => $teamHasUser->user_id,
-            'team_id' => $teamHasUser->team_id,
-            'create_origin' => Dataset::ORIGIN_MANUAL,
-            'status' => Dataset::STATUS_ACTIVE,
-        ]);
-        $this->assertDatabaseHas('dataset_versions', ['dataset_id' => $this->initialCountDatasets + 1]);
-
-        Dataset::where('id', $this->initialCountDatasets + 1)->first()->delete();
-        $dataset = Dataset::where('id', $this->initialCountDatasets + 1)->withTrashed()->first();
-        $dataset->prevStatus = Dataset::STATUS_ACTIVE;
-
-        $observer->deleted($dataset);
-
-        $this->assertDatabaseHas('datasets', [
-            'user_id' => $teamHasUser->user_id,
-            'team_id' => $teamHasUser->team_id,
-            'create_origin' => Dataset::ORIGIN_MANUAL,
-            'status' => Dataset::STATUS_ACTIVE,
-        ]);
-        $this->assertSoftDeleted('datasets', ['id' => $this->initialCountDatasets + 1]);
+        Queue::assertNotPushed(DeindexDataset::class);
     }
 }


### PR DESCRIPTION
… out of its window

## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
