### PR TITLE
feat(GAT-8907): Add logging of the download data buttons on the dataset page to logs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -55,10 +55,29 @@ cmd_button(
     resource="gateway-api",
     argv=[
         "osascript", "-e",
-        'tell app "iTerm" to create window with default profile command "kubectl exec -it deploy/gateway-api -- bash"'
+        'tell application "iTerm2" to activate',
+        "-e",
+        'tell application "iTerm2"',
+        "-e",
+        'set newWindow to (create window with default profile)',
+        "-e",
+        'delay 2',
+        "-e",
+        'tell current session of newWindow',
+        "-e",
+        'write text "n"',
+        "-e",
+        'delay 1',
+        "-e",
+        'write text "kubectl exec -it deploy/gateway-api -- bash"',
+        "-e",
+        'end tell',
+        "-e",
+        'end tell',
     ],
     icon_name="terminal",
 )
+
 
 # Load in any locally set config
 cfg = read_json("tiltconf.json")

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1462,12 +1462,13 @@ class DatasetController extends Controller
     public function exportMetadata(ExportDataset $request, int $id): StreamedResponse
     {
         $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
         $download_type = strtolower($input['download_type']);
 
         $dataset = Dataset::where('id', '=', $id)->first();
 
         $result = $dataset->latestVersion()['metadata']['metadata'];
-        $originalMetadata = $dataset->latestVersion()['metadata']['original_metadata'];
+        // $originalMetadata = $dataset->latestVersion()['metadata']['original_metadata'];
 
         $response = new StreamedResponse(
             function () use ($result, $download_type) {
@@ -1635,6 +1636,13 @@ class DatasetController extends Controller
         }
         $response->headers->set('Content-Disposition', 'attachment;filename="' . $filename . '"');
         $response->headers->set('Cache-Control', 'max-age=0');
+
+        Auditor::log([
+            'team_id' => $dataset->team_id,
+            'action_type' => 'export',
+            'action_name' => class_basename($this) . '@' . __FUNCTION__,
+            'description' => 'Export dataset ' . $download_type . ' for dataset ' . $id,
+        ]);
 
         return $response;
     }

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1462,7 +1462,6 @@ class DatasetController extends Controller
     public function exportMetadata(ExportDataset $request, int $id): StreamedResponse
     {
         $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
         $download_type = strtolower($input['download_type']);
 
         $dataset = Dataset::where('id', '=', $id)->first();

--- a/app/Http/Controllers/Api/V1/DatasetController.php
+++ b/app/Http/Controllers/Api/V1/DatasetController.php
@@ -1467,7 +1467,6 @@ class DatasetController extends Controller
         $dataset = Dataset::where('id', '=', $id)->first();
 
         $result = $dataset->latestVersion()['metadata']['metadata'];
-        // $originalMetadata = $dataset->latestVersion()['metadata']['original_metadata'];
 
         $response = new StreamedResponse(
             function () use ($result, $download_type) {


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8907


## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
