### PR TITLE
feat(GAT-8924): Adds partner_context to dataset to ensure separation …

### DIFF
--- a/app/Context/PartnerContext.php
+++ b/app/Context/PartnerContext.php
@@ -2,7 +2,6 @@
 
 namespace App\Context;
 
-use Illuminate\Http\Request;
 use App\Http\Resources\DatasetResource;
 use App\Models\Dataset;
 
@@ -27,19 +26,12 @@ use App\Models\Dataset;
  */
 class PartnerContext
 {
-    private string $partner;
-
-    public function __construct(Request $request)
+    public function getPartner(): string
     {
-        $this->partner = $request->header(
+        return request()->header(
             'x-partner-context',
             config('partners.default', 'HDRUK')
         );
-    }
-
-    public function getPartner(): string
-    {
-        return $this->partner;
     }
 
     /**
@@ -53,7 +45,7 @@ class PartnerContext
      */
     public function resourceFor(string $modelClass): string
     {
-        $partnerMap = config('partners.resources.' . $this->partner, []);
+        $partnerMap = config('partners.resources.' . $this->getPartner(), []);
 
         if (isset($partnerMap[$modelClass])) {
             return $partnerMap[$modelClass];
@@ -71,7 +63,7 @@ class PartnerContext
      */
     public function indexResourceFor(string $modelClass): string
     {
-        $partnerMap = config('partners.index_resources.' . $this->partner, []);
+        $partnerMap = config('partners.index_resources.' . $this->getPartner(), []);
 
         if (isset($partnerMap[$modelClass])) {
             return $partnerMap[$modelClass];
@@ -82,11 +74,11 @@ class PartnerContext
 
     private function defaultResourceFor(string $modelClass): string
     {
-        return config('partners.resources.HDRUK.' . $modelClass, $modelClass);
+        return config('partners.resources.HDRUK', [])[$modelClass] ?? $modelClass;
     }
 
     private function defaultIndexResourceFor(string $modelClass): string
     {
-        return config('partners.index_resources.HDRUK.' . $modelClass, $modelClass);
+        return config('partners.index_resources.HDRUK', [])[$modelClass] ?? $modelClass;
     }
 }

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -93,6 +93,7 @@ class DatasetController extends Controller
                 filterTitle: $request->query('title'),
                 withMetadata: $request->boolean('with_metadata', true),
                 perPage: $request->integer('per_page', Config::get('constants.per_page')),
+                partnerContext: $this->partnerContext->getPartner(),
             );
 
             Auditor::log([
@@ -173,7 +174,7 @@ class DatasetController extends Controller
     public function showActive(GetDataset $request, int $id): JsonResponse|BinaryFileResponse
     {
         try {
-            $dataset = $this->datasetService->findActive($id);
+            $dataset = $this->datasetService->findActive($id, $this->partnerContext->getPartner());
 
             if (!$dataset) {
                 return response()->json(['message' => 'Dataset not found'], 404);
@@ -281,6 +282,7 @@ class DatasetController extends Controller
                 inputSchema: $request->query('input_schema'),
                 inputVersion: $request->query('input_version'),
                 elasticIndexing: $request->boolean('elastic_indexing', false),
+                partnerContext: $this->partnerContext->getPartner(),
             );
 
             if ($result['translated']) {

--- a/app/Http/Controllers/Api/V2/TeamDatasetController.php
+++ b/app/Http/Controllers/Api/V2/TeamDatasetController.php
@@ -27,6 +27,7 @@ use App\Http\Traits\GetValueByPossibleKeys;
 use App\Http\Requests\V2\Dataset\GetDataset;
 use App\Http\Requests\V2\Dataset\DeleteDataset;
 use App\Http\Requests\V2\Dataset\EditTeamDataset;
+use App\Context\PartnerContext;
 use App\Http\Requests\V2\Dataset\CreateTeamDataset;
 use App\Http\Requests\V2\Dataset\UpdateTeamDataset;
 use App\Exports\DatasetStructuralMetadataExport;
@@ -42,6 +43,10 @@ class TeamDatasetController extends Controller
     use RequestTransformation;
     use DatasetsV2Helpers;
     use TrimPayload;
+
+    public function __construct(private readonly PartnerContext $partnerContext)
+    {
+    }
 
     /**
      * @OA\Get(
@@ -501,7 +506,8 @@ class TeamDatasetController extends Controller
                 $team,
                 $inputSchema,
                 $inputVersion,
-                $elasticIndexing
+                $elasticIndexing,
+                $this->partnerContext->getPartner(),
             );
 
             if ($metadataResult['translated']) {

--- a/app/Http/Traits/MetadataOnboard.php
+++ b/app/Http/Traits/MetadataOnboard.php
@@ -25,7 +25,8 @@ trait MetadataOnboard
         array $team,
         string | null $inputSchema,
         string | null $inputVersion,
-        bool $elasticIndexing
+        bool $elasticIndexing,
+        string $partnerContext = 'HDRUK',
     ): array {
         $isCohortDiscovery = array_key_exists('is_cohort_discovery', $input) ?
             $input['is_cohort_discovery'] : false;
@@ -81,6 +82,7 @@ trait MetadataOnboard
                 'create_origin' => $input['create_origin'],
                 'status' => $input['status'],
                 'is_cohort_discovery' => $isCohortDiscovery,
+                'partner_context' => $partnerContext,
             ]);
 
             $publisher = null;

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -102,6 +102,7 @@ class Dataset extends Model
         'create_origin',
         'status',
         'is_cohort_discovery',
+        'partner_context',
     ];
 
     protected $casts = [

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -35,7 +35,8 @@ class DatasetService
         ?string $filterStatus,
         ?string $filterTitle,
         bool $withMetadata,
-        int $perPage
+        int $perPage,
+        ?string $partnerContext = null,
     ): LengthAwarePaginator {
         if (!empty($filterTitle)) {
             // Use a subquery for the status filter to avoid materialising all IDs.
@@ -44,6 +45,10 @@ class DatasetService
             // functions, so we load only the filtered version rows and deduplicate.
             $statusSubquery = Dataset::query()
                 ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
+                ->when(
+                    $partnerContext && $partnerContext !== 'HDRUK',
+                    fn ($q) => $q->where('partner_context', $partnerContext)
+                )
                 ->select('id');
 
             $matchingIds = DatasetVersion::whereIn('dataset_id', $statusSubquery)
@@ -57,7 +62,11 @@ class DatasetService
             $query = Dataset::whereIn('id', $matchingIds);
         } else {
             $query = Dataset::query()
-                ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus));
+                ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
+                ->when(
+                    $partnerContext && $partnerContext !== 'HDRUK',
+                    fn ($q) => $q->where('partner_context', $partnerContext)
+                );
         }
 
         if ($withMetadata) {
@@ -67,9 +76,15 @@ class DatasetService
         return $query->applySorting()->paginate($perPage, ['*'], 'page');
     }
 
-    public function findActive(int $id): ?Dataset
+    public function findActive(int $id, ?string $partnerContext = null): ?Dataset
     {
-        return Dataset::with('team')->where('status', Dataset::STATUS_ACTIVE)->find($id);
+        return Dataset::with('team')
+            ->where('status', Dataset::STATUS_ACTIVE)
+            ->when(
+                $partnerContext && $partnerContext !== 'HDRUK',
+                fn ($q) => $q->where('partner_context', $partnerContext)
+            )
+            ->find($id);
     }
 
     /**
@@ -222,7 +237,8 @@ class DatasetService
         Team $team,
         ?string $inputSchema,
         ?string $inputVersion,
-        bool $elasticIndexing
+        bool $elasticIndexing,
+        string $partnerContext = 'HDRUK',
     ): array {
         $input['metadata'] = $this->extractMetadata($input['metadata']);
 
@@ -270,6 +286,7 @@ class DatasetService
             'create_origin'       => $input['create_origin'],
             'status'              => $input['status'],
             'is_cohort_discovery' => $isCohortDiscovery,
+            'partner_context'     => $partnerContext,
         ]);
 
         $required = $this->buildRequiredBlock($dataset, 1);

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -46,7 +46,7 @@ class DatasetService
             $statusSubquery = Dataset::query()
                 ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
                 ->when(
-                    $partnerContext && $partnerContext !== 'HDRUK',
+                    $partnerContext && ($partnerContext !== 'HDRUK' || !config('partners.allow_cross_context_read', true)),
                     fn ($q) => $q->where('partner_context', $partnerContext)
                 )
                 ->select('id');
@@ -64,7 +64,7 @@ class DatasetService
             $query = Dataset::query()
                 ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
                 ->when(
-                    $partnerContext && $partnerContext !== 'HDRUK',
+                    $partnerContext && ($partnerContext !== 'HDRUK' || !config('partners.allow_cross_context_read', true)),
                     fn ($q) => $q->where('partner_context', $partnerContext)
                 );
         }

--- a/config/partners.php
+++ b/config/partners.php
@@ -42,6 +42,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cross-context read (HDRUK portal safeguard)
+    |--------------------------------------------------------------------------
+    | When true (default), the HDRUK operator context sees datasets from ALL
+    | partners. Set to false to restrict HDRUK to its own datasets — useful
+    | while partner schemas are in development and risk breaking the portal.
+    */
+    'allow_cross_context_read' => env('HDRUK_CROSS_CONTEXT_READ', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Detail (show) resource map
     |--------------------------------------------------------------------------
     | Keyed by partner identifier → model class → resource class.

--- a/database/migrations/2026_05_20_000001_add_partner_context_to_datasets_table.php
+++ b/database/migrations/2026_05_20_000001_add_partner_context_to_datasets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->string('partner_context')->default('HDRUK')->after('is_cohort_discovery');
+        });
+
+        DB::table('datasets')->update(['partner_context' => 'HDRUK']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->dropColumn('partner_context');
+        });
+    }
+};

--- a/tests/Feature/V2/PartnerContextTest.php
+++ b/tests/Feature/V2/PartnerContextTest.php
@@ -253,6 +253,29 @@ class PartnerContextTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Feature flag — allow_cross_context_read
+    // -------------------------------------------------------------------------
+
+    public function test_hdruk_context_index_excludes_other_partner_datasets_when_cross_context_read_disabled(): void
+    {
+        config(['partners.allow_cross_context_read' => false]);
+
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $initialHdrukCount = Dataset::where('partner_context', 'HDRUK')->count();
+
+        $this->createDataset($teamId, $userId, 'HDRUK');
+        $this->createDataset($teamId, $userId, 'CRUK');
+
+        $response = $this->json('GET', self::DATASETS_URL, [], $this->header);
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        // Flag off → HDRUK sees only its own datasets
+        $this->assertCount($initialHdrukCount + 1, $response->json('data'));
+
+        config(['partners.allow_cross_context_read' => true]);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/tests/Feature/V2/PartnerContextTest.php
+++ b/tests/Feature/V2/PartnerContextTest.php
@@ -1,0 +1,359 @@
+<?php
+
+namespace Tests\Feature\V2;
+
+use Config;
+use Tests\TestCase;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Http\Enums\TeamMemberOf;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Tests for partner_context isolation (GAT-8924).
+ *
+ * Two creation paths are covered:
+ *   - POST /api/v2/datasets           (DatasetController via DatasetService)
+ *   - POST /api/v2/teams/{id}/datasets (TeamDatasetController via MetadataOnboard trait)
+ *
+ * Read isolation assertions:
+ *   - HDRUK (default, no header) sees ALL datasets regardless of partner_context.
+ *   - CRUK (x-partner-context: CRUK) only sees datasets where partner_context = 'CRUK'.
+ *   - CRUK receives 404 when requesting a dataset owned by another partner.
+ */
+class PartnerContextTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const DATASETS_URL      = '/api/v2/datasets';
+    public const TEAMS_URL         = '/api/v1/teams';
+    public const NOTIFICATIONS_URL = '/api/v1/notifications';
+    public const USERS_URL         = '/api/v1/users';
+
+    protected array $metadata;
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        Dataset::flushEventListeners();
+        DatasetVersion::flushEventListeners();
+
+        $this->metadata = $this->getMetadata();
+    }
+
+    // -------------------------------------------------------------------------
+    // Write path — partner_context is stamped at creation
+    // -------------------------------------------------------------------------
+
+    public function test_v2_endpoint_stamps_cruk_partner_context_when_header_present(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+
+        $response = $this->json(
+            'POST',
+            self::DATASETS_URL,
+            [
+                'team_id'       => $teamId,
+                'user_id'       => $userId,
+                'metadata'      => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status'        => Dataset::STATUS_ACTIVE,
+            ],
+            array_merge($this->header, ['x-partner-context' => 'CRUK']),
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $datasetId = $response->json('data');
+
+        $this->assertSame('CRUK', Dataset::find($datasetId)->partner_context);
+    }
+
+    public function test_v2_endpoint_defaults_to_hdruk_partner_context_when_no_header(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+
+        $response = $this->json(
+            'POST',
+            self::DATASETS_URL,
+            [
+                'team_id'       => $teamId,
+                'user_id'       => $userId,
+                'metadata'      => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status'        => Dataset::STATUS_ACTIVE,
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $datasetId = $response->json('data');
+
+        $this->assertSame('HDRUK', Dataset::find($datasetId)->partner_context);
+    }
+
+    public function test_team_endpoint_stamps_cruk_partner_context_when_header_present(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+
+        $response = $this->json(
+            'POST',
+            $this->teamDatasetsUrl($teamId),
+            [
+                'user_id'       => $userId,
+                'metadata'      => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status'        => Dataset::STATUS_ACTIVE,
+            ],
+            array_merge($this->header, ['x-partner-context' => 'CRUK']),
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $datasetId = $response->json('data');
+
+        $this->assertSame('CRUK', Dataset::find($datasetId)->partner_context);
+    }
+
+    public function test_team_endpoint_defaults_to_hdruk_partner_context_when_no_header(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+
+        $response = $this->json(
+            'POST',
+            $this->teamDatasetsUrl($teamId),
+            [
+                'user_id'       => $userId,
+                'metadata'      => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status'        => Dataset::STATUS_ACTIVE,
+            ],
+            $this->header,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+        $datasetId = $response->json('data');
+
+        $this->assertSame('HDRUK', Dataset::find($datasetId)->partner_context);
+    }
+
+    // -------------------------------------------------------------------------
+    // Read path — listing isolation
+    // -------------------------------------------------------------------------
+
+    public function test_hdruk_context_index_returns_all_datasets(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $initialCount = Dataset::count();
+
+        $this->createDataset($teamId, $userId);
+        $this->createDataset($teamId, $userId, 'CRUK');
+
+        // No x-partner-context header → HDRUK context → sees both
+        $response = $this->json('GET', self::DATASETS_URL, [], $this->header);
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $this->assertCount($initialCount + 2, $response->json('data'));
+    }
+
+    public function test_cruk_context_index_returns_only_cruk_datasets(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $initialCrukCount = Dataset::where('partner_context', 'CRUK')->count();
+
+        $crukHeaders = array_merge($this->header, ['x-partner-context' => 'CRUK']);
+
+        // Create one HDRUK dataset (no partner context header)
+        $this->json('POST', self::DATASETS_URL, [
+            'team_id' => $teamId, 'user_id' => $userId,
+            'metadata' => $this->metadata,
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ], $this->header)->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        // Create two CRUK datasets using explicit inline headers
+        $crukId1 = $this->json('POST', self::DATASETS_URL, [
+            'team_id' => $teamId, 'user_id' => $userId,
+            'metadata' => $this->metadata,
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ], $crukHeaders)->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))->json('data');
+
+        $crukId2 = $this->json('POST', self::DATASETS_URL, [
+            'team_id' => $teamId, 'user_id' => $userId,
+            'metadata' => $this->metadata,
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ], $crukHeaders)->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))->json('data');
+
+        // Verify DB state
+        $this->assertSame('CRUK', Dataset::find($crukId1)->partner_context, 'crukId1');
+        $this->assertSame('CRUK', Dataset::find($crukId2)->partner_context, 'crukId2');
+        $this->assertSame(
+            $initialCrukCount + 2,
+            Dataset::where('partner_context', 'CRUK')->count()
+        );
+
+        $response = $this->json('GET', self::DATASETS_URL . '?with_metadata=0', [], $crukHeaders);
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        // CRUK context sees only its own 2 datasets
+        $this->assertCount($initialCrukCount + 2, $response->json('data'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Read path — single-dataset show isolation
+    // -------------------------------------------------------------------------
+
+    public function test_hdruk_context_can_show_cruk_dataset(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $crukDatasetId = $this->createDataset($teamId, $userId, 'CRUK');
+
+        // HDRUK (no header) should see the CRUK dataset
+        $response = $this->json(
+            'GET',
+            self::DATASETS_URL . '/' . $crukDatasetId,
+            [],
+            $this->header,
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+    }
+
+    public function test_cruk_context_receives_404_for_hdruk_dataset(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $hdrukDatasetId = $this->createDataset($teamId, $userId, 'HDRUK');
+
+        $response = $this->json(
+            'GET',
+            self::DATASETS_URL . '/' . $hdrukDatasetId,
+            [],
+            array_merge($this->header, ['x-partner-context' => 'CRUK']),
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+        $response->assertJson(['message' => 'Dataset not found']);
+    }
+
+    public function test_cruk_context_can_show_its_own_dataset(): void
+    {
+        [$teamId, $userId] = $this->createTeamAndUser();
+        $crukDatasetId = $this->createDataset($teamId, $userId, 'CRUK');
+
+        $response = $this->json(
+            'GET',
+            self::DATASETS_URL . '/' . $crukDatasetId,
+            [],
+            array_merge($this->header, ['x-partner-context' => 'CRUK']),
+        );
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Create a dataset via the v2 endpoint and return its ID.
+     * Partner context is applied via the x-partner-context header.
+     */
+    private function createDataset(
+        int $teamId,
+        int $userId,
+        string $partnerContext = 'HDRUK',
+    ): int {
+        $headers = $partnerContext !== 'HDRUK'
+            ? array_merge($this->header, ['x-partner-context' => $partnerContext])
+            : $this->header;
+
+        $response = $this->json(
+            'POST',
+            self::DATASETS_URL,
+            [
+                'team_id'       => $teamId,
+                'user_id'       => $userId,
+                'metadata'      => $this->metadata,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+                'status'        => Dataset::STATUS_ACTIVE,
+            ],
+            $headers,
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        return $response->json('data');
+    }
+
+    /**
+     * Create a team and user, returning [$teamId, $userId].
+     */
+    private function createTeamAndUser(): array
+    {
+        $notificationId = $this->json(
+            'POST',
+            self::NOTIFICATIONS_URL,
+            [
+                'notification_type' => 'applicationSubmitted',
+                'message'           => 'Test',
+                'email'             => null,
+                'user_id'           => 3,
+                'opt_in'            => 1,
+                'enabled'           => 1,
+            ],
+            $this->header,
+        )->json('data');
+
+        $teamId = $this->json(
+            'POST',
+            self::TEAMS_URL,
+            [
+                'name'                          => 'Partner Context Test Team ' . uniqid(),
+                'enabled'                       => 1,
+                'allows_messaging'              => 1,
+                'workflow_enabled'              => 1,
+                'access_requests_management'    => 1,
+                'uses_5_safes'                  => 1,
+                'is_admin'                      => 1,
+                'member_of'                     => TeamMemberOf::OTHER,
+                'contact_point'                 => 'test@example.com',
+                'application_form_updated_by'   => 'Test',
+                'application_form_updated_on'   => '2023-04-06 15:44:41',
+                'notifications'                 => [$notificationId],
+                'users'                         => [],
+            ],
+            $this->header,
+        )->json('data');
+
+        $userId = $this->json(
+            'POST',
+            self::USERS_URL,
+            [
+                'firstname'        => 'Test',
+                'lastname'         => 'User',
+                'email'            => 'test.partner.context.' . uniqid() . '@example.com',
+                'password'         => 'Passw@rd1!',
+                'sector_id'        => 1,
+                'organisation'     => 'Test Org',
+                'bio'              => 'Bio',
+                'domain'           => 'https://example.com',
+                'link'             => 'https://example.com/link',
+                'orcid'            => 'https://orcid.org/00000000',
+                'contact_feedback' => 1,
+                'contact_news'     => 1,
+                'mongo_id'         => random_int(100000, 999999),
+                'mongo_object_id'  => uniqid(),
+            ],
+            $this->header,
+        )->json('data');
+
+        return [$teamId, $userId];
+    }
+
+    private function teamDatasetsUrl(int $teamId): string
+    {
+        return 'api/v2/teams/' . $teamId . '/datasets';
+    }
+}


### PR DESCRIPTION
…of concerns from HDRUK and CRUK datasets

> AI disclaimer - CLAUDE (Sonnet 4.6) was used for generating additional unit tests to prove solution paths.

## Screenshots (if relevant)

## Describe your changes
Implements a context flag against `datasets` table, denoting the partner onboarding/owning the dataset metadata.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8924

## Environment / Configuration changes (if applicable)
N/A

## Requires migrations being run?
Yes

## If not using the pre-push hook. Confirm tests pass:

```
  Tests:    1 skipped, 821 passed (9374 assertions)
  Duration: 143.37s
  Parallel: 11 processes
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
