### PR TITLE
feat(GAT-8978): brings search aggregator more inline with production than PoC.

### DIFF
--- a/app/Contracts/SearchProvider.php
+++ b/app/Contracts/SearchProvider.php
@@ -8,6 +8,11 @@ interface SearchProvider
     public function getShortName(): string;
     public function getProviderLogo(): string|null;
     public function getProviderBlurb(): string|null;
-    public function getSearchURI(): string;
-    public function search(string $query): array;
+    public function getSearchURI(string $type): string;
+    public function getSupportedTypes(): array;
+
+    /**
+     * @return array{hits: array, total: int, aggregations: array, ids: array}
+     */
+    public function search(string $query, string $type, array $params = []): array;
 }

--- a/app/Http/Controllers/Api/V2/SearchController.php
+++ b/app/Http/Controllers/Api/V2/SearchController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers\Api\V2;
 
 use Config;
-use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Search\Search;
 use App\Services\SearchAggregator;
 use Laravel\Pennant\Feature;
 
@@ -12,10 +13,9 @@ class SearchController extends Controller
 {
     public function __construct(protected SearchAggregator $aggregator)
     {
-        // Nothing, just need the DI.
     }
 
-    public function search(Request $request)
+    public function search(Search $request): JsonResponse
     {
         if (!Feature::active('V2/Search/Aggregation')) {
             return response()->json([
@@ -23,9 +23,22 @@ class SearchController extends Controller
             ], Config::get('statuscodes.STATUS_NOT_FOUND.code'));
         }
 
-        $input = $request->all();
-        $results = $this->aggregator->search((isset($input['query']) ?? ''));
+        $type = $request->input('type');
 
-        return response()->json($results);
+        if (!$type) {
+            return response()->json(['message' => "'type' is required"], 400);
+        }
+
+        $results = $this->aggregator->search(
+            query: $request->input('query', ''),
+            type: $type,
+            params: $request->except(['query', 'type']),
+        );
+
+        $status = $results['message'] === 'success'
+            ? Config::get('statuscodes.STATUS_OK.code')
+            : 404;
+
+        return response()->json($results, $status);
     }
 }

--- a/app/SearchProviders/ARDC.php
+++ b/app/SearchProviders/ARDC.php
@@ -2,16 +2,12 @@
 
 namespace App\SearchProviders;
 
+use Auditor;
 use Http;
 use App\Contracts\SearchProvider;
 
 class ARDC implements SearchProvider
 {
-    private function getDefaultSearchType(): string
-    {
-        return 'health.dataset';
-    }
-
     public function getFullName(): string
     {
         return 'Australian Research Data Commons';
@@ -30,31 +26,57 @@ class ARDC implements SearchProvider
     public function getProviderBlurb(): string|null
     {
         return '<b>ABOUT THE ARDC</b>
-            <p>At the Australian Research Data Commons (ARDC), we’re accelerating Australian research and innovation by driving excellence in the creation, analysis and retention of high-quality data assets.</p>
+            <p>At the Australian Research Data Commons (ARDC), we\'re accelerating Australian research and innovation by driving excellence in the creation, analysis and retention of high-quality data assets.</p>
             <p>We partner with the research community and industry to build leading-edge digital research infrastructure to provide Australian researchers with competitive advantage through data.</p>';
     }
 
-    public function getSearchURI(): string
+    public function getSearchURI(string $type): string
     {
         return 'https://researchdata.edu.au/registry/services/registry/post_solr_search';
     }
 
-    public function search(string $query): array
+    public function getSupportedTypes(): array
     {
-        $response = Http::post($this->getSearchURI(), [
-            'filters' => [
-                'q' => (empty($query) ? false : $query),
-                'type' => $this->getDefaultSearchType(),
-            ],
-        ]);
+        return ['datasets'];
+    }
 
-        $newArr = [];
-        $incoming = $response->json();
+    public function search(string $query, string $type, array $params = []): array
+    {
+        try {
+            $response = Http::post($this->getSearchURI($type), [
+                'filters' => [
+                    'q'    => empty($query) ? false : $query,
+                    'type' => 'health.dataset',
+                ],
+            ]);
 
-        foreach ($incoming['result']['docs'] as $arr) {
-            $newArr[] = $arr;
+            if (!$response->successful()) {
+                return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
+            }
+
+            $incoming = $response->json();
+
+            if (!isset($incoming['result']['docs']) || !is_array($incoming['result']['docs'])) {
+                return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
+            }
+
+            $hits = array_values($incoming['result']['docs']);
+
+            return [
+                'hits'         => $hits,
+                'total'        => count($hits),
+                'aggregations' => [],
+                'ids'          => [],
+            ];
+        } catch (\Throwable $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+            \Log::error($e->getMessage());
         }
 
-        return $newArr;
+        return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
     }
 }

--- a/app/SearchProviders/HDRUK.php
+++ b/app/SearchProviders/HDRUK.php
@@ -4,16 +4,37 @@ namespace App\SearchProviders;
 
 use Auditor;
 use Http;
-use App\Models\Filter;
-use App\Models\Dataset;
 use App\Contracts\SearchProvider;
+use App\Services\Search\FilterCache;
+use App\Services\Search\CollectionHydrator;
+use App\Services\Search\DataCustodianHydrator;
+use App\Services\Search\DataCustodianNetworkHydrator;
+use App\Services\Search\DatasetHydrator;
+use App\Services\Search\DataUseHydrator;
+use App\Services\Search\PublicationHydrator;
+use App\Services\Search\ToolHydrator;
 
 class HDRUK implements SearchProvider
 {
-    private function getDefaultSearchType(): string
-    {
-        return 'datasets';
-    }
+    private const SERVICE_PATH_MAP = [
+        'datasets'                => 'datasets',
+        'tools'                   => 'tools',
+        'collections'             => 'collections',
+        'dur'                     => 'dur',
+        'publications'            => 'publications',
+        'data_custodian_networks' => 'data_custodian_networks',
+        'data_custodians'         => 'data_providers',
+    ];
+
+    private const FILTER_TYPE_MAP = [
+        'datasets'                => ['type' => 'dataset',          'enabledOnly' => true],
+        'tools'                   => ['type' => 'tool',             'enabledOnly' => false],
+        'collections'             => ['type' => 'collection',       'enabledOnly' => false],
+        'dur'                     => ['type' => 'dataUseRegister',  'enabledOnly' => false],
+        'publications'            => ['type' => 'paper',            'enabledOnly' => false],
+        'data_custodian_networks' => ['type' => 'dataProviderColl', 'enabledOnly' => false],
+        'data_custodians'         => ['type' => 'dataProvider',     'enabledOnly' => false],
+    ];
 
     public function getFullName(): string
     {
@@ -35,75 +56,78 @@ class HDRUK implements SearchProvider
         return null;
     }
 
-    public function getSearchURI(): string
+    public function getSearchURI(string $type): string
     {
-        return config('gateway.search_service_url') . "/search/{$this->getDefaultSearchType()}";
+        $path = self::SERVICE_PATH_MAP[$type] ?? $type;
+        return config('gateway.search_service_url') . "/search/{$path}";
     }
 
-    public function search(string $query): array
+    public function getSupportedTypes(): array
+    {
+        return array_keys(self::SERVICE_PATH_MAP);
+    }
+
+    public function search(string $query, string $type, array $params = []): array
     {
         try {
-            $aggs = Filter::where('type', 'dataset')->where('enabled', 1)->get()->toArray();
-            $input['aggs'] = $aggs;
+            $filterConfig = self::FILTER_TYPE_MAP[$type] ?? ['type' => $type, 'enabledOnly' => false];
 
-            $response = Http::post($this->getSearchURI(), $input);
+            $input          = $params;
+            $input['query'] = $query;
+            $input['aggs']  = FilterCache::get($filterConfig['type'], $filterConfig['enabledOnly']);
+
+            $response = Http::post($this->getSearchURI($type), $input);
 
             if (!$response->successful()) {
-                return [];
+                return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
             }
 
-            $response = $response->json();
+            $body = $response->json();
 
             if (
-                !isset($response['hits']) || !is_array($response['hits']) ||
-                !isset($response['hits']['hits']) || !is_array($response['hits']['hits']) ||
-                !isset($response['hits']['total']['value'])
+                !isset($body['hits']) || !is_array($body['hits']) ||
+                !isset($body['hits']['hits']) || !is_array($body['hits']['hits']) ||
+                !isset($body['hits']['total']['value'])
             ) {
-                return [];
+                return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
             }
 
-            $datasetsArray = $response['hits']['hits'];
-            $totalResults = $response['hits']['total']['value'];
-            $matchedIds = [];
+            $rawHits = $body['hits']['hits'];
+            $total   = $body['hits']['total']['value'];
+            $ids     = array_column($rawHits, '_id');
+            $aggs    = $body['aggregations'] ?? [];
 
-            foreach (array_values($datasetsArray) as $i => $d) {
-                $matchedIds[] = $d['_id'];
-            }
+            $hydrated = $this->hydrate($rawHits, $type, $params['view_type'] ?? 'full');
 
-            foreach ($matchedIds as $i => $matchedId) {
-                $model = Dataset::with('team')->where('id', $matchedId)->first();
-
-                if (!$model) {
-                    continue;
-                }
-
-                $latestVersion = $model->latestVersion();
-                if (is_null($latestVersion)) {
-                    continue;
-                }
-
-                $model = $model->toArray();
-                $datasetsArray[$i]['_source']['created_at'] = $model['created_at'];
-                $datasetsArray[$i]['_source']['updated_at'] = $model['updated_at'];
-            }
-
-            $newArr = [];
-
-            foreach ($datasetsArray as $arr) {
-                $newArr[] = $arr['_source'];
-            }
-
-            return $newArr;
-
+            return [
+                'hits'         => $hydrated,
+                'total'        => $total,
+                'aggregations' => $aggs,
+                'ids'          => $ids,
+            ];
         } catch (\Throwable $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
                 'action_name' => class_basename($this) . '@' . __FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
-            \Log::info($e->getMessage());
+            \Log::error($e->getMessage());
         }
 
-        return [];
+        return ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []];
+    }
+
+    private function hydrate(array $hits, string $type, string $viewType = 'full'): array
+    {
+        return match ($type) {
+            'datasets'                => (new DatasetHydrator())->hydrate($hits, $viewType),
+            'tools'                   => (new ToolHydrator())->hydrate($hits),
+            'collections'             => (new CollectionHydrator())->hydrate($hits),
+            'dur'                     => (new DataUseHydrator())->hydrate($hits),
+            'publications'            => (new PublicationHydrator())->hydrate($hits),
+            'data_custodian_networks' => (new DataCustodianNetworkHydrator())->hydrate($hits),
+            'data_custodians'         => (new DataCustodianHydrator())->hydrate($hits),
+            default                   => $hits,
+        };
     }
 }

--- a/app/Services/Search/DatasetHydrator.php
+++ b/app/Services/Search/DatasetHydrator.php
@@ -5,6 +5,7 @@ namespace App\Services\Search;
 use App\Models\Dataset;
 use App\Models\DataAccessTemplate;
 use App\Models\Team;
+use App\Services\DatasetService;
 use Illuminate\Support\Arr;
 use Config;
 
@@ -62,7 +63,14 @@ class DatasetHydrator
                 continue;
             }
 
-            $metadata = $latestVersion->metadata['metadata'] ?? null;
+            // Delta rows (patch !== null) store no metadata — reconstruct from the nearest snapshot.
+            if ($latestVersion->patch !== null) {
+                $envelope = app(DatasetService::class)->getVersion($model, $latestVersion->version);
+                $metadata = $envelope['metadata'] ?? null;
+            } else {
+                $metadata = $latestVersion->metadata['metadata'] ?? null;
+            }
+
             if (!$metadata) {
                 \Log::warning('Missing metadata structure for dataset version id=' . $latestVersion->id . ', dataset id=' . $model->id);
                 unset($hits[$i]);

--- a/app/Services/SearchAggregator.php
+++ b/app/Services/SearchAggregator.php
@@ -14,37 +14,47 @@ class SearchAggregator
         $this->providers = $providers;
     }
 
-    // Intentionally not exposed via swagger for the time being
-    public function search(string $query): array
+    public function search(string $query, string $type, array $params = []): array
     {
         $results = [];
 
         foreach ($this->providers as $provider) {
+            if (!in_array($type, $provider->getSupportedTypes())) {
+                continue;
+            }
+
             try {
+                $providerResult = $provider->search($query, $type, $params);
+
                 $results[$provider->getShortName()] = [
                     'provider_logo' => $provider->getProviderLogo(),
-                    'about' => $provider->getProviderBlurb(),
-                    $provider->search($query),
-                ];
-
-                return [
-                    'message' => 'success',
-                    'data' => [
-                        'query' => $query,
-                        'results' => $results,
-                    ],
+                    'about'         => $provider->getProviderBlurb(),
+                    'hits'          => $providerResult['hits'],
+                    'total'         => $providerResult['total'],
+                    'aggregations'  => $providerResult['aggregations'] ?? [],
+                    'ids'           => $providerResult['ids'] ?? [],
                 ];
             } catch (\Throwable $e) {
-                \Log::error("Search provider {$provider->getShortName()} failed with error ", [
+                \Log::error("Search provider {$provider->getShortName()} failed", [
                     'error' => $e->getMessage(),
                 ]);
-                continue;
             }
         }
 
+        if (empty($results)) {
+            return [
+                'message' => 'failed',
+                'data'    => null,
+            ];
+        }
+
         return [
-            'message' => 'failed',
-            'data' => null,
+            'message' => 'success',
+            'data' => [
+                'query'   => $query,
+                'type'    => $type,
+                'results' => $results,
+            ],
         ];
     }
 }

--- a/tests/Feature/V2/SearchAggregationTest.php
+++ b/tests/Feature/V2/SearchAggregationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature\V2;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+use Laravel\Pennant\Feature;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Feature tests for POST /api/v2/search/aggregation.
+ *
+ * Covers:
+ *  1. Feature flag guard (404 when inactive)
+ *  2. Input validation (400 when type missing or query invalid)
+ *  3. Successful aggregation response shape
+ *  4. HDRUK provider hydrates a snapshot-versioned dataset
+ *  5. HDRUK provider reconstructs and hydrates a delta-versioned dataset
+ *     (regression for the bug where latestMetadata returning a delta row
+ *     caused DatasetHydrator to silently drop all hits)
+ */
+class SearchAggregationTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const TEST_URL = '/api/v2/search/aggregation';
+
+    protected $metadata;
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->metadata = $this->getMetadata();
+
+        // Flush the Pennant in-memory cache, then write an explicit stored value
+        // so Feature::active() always sees a fresh result within each test.
+        Feature::flushCache();
+        Feature::activate('V2/Search/Aggregation');
+
+        // Stub the ARDC external endpoint so it never hits the real network.
+        Http::fake([
+            'https://researchdata.edu.au/*' => Http::response(
+                ['result' => ['docs' => []]],
+                200,
+                ['application/json']
+            ),
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Feature flag
+    // -------------------------------------------------------------------------
+
+    public function test_returns_404_when_feature_flag_is_inactive(): void
+    {
+        Feature::flushCache();
+        Feature::deactivate('V2/Search/Aggregation');
+
+        $response = $this->json('POST', self::TEST_URL, ['query' => 'asthma', 'type' => 'datasets'], $this->header);
+
+        $response->assertStatus(404);
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation
+    // -------------------------------------------------------------------------
+
+    public function test_returns_400_when_type_is_missing(): void
+    {
+        $response = $this->json('POST', self::TEST_URL, ['query' => 'asthma'], $this->header);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_returns_400_when_query_contains_injection_pattern(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['query' => "asthma'; DROP TABLE datasets;--", 'type' => 'datasets'],
+            $this->header
+        );
+
+        $response->assertStatus(400);
+    }
+
+    public function test_returns_400_when_sort_format_is_invalid(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['query' => 'asthma', 'type' => 'datasets', 'sort' => 'invalid_sort_string'],
+            $this->header
+        );
+
+        $response->assertStatus(400);
+    }
+
+    // -------------------------------------------------------------------------
+    // Success — response structure
+    // -------------------------------------------------------------------------
+
+    public function test_returns_success_envelope_with_query_and_type(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['query' => 'asthma', 'type' => 'tools'],
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data' => [
+                'query',
+                'type',
+                'results',
+            ],
+        ]);
+        $response->assertJsonPath('data.query', 'asthma');
+        $response->assertJsonPath('data.type', 'tools');
+    }
+
+    public function test_hdruk_results_contain_expected_keys(): void
+    {
+        // HDRUK search for tools has no DB hydration step, so no dataset setup needed.
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['query' => 'nlp', 'type' => 'tools'],
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                'results' => [
+                    'HDRUK' => [
+                        'provider_logo',
+                        'about',
+                        'hits',
+                        'total',
+                        'aggregations',
+                        'ids',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_ardc_results_are_present_for_dataset_search(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['query' => 'asthma', 'type' => 'datasets'],
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        // ARDC is present and has the expected structure; exact hit count depends
+        // on the ARDC external stub registered in setUp.
+        $response->assertJsonStructure([
+            'data' => ['results' => ['ARDC' => ['hits', 'total', 'aggregations']]],
+        ]);
+        $this->assertIsArray($response->json('data.results.ARDC.hits'));
+    }
+
+}

--- a/tests/Unit/DatasetHydratorTest.php
+++ b/tests/Unit/DatasetHydratorTest.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Tests\Unit;
+
+use Config;
+use Tests\TestCase;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use App\Services\Search\DatasetHydrator;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Unit tests for DatasetHydrator::hydrate().
+ *
+ * Covers:
+ *  1. A dataset whose latest version is a full snapshot is hydrated correctly.
+ *  2. A dataset whose latest version is a delta row (patch != null, metadata = [])
+ *     is reconstructed from the nearest snapshot and hydrated correctly.
+ *     This is the regression test for the bug where DatasetHydrator silently
+ *     dropped all delta-versioned datasets from search results.
+ *  3. A dataset that does not exist in the DB is dropped from the hit list.
+ */
+class DatasetHydratorTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        Dataset::flushEventListeners();
+        DatasetVersion::flushEventListeners();
+    }
+
+    // -------------------------------------------------------------------------
+    // Snapshot version
+    // -------------------------------------------------------------------------
+
+    public function test_hydrates_dataset_with_snapshot_version(): void
+    {
+        [$dataset, $gwdm] = $this->createDatasetWithSnapshotVersion('Snapshot Title');
+
+        $hit = $this->makeHit((string)$dataset->id);
+
+        $results = (new DatasetHydrator())->hydrate([$hit]);
+
+        $this->assertCount(1, $results, 'Expected one hydrated hit for a snapshot dataset');
+        $this->assertEquals('Snapshot Title', $results[0]['metadata']['summary']['title']);
+        $this->assertArrayHasKey('team', $results[0]);
+        $this->assertArrayHasKey('isCohortDiscovery', $results[0]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Delta version — regression test for the DatasetHydrator fix
+    // -------------------------------------------------------------------------
+
+    /**
+     * Before the fix, DatasetHydrator accessed `$latestVersion->metadata['metadata']`
+     * on a delta row. Delta rows store `metadata = []`, so this returned null and
+     * the dataset was silently dropped with a Log::warning.
+     *
+     * After the fix, the hydrator detects `patch !== null`, calls
+     * DatasetService::getVersion() to reconstruct the full GWDM object from the
+     * nearest snapshot + forward delta walk, and returns a properly hydrated hit.
+     */
+    public function test_hydrates_dataset_whose_latest_version_is_a_delta(): void
+    {
+        [$dataset] = $this->createDatasetWithDeltaVersion('Original Title', 'Updated via Delta');
+
+        $hit = $this->makeHit((string)$dataset->id);
+
+        $results = (new DatasetHydrator())->hydrate([$hit]);
+
+        $this->assertCount(1, $results, 'DatasetHydrator dropped a delta-versioned dataset — reconstruction is broken');
+        $this->assertEquals(
+            'Updated via Delta',
+            $results[0]['metadata']['summary']['title'],
+            'Reconstructed metadata should reflect the delta patch, not the original snapshot title'
+        );
+    }
+
+    public function test_reconstruction_applies_all_deltas_in_sequence(): void
+    {
+        [$dataset] = $this->createDatasetWithMultipleDeltas('V1 Title', ['V2 Title', 'V3 Title']);
+
+        $hit = $this->makeHit((string)$dataset->id);
+
+        $results = (new DatasetHydrator())->hydrate([$hit]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('V3 Title', $results[0]['metadata']['summary']['title']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing dataset
+    // -------------------------------------------------------------------------
+
+    public function test_drops_hit_whose_dataset_id_does_not_exist_in_the_database(): void
+    {
+        $hit = $this->makeHit('99999');
+
+        $results = (new DatasetHydrator())->hydrate([$hit]);
+
+        $this->assertEmpty($results, 'Hit for a non-existent dataset should be dropped');
+    }
+
+    public function test_partial_results_when_some_ids_are_missing(): void
+    {
+        [$dataset] = $this->createDatasetWithSnapshotVersion('Real Dataset');
+
+        $results = (new DatasetHydrator())->hydrate([
+            $this->makeHit((string)$dataset->id),
+            $this->makeHit('99999'),
+        ]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Real Dataset', $results[0]['metadata']['summary']['title']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a minimal Elasticsearch hit array for a given dataset ID.
+     */
+    private function makeHit(string $datasetId): array
+    {
+        return [
+            '_id'     => $datasetId,
+            '_score'  => 1.0,
+            '_index'  => 'datasets',
+            '_source' => [
+                'abstract'       => '',
+                'description'    => '',
+                'keywords'       => '',
+                'named_entities' => [],
+                'publisherName'  => '',
+                'shortTitle'     => '',
+                'title'          => '',
+                'dataUseTitles'  => [],
+                'populationSize' => 0,
+            ],
+            'highlight' => ['abstract' => [], 'description' => []],
+        ];
+    }
+
+    /**
+     * Create a team + dataset + v1 snapshot DatasetVersion.
+     *
+     * @return array{0: Dataset, 1: array}  [$dataset, $gwdm]
+     */
+    private function createDatasetWithSnapshotVersion(string $title): array
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+        $gwdm    = $this->buildMinimalGwdm($team->id, $title);
+
+        DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => 1,
+            'patch'       => null,
+            'metadata'    => [
+                'gwdmVersion'       => Config::get('metadata.GWDM.version'),
+                'metadata'          => $gwdm,
+                'original_metadata' => [],
+            ],
+            'title'       => $title,
+            'short_title' => $title,
+        ]);
+
+        return [$dataset, $gwdm];
+    }
+
+    /**
+     * Create a team + dataset with a v1 snapshot and a v2 delta changing title.
+     *
+     * @return array{0: Dataset, 1: Team}
+     */
+    private function createDatasetWithDeltaVersion(string $originalTitle, string $updatedTitle): array
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+        $gwdm    = $this->buildMinimalGwdm($team->id, $originalTitle);
+
+        DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => 1,
+            'patch'       => null,
+            'metadata'    => [
+                'gwdmVersion'       => Config::get('metadata.GWDM.version'),
+                'metadata'          => $gwdm,
+                'original_metadata' => [],
+            ],
+            'title'       => $originalTitle,
+            'short_title' => $originalTitle,
+        ]);
+
+        DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => 2,
+            'patch'       => [['op' => 'replace', 'path' => '/summary/title', 'value' => $updatedTitle]],
+            'metadata'    => [],
+            'title'       => $updatedTitle,
+            'short_title' => $updatedTitle,
+        ]);
+
+        return [$dataset, $team];
+    }
+
+    /**
+     * Create a dataset with one snapshot and N sequential delta versions.
+     *
+     * @return array{0: Dataset, 1: Team}
+     */
+    private function createDatasetWithMultipleDeltas(string $v1Title, array $deltaTitles): array
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+        $gwdm    = $this->buildMinimalGwdm($team->id, $v1Title);
+
+        DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => 1,
+            'patch'       => null,
+            'metadata'    => [
+                'gwdmVersion'       => Config::get('metadata.GWDM.version'),
+                'metadata'          => $gwdm,
+                'original_metadata' => [],
+            ],
+            'title'       => $v1Title,
+            'short_title' => $v1Title,
+        ]);
+
+        foreach ($deltaTitles as $i => $title) {
+            DatasetVersion::create([
+                'dataset_id'  => $dataset->id,
+                'version'     => $i + 2,
+                'patch'       => [['op' => 'replace', 'path' => '/summary/title', 'value' => $title]],
+                'metadata'    => [],
+                'title'       => $title,
+                'short_title' => $title,
+            ]);
+        }
+
+        return [$dataset, $team];
+    }
+
+    private function buildMinimalGwdm(int $teamId, string $title): array
+    {
+        return [
+            'summary' => [
+                'title'      => $title,
+                'shortTitle' => $title,
+                'abstract'   => 'Test abstract.',
+                'publisher'  => [
+                    'gatewayId'     => (string)$teamId,
+                    'publisherName' => 'Test Publisher',
+                ],
+            ],
+            'coverage'             => [],
+            'provenance'           => [],
+            'accessibility'        => ['access' => ['accessServiceCategory' => null]],
+            'enrichmentAndLinkage' => [],
+            'observations'         => [],
+            'structuralMetadata'   => [],
+            'required'             => [
+                'gatewayId'  => (string)$teamId,
+                'gatewayPid' => '',
+                'issued'     => now()->toIso8601String(),
+                'modified'   => now()->toIso8601String(),
+                'revisions'  => [],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/SearchAggregatorTest.php
+++ b/tests/Unit/SearchAggregatorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Services\SearchAggregator;
+use App\Contracts\SearchProvider;
+use Mockery;
+
+class SearchAggregatorTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeProvider(
+        string $shortName,
+        array $supportedTypes,
+        array $result = [],
+        bool $shouldReceiveSearch = true
+    ): SearchProvider {
+        $mock = Mockery::mock(SearchProvider::class);
+        $mock->shouldReceive('getShortName')->andReturn($shortName)->byDefault();
+        $mock->shouldReceive('getFullName')->andReturn($shortName . ' Full Name')->byDefault();
+        $mock->shouldReceive('getProviderLogo')->andReturn(null)->byDefault();
+        $mock->shouldReceive('getProviderBlurb')->andReturn(null)->byDefault();
+        $mock->shouldReceive('getSupportedTypes')->andReturn($supportedTypes)->byDefault();
+
+        if ($shouldReceiveSearch) {
+            $mock->shouldReceive('search')
+                ->andReturn(array_merge(
+                    ['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []],
+                    $result
+                ))
+                ->byDefault();
+        }
+
+        return $mock;
+    }
+
+    // -------------------------------------------------------------------------
+    // Type routing
+    // -------------------------------------------------------------------------
+
+    public function test_only_calls_providers_that_support_the_requested_type(): void
+    {
+        $matching = $this->makeProvider('MATCH', ['datasets']);
+        $matching->shouldReceive('search')->once()
+            ->with('asthma', 'datasets', [])
+            ->andReturn(['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []]);
+
+        $skipped = Mockery::mock(SearchProvider::class);
+        $skipped->shouldReceive('getSupportedTypes')->andReturn(['tools']);
+        $skipped->shouldNotReceive('search');
+
+        $aggregator = new SearchAggregator([$matching, $skipped]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertEquals('success', $result['message']);
+        $this->assertArrayHasKey('MATCH', $result['data']['results']);
+    }
+
+    public function test_returns_failed_when_no_providers_support_the_type(): void
+    {
+        $provider = Mockery::mock(SearchProvider::class);
+        $provider->shouldReceive('getSupportedTypes')->andReturn(['tools']);
+        $provider->shouldNotReceive('search');
+
+        $aggregator = new SearchAggregator([$provider]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertEquals('failed', $result['message']);
+        $this->assertNull($result['data']);
+    }
+
+    public function test_returns_failed_when_provider_list_is_empty(): void
+    {
+        $aggregator = new SearchAggregator([]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertEquals('failed', $result['message']);
+        $this->assertNull($result['data']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Resilience
+    // -------------------------------------------------------------------------
+
+    public function test_continues_and_returns_partial_results_when_one_provider_throws(): void
+    {
+        $failing = Mockery::mock(SearchProvider::class);
+        $failing->shouldReceive('getShortName')->andReturn('FAIL');
+        $failing->shouldReceive('getSupportedTypes')->andReturn(['datasets']);
+        $failing->shouldReceive('search')->andThrow(new \RuntimeException('Search service unreachable'));
+
+        $working = $this->makeProvider('WORK', ['datasets'], [
+            'hits'  => [['_id' => '1', '_source' => ['title' => 'A dataset']]],
+            'total' => 1,
+        ]);
+
+        $aggregator = new SearchAggregator([$failing, $working]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertEquals('success', $result['message']);
+        $this->assertArrayNotHasKey('FAIL', $result['data']['results']);
+        $this->assertArrayHasKey('WORK', $result['data']['results']);
+        $this->assertEquals(1, $result['data']['results']['WORK']['total']);
+    }
+
+    public function test_returns_failed_when_all_providers_throw(): void
+    {
+        $provider = Mockery::mock(SearchProvider::class);
+        $provider->shouldReceive('getShortName')->andReturn('FAIL');
+        $provider->shouldReceive('getSupportedTypes')->andReturn(['datasets']);
+        $provider->shouldReceive('search')->andThrow(new \RuntimeException('down'));
+
+        $aggregator = new SearchAggregator([$provider]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertEquals('failed', $result['message']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Response envelope
+    // -------------------------------------------------------------------------
+
+    public function test_response_envelope_contains_query_and_type(): void
+    {
+        $provider = $this->makeProvider('TEST', ['datasets'], [
+            'hits'         => [],
+            'total'        => 0,
+            'aggregations' => [],
+            'ids'          => [],
+        ]);
+
+        $aggregator = new SearchAggregator([$provider]);
+        $result = $aggregator->search('cancer research', 'datasets', ['per_page' => 10]);
+
+        $this->assertEquals('success', $result['message']);
+        $this->assertEquals('cancer research', $result['data']['query']);
+        $this->assertEquals('datasets', $result['data']['type']);
+    }
+
+    public function test_response_contains_provider_metadata(): void
+    {
+        $provider = Mockery::mock(SearchProvider::class);
+        $provider->shouldReceive('getShortName')->andReturn('HDR');
+        $provider->shouldReceive('getProviderLogo')->andReturn('https://example.com/logo.svg');
+        $provider->shouldReceive('getProviderBlurb')->andReturn('<p>About HDR</p>');
+        $provider->shouldReceive('getSupportedTypes')->andReturn(['datasets']);
+        $provider->shouldReceive('search')->andReturn([
+            'hits'         => [['_id' => '1']],
+            'total'        => 1,
+            'aggregations' => ['publisherName' => ['buckets' => []]],
+            'ids'          => ['1'],
+        ]);
+
+        $aggregator = new SearchAggregator([$provider]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $entry = $result['data']['results']['HDR'];
+
+        $this->assertEquals('https://example.com/logo.svg', $entry['provider_logo']);
+        $this->assertEquals('<p>About HDR</p>', $entry['about']);
+        $this->assertCount(1, $entry['hits']);
+        $this->assertEquals(1, $entry['total']);
+        $this->assertIsArray($entry['aggregations']);
+        $this->assertIsArray($entry['ids']);
+        $this->assertContains('1', $entry['ids']);
+    }
+
+    public function test_params_are_forwarded_to_provider(): void
+    {
+        $expectedParams = ['sort' => 'score:desc', 'per_page' => 25, 'view_type' => 'mini'];
+
+        $provider = Mockery::mock(SearchProvider::class);
+        $provider->shouldReceive('getShortName')->andReturn('TEST');
+        $provider->shouldReceive('getProviderLogo')->andReturn(null);
+        $provider->shouldReceive('getProviderBlurb')->andReturn(null);
+        $provider->shouldReceive('getSupportedTypes')->andReturn(['datasets']);
+        $provider->shouldReceive('search')
+            ->once()
+            ->with('asthma', 'datasets', $expectedParams)
+            ->andReturn(['hits' => [], 'total' => 0, 'aggregations' => [], 'ids' => []]);
+
+        $aggregator = new SearchAggregator([$provider]);
+        $aggregator->search('asthma', 'datasets', $expectedParams);
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-provider
+    // -------------------------------------------------------------------------
+
+    public function test_results_from_multiple_providers_are_keyed_by_short_name(): void
+    {
+        $hdruk = $this->makeProvider('HDRUK', ['datasets'], ['total' => 104]);
+        $ardc  = $this->makeProvider('ARDC', ['datasets'], ['total' => 3]);
+
+        $aggregator = new SearchAggregator([$hdruk, $ardc]);
+        $result = $aggregator->search('asthma', 'datasets');
+
+        $this->assertArrayHasKey('HDRUK', $result['data']['results']);
+        $this->assertArrayHasKey('ARDC', $result['data']['results']);
+        $this->assertEquals(104, $result['data']['results']['HDRUK']['total']);
+        $this->assertEquals(3, $result['data']['results']['ARDC']['total']);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes
Updates the Search Aggregation to fall in line with an already used payload return, to minimise changes required on the frontend. Also handles some small bugs and defences.

Pads out the search provider interface with new suitability functions, like defining search types available via provider. 

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8978

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [x] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
