### PR TITLE
fix(GAT-8925): Properly handles SDE expiry isolated from general cohort expiry

### DIFF
--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -55,6 +55,11 @@ class CohortUserExpiry extends Command
         $trueExpiryDate = $this->calculateTrueExpiry($r, $expiryField);
 
         if ($trueExpiryDate === null) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'CohortUserExpiry - found null expiry for CohortRequest ID ' . $r->id,
+            ]);
             return;
         }
 

--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -42,60 +42,106 @@ class CohortUserExpiry extends Command
         foreach ($users as $u) {
             if (count($u->cohortRequests) > 0) {
                 foreach ($u->cohortRequests as $r) {
-                    $now = Carbon::now();
-
-                    $trueExpiryDate = $this->calculateTrueExpiry($r);
-
-                    $diff = (int) abs($trueExpiryDate->diffInDays($now));
-
-                    if (in_array($diff, $warnings)) {
-                        if ($r->request_status === 'APPROVED') {
-                            $this->sendEmail($r->id, 'WILL_EXPIRE');
-                        }
-                    }
-
-                    if ($trueExpiryDate <= $now) {
-                        if ($r->request_status === 'APPROVED') {
-                            $r->update([
-                                'request_status' => 'EXPIRED',
-                                'cohort_status' => false,
-                                'request_expire_at' => Carbon::now(),
-                            ]);
-                            foreach ($r->permissions as $p) {
-                                // Remove GENERAL_ACCESS permission from request
-                                $perm = Permission::where([
-                                    'application' => 'cohort',
-                                    'name' => 'GENERAL_ACCESS',
-                                ])->first();
-
-                                CohortRequestHasPermission::where([
-                                    'cohort_request_id' => $r->id,
-                                    'permission_id' => $perm->id,
-                                ])->delete();
-                            }
-
-                            // Log and associate with this request
-                            $log = CohortRequestLog::create([
-                                'user_id' => $u->id,
-                                'details' => 'Access expired',
-                                'request_status' => 'EXPIRED',
-                                'nhse_sde_request_status' => $r->nhse_sde_request_status,
-                            ]);
-
-                            CohortRequestHasLog::create([
-                                'cohort_request_id' => $r->id,
-                                'cohort_request_log_id' => $log->id,
-                            ]);
-
-                            $this->sendEmail($r->id, 'EXPIRED');
-                        }
-                    }
+                    $this->handleExpiryCheck($r, $u, 'request_expire_at', $warnings);
+                    $this->handleExpiryCheck($r, $u, 'nhse_sde_request_expire_at', $warnings);
                 }
             }
         }
     }
 
-    private function sendEmail($cohortId, $cohortRequestStatus)
+    private function handleExpiryCheck(CohortRequest $r, User $u, string $expiryField, array $warnings): void
+    {
+        $now = Carbon::now();
+        $trueExpiryDate = $this->calculateTrueExpiry($r, $expiryField);
+
+        if ($trueExpiryDate === null) {
+            return;
+        }
+
+        $diff = (int) round(abs($trueExpiryDate->diffInDays($now)));
+
+        switch ($expiryField) {
+            case 'request_expire_at':
+                if ($trueExpiryDate <= $now) {
+                    if ($r->request_status === CohortRequest::REQUEST_APPROVED) {
+                        $this->expireRequest($r, $expiryField);
+                        $this->removePermissions($r);
+                        $this->createLog($r, $u);
+                        $this->sendEmail($r->id, CohortRequest::REQUEST_EXPIRED, $trueExpiryDate);
+                    }
+                } elseif (in_array($diff, $warnings)) {
+                    if ($r->request_status === CohortRequest::REQUEST_APPROVED) {
+                        $this->sendEmail($r->id, 'WILL_EXPIRE', $trueExpiryDate);
+                    }
+                }
+                break;
+
+            case 'nhse_sde_request_expire_at':
+                if ($trueExpiryDate <= $now) {
+                    if ($r->nhse_sde_request_status === CohortRequest::REQUEST_APPROVED) {
+                        $this->expireRequest($r, $expiryField);
+                        $this->removePermissions($r);
+                        $this->createLog($r, $u);
+                        $this->sendEmail($r->id, CohortRequest::REQUEST_EXPIRED, $trueExpiryDate);
+                    }
+                } elseif (in_array($diff, $warnings)) {
+                    if ($r->nhse_sde_request_status === CohortRequest::REQUEST_APPROVED) {
+                        $this->sendEmail($r->id, 'WILL_EXPIRE', $trueExpiryDate);
+                    }
+                }
+                break;
+
+            default:
+                throw new \InvalidArgumentException("Unknown expiry field: {$expiryField}");
+        }
+    }
+
+    private function createLog(CohortRequest $r, User $user): void
+    {
+        $log = CohortRequestLog::create([
+            'user_id' => $user->id,
+            'details' => 'Access expired',
+            'request_status' => CohortRequest::REQUEST_EXPIRED,
+            'nhse_sde_request_status' => $r->nhse_sde_request_status,
+        ]);
+
+        CohortRequestHasLog::create([
+            'cohort_request_id' => $r->id,
+            'cohort_request_log_id' => $log->id,
+        ]);
+    }
+
+    private function removePermissions(CohortRequest $r): void
+    {
+        $permId = Permission::where([
+            'application' => 'cohort',
+            'name' => 'GENERAL_ACCESS',
+        ])->value('id');
+
+        if ($permId) {
+            CohortRequestHasPermission::where([
+                'cohort_request_id' => $r->id,
+                'permission_id' => $permId,
+            ])->delete();
+        }
+    }
+
+    private function expireRequest(CohortRequest $r, string $expiryField): void
+    {
+        if ($expiryField === 'nhse_sde_request_expire_at') {
+            $r->update([
+                'nhse_sde_request_status' => CohortRequest::REQUEST_EXPIRED,
+                'nhse_sde_request_expire_at' => Carbon::now(),
+            ]);
+        } else {
+            $r->update([
+                'request_status' => CohortRequest::REQUEST_EXPIRED,
+                'request_expire_at' => Carbon::now(),
+            ]);
+        }
+    }
+
+    private function sendEmail(int $cohortId, string $cohortRequestStatus, Carbon $expiryDate): void
     {
         try {
             $cohort = CohortRequest::where('id', $cohortId)->first();
@@ -105,7 +151,7 @@ class CohortUserExpiry extends Command
                 $user['email'] : $user['secondary_email'];
             $template = null;
             switch ($cohortRequestStatus) {
-                case 'WILL_EXPIRE': // submitted
+                case 'WILL_EXPIRE':
                     $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.will.expire')->first();
                     break;
                 case 'EXPIRED':
@@ -120,11 +166,9 @@ class CohortUserExpiry extends Command
                 ],
             ];
 
-            $trueExpiryDate = $this->calculateTrueExpiry($cohort);
-
             $replacements = [
                 '[[USER_FIRSTNAME]]' => $user['firstname'],
-                '[[EXPIRE_DATE]]' => $trueExpiryDate,
+                '[[EXPIRE_DATE]]' => $expiryDate,
                 '[[CURRENT_YEAR]]' => date("Y"),
                 '[[USER_EMAIL]]' => $userEmail,
                 '[[COHORT_DISCOVERY_ACCESS_URL]]' => Config::get('cohort.cohort_discovery_access_url'),
@@ -144,21 +188,25 @@ class CohortUserExpiry extends Command
         }
     }
 
-    private function calculateTrueExpiry($cohort)
+    private function calculateTrueExpiry(CohortRequest $cohort, string $expiryField = 'request_expire_at'): Carbon|null
     {
-        $request_expire_at = null;
-        if (!is_null($cohort->request_expire_at)) {
-            $request_expire_at = Carbon::createFromFormat('Y-m-d H:i:s', $cohort->request_expire_at);
+        /** @var Carbon|null $explicitExpiry */
+        $explicitExpiry = $cohort->$expiryField;
+
+        if ($expiryField === 'nhse_sde_request_expire_at') {
+            $basedOnUpdatedAt = $cohort->nhse_sde_updated_at
+                ? $cohort->nhse_sde_updated_at->copy()->addDays((int) Config::get('cohort.cohort_access_expiry_time_in_days'))
+                : null;
+        } else {
+            $basedOnUpdatedAt = $cohort->updated_at->copy()->addDays((int) Config::get('cohort.cohort_access_expiry_time_in_days'));
         }
 
-        return min(
-            array_diff(
-                [
-                $cohort->updated_at->addDays((int)Config::get('cohort.cohort_access_expiry_time_in_days')),
-                $request_expire_at
-            ],
-                array(null)
-            )
-        );
+        $candidates = array_filter([$basedOnUpdatedAt, $explicitExpiry]);
+
+        if (empty($candidates)) {
+            return null;
+        }
+
+        return Carbon::instance(min($candidates));
     }
 }

--- a/app/Models/CohortRequest.php
+++ b/app/Models/CohortRequest.php
@@ -41,7 +41,18 @@ class CohortRequest extends Model
 
     protected $casts = [
         'accept_declaration' => 'boolean',
+        'request_expire_at' => 'datetime',
+        'nhse_sde_requested_at' => 'datetime',
+        'nhse_sde_self_declared_approved_at' => 'datetime',
+        'nhse_sde_request_expire_at' => 'datetime',
+        'nhse_sde_updated_at' => 'datetime',
     ];
+
+    public const REQUEST_APPROVED = 'APPROVED';
+    public const REQUEST_IN_PROCESS = 'IN PROCESS';
+    public const REQUEST_APPROVAL_REQUESTED = 'APPROVAL REQUESTED';
+    public const REQUEST_PENDING = 'PENDING';
+    public const REQUEST_EXPIRED = 'EXPIRED';
 
     public function user(): BelongsTo
     {

--- a/tests/Unit/CohortUserExpiryTest.php
+++ b/tests/Unit/CohortUserExpiryTest.php
@@ -3,9 +3,13 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
+use App\Jobs\SendEmailJob;
+use App\Jobs\TermExtraction;
+use App\Jobs\LinkageExtraction;
 use App\Models\Permission;
 use App\Models\CohortRequest;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
 use Tests\Traits\MockExternalApis;
 use Illuminate\Support\Facades\Mail;
 use App\Models\CohortRequestHasPermission;
@@ -19,6 +23,12 @@ class CohortUserExpiryTest extends TestCase
     public function setUp(): void
     {
         $this->commonSetUp();
+
+        Queue::fake([
+            LinkageExtraction::class,
+            TermExtraction::class,
+            SendEmailJob::class,
+        ]);
     }
 
     public function test_it_can_run(): void
@@ -107,6 +117,273 @@ class CohortUserExpiryTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('cohort_request_has_permissions', [
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+    }
+
+    public function test_it_can_expire_nhse_sde_requests(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(181),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100); // standard access not yet expired
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(181); // NHSE SDE access expired
+        $cr->save();
+
+        $perms = Permission::where([
+            'application' => 'cohort',
+            'name' => 'GENERAL_ACCESS',
+        ])->first();
+
+        CohortRequestHasPermission::create([
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'nhse_sde_request_status' => 'EXPIRED',
+            'request_status' => 'APPROVED', // standard access untouched
+        ]);
+
+        $this->assertDatabaseHas('cohort_request_logs', [
+            'user_id' => 1,
+            'details' => 'Access expired',
+            'request_status' => 'EXPIRED',
+            'nhse_sde_request_status' => 'EXPIRED',
+        ]);
+
+        $this->assertDatabaseMissing('cohort_request_has_permissions', [
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+    }
+
+    public function test_it_doesnt_expire_valid_nhse_sde_requests(): void
+    {
+        Mail::fake();
+
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(181),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100);
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(100); // still within the window
+        $cr->save();
+
+        $perms = Permission::where([
+            'application' => 'cohort',
+            'name' => 'GENERAL_ACCESS',
+        ])->first();
+
+        CohortRequestHasPermission::create([
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_status' => 'APPROVED',
+        ]);
+
+        $this->assertDatabaseHas('cohort_request_has_permissions', [
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+    }
+
+    public function test_nhse_sde_expiry_does_not_affect_standard_request(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(181),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100); // standard NOT expired
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(181); // NHSE SDE expired
+        $cr->save();
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        // NHSE SDE should be expired, standard should remain APPROVED
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'EXPIRED',
+        ]);
+    }
+
+    public function test_standard_expiry_does_not_affect_nhse_sde_request(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(181),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(181); // standard expired
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(100); // NHSE SDE NOT expired
+        $cr->save();
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        // Standard should be expired, NHSE SDE should remain APPROVED
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'request_status' => 'EXPIRED',
+            'nhse_sde_request_status' => 'APPROVED',
+        ]);
+    }
+
+    public function test_it_sends_warning_email_when_standard_request_nearing_expiry(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => null,
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(179),
+        ]);
+
+        // updated_at + 180 days = now + 1 day; diff = 1; 1 is in the warning window [1,7,14]
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(179);
+        $cr->save();
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        Queue::assertPushed(SendEmailJob::class, 1);
+
+        // Status should NOT have changed to EXPIRED
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'request_status' => 'APPROVED',
+        ]);
+    }
+
+    public function test_it_sends_warning_email_when_nhse_sde_request_nearing_expiry(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'created_at' => Carbon::now()->subDays(179),
+        ]);
+
+        // Both within warning window (1 day left each), but let's make standard not in window
+        // and NHSE SDE in window to isolate the test.
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100); // standard: 80 days left, not in warning
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(179); // NHSE SDE: 1 day left, in warning
+        $cr->save();
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        Queue::assertPushed(SendEmailJob::class, 1);
+
+        // Neither status should have changed to EXPIRED
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+        ]);
+    }
+
+    public function test_it_skips_nhse_sde_check_when_no_dates_are_set(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => null,
+            'nhse_sde_updated_at' => null,
+            'created_at' => Carbon::now()->subDays(100),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(100);
+        $cr->save();
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        // No NHSE SDE dates — should never touch nhse_sde_request_status
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'nhse_sde_request_status' => 'APPROVED',
+        ]);
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_explicit_nhse_sde_expire_at_date_triggers_expiry(): void
+    {
+        $req = CohortRequest::create([
+            'user_id' => 1,
+            'request_status' => 'APPROVED',
+            'nhse_sde_request_status' => 'APPROVED',
+            'request_expire_at' => null,
+            'nhse_sde_request_expire_at' => Carbon::now()->subDay(),
+            'created_at' => Carbon::now()->subDays(10),
+        ]);
+
+        $cr = CohortRequest::find($req->id);
+        $cr->updated_at = Carbon::now()->subDays(10);
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(10); // time-based expiry is 170 days away
+        $cr->save();
+
+        $perms = Permission::where([
+            'application' => 'cohort',
+            'name' => 'GENERAL_ACCESS',
+        ])->first();
+
+        CohortRequestHasPermission::create([
+            'cohort_request_id' => $req->id,
+            'permission_id' => $perms->id,
+        ]);
+
+        $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
+
+        // Explicit nhse_sde_request_expire_at was yesterday → must expire even though
+        // nhse_sde_updated_at + 180 days is still far in the future.
+        $this->assertDatabaseHas('cohort_requests', [
+            'id' => $req->id,
+            'nhse_sde_request_status' => 'EXPIRED',
+            'request_status' => 'APPROVED',
+        ]);
+
+        $this->assertDatabaseMissing('cohort_request_has_permissions', [
             'cohort_request_id' => $req->id,
             'permission_id' => $perms->id,
         ]);


### PR DESCRIPTION
> Claude 4.6 Sonnet was used in the creation of this PR. Claude was used to implement unit tests to prove the solution

## Screenshots (if relevant)

## Describe your changes
The two expiry checks were tightly coupled and didn't take into account the additional length of SDE access.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [x] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
