### PR TITLE
feat(GAT-0000): seed 20 CRUK datasets from cruk_dummy_data fixtures

### DIFF
--- a/database/seeders/CRUKDatasetSeeder.php
+++ b/database/seeders/CRUKDatasetSeeder.php
@@ -5,13 +5,15 @@ namespace Database\Seeders;
 use App\Models\Dataset;
 use Illuminate\Database\Seeder;
 
-class DatasetSeeder extends Seeder
+class CRUKDatasetSeeder extends Seeder
 {
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        Dataset::factory()->count(10)->create();
+        Dataset::factory()->count(20)->create([
+            'partner_context' => 'CRUK',
+        ]);
     }
 }

--- a/database/seeders/CRUKDatasetVersionSeeder.php
+++ b/database/seeders/CRUKDatasetVersionSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use Illuminate\Database\Seeder;
+
+class CRUKDatasetVersionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $files = glob(base_path('tests/Unit/test_files/cruk_dummy_data/dataset_*.json'));
+        sort($files, SORT_NATURAL);
+
+        $datasets = Dataset::where('partner_context', 'CRUK')->orderBy('id')->get();
+
+        foreach ($datasets as $index => $dataset) {
+            if (!isset($files[$index])) {
+                break;
+            }
+
+            $metadata = json_decode(file_get_contents($files[$index]), true);
+            $gatewayId = $metadata['metadata']['required']['gatewayId'] ?? null;
+
+            if ($gatewayId) {
+                $dataset->update(['pid' => $gatewayId]);
+            }
+
+            $summary = $metadata['metadata']['summary'] ?? [];
+
+            DatasetVersion::create([
+                'dataset_id' => $dataset->id,
+                'metadata' => $metadata,
+                'version' => 1,
+                'title' => $summary['title'] ?? null,
+                'short_title' => $summary['shortTitle'] ?? $summary['title'] ?? null,
+                'provider_team_id' => $dataset->team_id,
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatasetSeeder.php
+++ b/database/seeders/DatasetSeeder.php
@@ -12,6 +12,8 @@ class DatasetSeeder extends Seeder
      */
     public function run(): void
     {
-        Dataset::factory()->count(10)->create();
+        Dataset::factory()->count(20)->create([
+            'partner_context' => 'CRUK',
+        ]);
     }
 }

--- a/database/seeders/DatasetVersionSeeder.php
+++ b/database/seeders/DatasetVersionSeeder.php
@@ -5,30 +5,41 @@ namespace Database\Seeders;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use Illuminate\Database\Seeder;
-use Tests\Traits\MockExternalApis;
 
 class DatasetVersionSeeder extends Seeder
 {
-    use MockExternalApis;
-
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        $datasets = Dataset::all();
+        $files = glob(base_path('tests/Unit/test_files/cruk_dummy_data/dataset_*.json'));
+        sort($files, SORT_NATURAL);
 
-        foreach ($datasets as $dataset) {
-            // Generate a random number of dataset versions for each dataset
-            $numVersions = rand(1, 5);
+        $datasets = Dataset::where('partner_context', 'CRUK')->orderBy('id')->get();
 
-            for ($version = 1; $version <= $numVersions; $version++) {
-                DatasetVersion::factory()->create([
-                    'dataset_id' => $dataset->id,
-                    'provider_team_id' => $dataset->team_id,
-                    'version' => $version, // Ensure the version increments
-                ]);
+        foreach ($datasets as $index => $dataset) {
+            if (!isset($files[$index])) {
+                break;
             }
+
+            $metadata = json_decode(file_get_contents($files[$index]), true);
+            $gatewayId = $metadata['metadata']['required']['gatewayId'] ?? null;
+
+            if ($gatewayId) {
+                $dataset->update(['pid' => $gatewayId]);
+            }
+
+            $summary = $metadata['metadata']['summary'] ?? [];
+
+            DatasetVersion::create([
+                'dataset_id' => $dataset->id,
+                'metadata' => $metadata,
+                'version' => 1,
+                'title' => $summary['title'] ?? null,
+                'short_title' => $summary['shortTitle'] ?? $summary['title'] ?? null,
+                'provider_team_id' => $dataset->team_id,
+            ]);
         }
     }
 }

--- a/database/seeders/DatasetVersionSeeder.php
+++ b/database/seeders/DatasetVersionSeeder.php
@@ -5,41 +5,30 @@ namespace Database\Seeders;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use Illuminate\Database\Seeder;
+use Tests\Traits\MockExternalApis;
 
 class DatasetVersionSeeder extends Seeder
 {
+    use MockExternalApis;
+
     /**
      * Run the database seeds.
      */
     public function run(): void
     {
-        $files = glob(base_path('tests/Unit/test_files/cruk_dummy_data/dataset_*.json'));
-        sort($files, SORT_NATURAL);
+        $datasets = Dataset::all();
 
-        $datasets = Dataset::where('partner_context', 'CRUK')->orderBy('id')->get();
+        foreach ($datasets as $dataset) {
+            // Generate a random number of dataset versions for each dataset
+            $numVersions = rand(1, 5);
 
-        foreach ($datasets as $index => $dataset) {
-            if (!isset($files[$index])) {
-                break;
+            for ($version = 1; $version <= $numVersions; $version++) {
+                DatasetVersion::factory()->create([
+                    'dataset_id' => $dataset->id,
+                    'provider_team_id' => $dataset->team_id,
+                    'version' => $version, // Ensure the version increments
+                ]);
             }
-
-            $metadata = json_decode(file_get_contents($files[$index]), true);
-            $gatewayId = $metadata['metadata']['required']['gatewayId'] ?? null;
-
-            if ($gatewayId) {
-                $dataset->update(['pid' => $gatewayId]);
-            }
-
-            $summary = $metadata['metadata']['summary'] ?? [];
-
-            DatasetVersion::create([
-                'dataset_id' => $dataset->id,
-                'metadata' => $metadata,
-                'version' => 1,
-                'title' => $summary['title'] ?? null,
-                'short_title' => $summary['shortTitle'] ?? $summary['title'] ?? null,
-                'provider_team_id' => $dataset->team_id,
-            ]);
         }
     }
 }

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_00.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_00.json
@@ -1,0 +1,171 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+    "required": {
+      "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890ab",
+      "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890ab",
+      "issued": "2018-03-01T00:00:00Z",
+      "modified": "2024-01-15T00:00:00Z",
+      "version": "1.0.0",
+      "revisions": [
+        {
+          "version": "1.0.0",
+          "url": "https://www.oncologytrust.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890ab"
+        }
+      ]
+    },
+    "summary": {
+      "abstract": "Registry data tracking treatment response patterns in advanced pancreatic ductal adenocarcinoma. Includes frequency of imaging and circulating tumor DNA details.",
+      "contactPoint": "access@oncologytrust.org",
+      "keywords": "Pancreatic;,;Cancer;,;Radiomics;,;Biomarkers;,;Response",
+      "controlledKeywords": null,
+      "datasetType": null,
+      "datasetSubType": null,
+      "populationSize": 2105,
+      "description": "Other data types:\n- Abdominal CT Scans (application/dicom): 3D volumetric scans of the pancreas with tumors segmented",
+      "doiName": "10.1500/data.45",
+      "shortTitle": "Pancreatic Cancer Radiomics and Biomarker Cohort",
+      "title": "Pancreatic Cancer Radiomics and Biomarker Cohort",
+      "leadResearcher": "Dr. Miller",
+      "leadResearchInstitute": "National Cancer Institute",
+      "datasetAliases": null,
+      "publisher": {
+        "name": "Oncology Research Trust",
+        "gatewayId": "https://ror.org/087654b32",
+        "rorId": null
+      },
+      "inPipeline": null,
+      "funders": null
+    },
+    "coverage": {
+      "typicalAgeRange": null,
+      "spatial": null,
+      "pathway": null,
+      "followUp": null,
+      "datasetCompleteness": null
+    },
+    "provenance": {
+      "origin": null,
+      "temporal": {
+        "timeLag": "Other",
+        "accrualPeriodicity": null,
+        "startDate": null,
+        "endDate": null,
+        "distributionReleaseDate": null
+      }
+    },
+    "accessibility": {
+      "access": {
+        "deliveryLeadTime": "Other",
+        "jurisdiction": "GB-ENG",
+        "dataController": "Oncology Research Trust",
+        "dataProcessor": "Oncology Research Trust",
+        "accessRights": "https://www.oncologytrust.org/terms",
+        "accessService": "https://www.oncologytrust.org/data-access",
+        "accessRequestCost": "Varies",
+        "accessServiceCategory": null
+      },
+      "usage": {
+        "dataUseLimitation": "General research use",
+        "dataUseRequirement": "Return to database or resource",
+        "resourceCreator": {
+          "name": "Oncology Research Trust",
+          "gatewayId": null,
+          "rorId": null
+        }
+      },
+      "formatAndStandards": {
+        "vocabularyEncodingSchemes": "OTHER",
+        "conformsTo": "OTHER",
+        "languages": "en",
+        "formats": "CSV;,;JSON"
+      }
+    },
+    "linkage": {
+      "isGeneratedUsing": null,
+      "dataUses": null,
+      "isReferenceIn": null,
+      "datasetLinkage": null,
+      "associatedMedia": null,
+      "tools": null,
+      "investigations": null,
+      "syntheticDataWebLink": null,
+      "publicationAboutDataset": null,
+      "publicationUsingDataset": null
+    },
+    "observations": [
+      {
+        "observedNode": "Persons",
+        "measuredValue": 4120,
+        "observationDate": "2023-12-01",
+        "measuredProperty": "Count",
+        "disambiguatingDescription": null
+      }
+    ],
+    "tissuesSampleCollection": [],
+    "demographicFrequency": null,
+    "omics": null,
+    "datasetFilters": [
+      {
+        "id": "0_0_0_1_10",
+        "label": "C25 Pancreas",
+        "category": "C15-C26 Digestive organs",
+        "primaryGroup": "cancer-type",
+        "description": ""
+      },
+      {
+        "id": "0_0_1_5_3",
+        "label": "8140/3 Adenocarcinoma, NOS",
+        "category": "814-838 Adenomas and adenocarcinomas",
+        "primaryGroup": "cancer-type",
+        "description": ""
+      },
+      {
+        "id": "0_1_1",
+        "label": "research specific restrictions",
+        "category": "accessType",
+        "primaryGroup": "access-type",
+        "description": "Limited to studies of a certain research type (DUO_0000012)"
+      },
+      {
+        "id": "0_2_4_2",
+        "label": "Imaging Data",
+        "category": "Techniques",
+        "primaryGroup": "data-type",
+        "description": ""
+      },
+      {
+        "id": "0_2_2_0_6",
+        "label": "Saccharomyces cerevisiae",
+        "category": "Organism",
+        "primaryGroup": "data-type",
+        "description": ""
+      },
+      {
+        "id": "0_2_2_0_2",
+        "label": "Fruit fly",
+        "category": "Organism",
+        "primaryGroup": "data-type",
+        "description": ""
+      }
+    ],
+    "projectGrants": [
+      {
+        "pid": "ORT105",
+        "projectGrantName": "Pancreatic Cancer Radiomics Integration",
+        "leadResearcher": "Dr. Miller",
+        "leadResearchInstitute": "National Cancer Institute",
+        "grantNumber": "ORT105, ORT106",
+        "projectGrantStartDate": "2019-06-01",
+        "projectGrantEndDate": "2024-06-01",
+        "projectGrantScope": "CT imaging, genetic markers, and clinical background information"
+      }
+    ],
+    "icons": ["Patient Study", "Imaging"],
+    "erd": {
+      "image": "https://github.com/OncologyResearch/panc_cohort/blob/main/assets/erd.png",
+      "description": null
+    },
+    "structuralMetadata": null
+  }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_01.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_01.json
@@ -1,0 +1,225 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890ac",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890ac",
+            "issued": "2018-03-01T00:00:00Z",
+            "modified": "2024-01-15T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.oncologytrust.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890ac"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Pancreatic Cancer Radiomics and Biomarker Cohort",
+            "abstract": "Registry data tracking treatment response patterns in advanced pancreatic ductal adenocarcinoma. Includes frequency of imaging and circulating tumor DNA details.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/087654b32",
+                "name": "Oncology Research Trust",
+                "logo": "https://www.oncologytrust.org/brand/",
+                "contactPoint": [
+                    "data@oncologytrust.org"
+                ],
+                "description": "https://www.oncologytrust.org/about"
+            },
+            "funders": "National Cancer Institute\nPancreatic Cancer Action Network",
+            "populationSize": 2105,
+            "keywords": [
+                "Pancreatic",
+                "Cancer",
+                "Radiomics",
+                "Biomarkers",
+                "Response"
+            ],
+            "doiName": "10.1500/data.45",
+            "contactPoint": "access@oncologytrust.org",
+            "datasetAliases": [
+                "Pancreatic Cancer Biomarker Registry"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking treatment response patterns in advanced pancreatic ductal adenocarcinoma. Includes frequency of imaging and circulating tumor DNA details. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://oncologytrust/docs/radiomics_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 35,
+            "typicalAgeRangeMax": 90,
+            "datasetCompleteness": "https://oncologytrust.org/pancreatic/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-03-01",
+                "timeLag": "More than 6 months",
+                "endDate": "2023-03-01",
+                "distributionReleaseDate": "2024-01-15"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Patients",
+                "measuredValue": 4120,
+                "observationDate": "2023-12-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 71
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 14
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 9
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 3
+                },
+                {
+                    "bin": "Other",
+                    "count": 1
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "01_000",
+                "projectGrantName": "Pancreatic Cancer Radiomics Integration",
+                "leadResearcher": "Dr. Miller",
+                "leadResearchInstitute": "National Cancer Institute",
+                "grantNumber": "ORT105, ORT106",
+                "projectGrantStartDate": "2019-06-01",
+                "projectGrantEndDate": "2024-06-01",
+                "projectGrantScope": "CT imaging, genetic markers, and clinical background information"
+            }
+        ],
+        "erd": "https://github.com/OncologyResearch/panc_cohort/blob/main/assets/erd.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Clinical_Features",
+                    "description": "Age, sex, tumor stage, treatment modalities",
+                    "columns": [
+                        {
+                            "name": "mutations",
+                            "dataType": "list",
+                            "description": "list of HGVS terms describing genetic mutations",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[KRAS_G12D]",
+                                    "description": "KRAS gene mutation",
+                                    "frequency": 1200
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 2500
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://oncologytrust.org/pancreatic/synthetic_data"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Abdominal CT Scans",
+                "description": "3D volumetric scans of the pancreas with tumors segmented",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Registry for Gastrointestinal Malignancies",
+                    "pid": "GI099",
+                    "url": "https://healthdatagateway.org/en/dataset/402"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/j.ejca.2021.08.012"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/j.ejca.2021.08.013"
+            ],
+            "tools": [
+                "https://github.com/topics/pancreatic-cancer-radiomics"
+            ],
+            "investigations": [
+                "ORT106"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/j.ejca.2019.05.004",
+                    "title": "Gastrointestinal Cancer Backgrounds",
+                    "pid": "ORTxyz"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Targeted panel sequencing",
+            "platform": "Illumina HiSeq"
+        },
+        "icons": [
+            "Patient Study",
+            "Imaging"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_1_10",
+                "label": "C25 Pancreas",
+                "category": "C15-C26 Digestive organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_3",
+                "label": "8140/3 Adenocarcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_1",
+                "label": "research specific restrictions",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to studies of a certain research type (DUO_0000012)"
+            },
+            {
+                "id": "0_2_4_2",
+                "label": "Imaging Data",
+                "category": "Techniques",
+                "primaryGroup": "Techniques",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_6",
+                "label": "Saccharomyces cerevisiae",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_2",
+                "label": "Fruit fly",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_02.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_02.json
@@ -1,0 +1,225 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890ad",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890ad",
+            "issued": "2017-05-01T00:00:00Z",
+            "modified": "2024-08-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.thoraciconcology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890ad"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Non-Small Cell Lung Cancer Targeted Therapy Resistance Registry",
+            "abstract": "Registry data evaluating the emergence of resistance mutations in non-small cell lung cancer patients undergoing EGFR inhibitor therapy. Includes longitudinal circulating tumor DNA analysis.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/055666d44",
+                "name": "Global Thoracic Oncology Consortium",
+                "logo": "https://www.thoraciconcology.org/media/logo.png",
+                "contactPoint": [
+                    "data-hub@thoraciconcology.org"
+                ],
+                "description": "https://www.thoraciconcology.org/mission"
+            },
+            "funders": "Lung Cancer Research Foundation\nEuropean Respiratory Society",
+            "populationSize": 3410,
+            "keywords": [
+                "Lung",
+                "Cancer",
+                "EGFR",
+                "Resistance",
+                "ctDNA"
+            ],
+            "doiName": "10.4000/data.12",
+            "contactPoint": "access@thoraciconcology.org",
+            "datasetAliases": [
+                "NSCLC Resistance Biomarker Study"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data evaluating the emergence of resistance mutations in non-small cell lung cancer patients undergoing EGFR inhibitor therapy. Includes longitudinal circulating tumor DNA analysis. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://thoraciconcology.org/files/ctdna_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 45,
+            "typicalAgeRangeMax": 88,
+            "datasetCompleteness": "https://thoraciconcology.org/registry/data-dictionary"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Quarterly",
+                "startDate": "2017-05-01",
+                "timeLag": "3 months",
+                "endDate": "2024-05-01",
+                "distributionReleaseDate": "2024-08-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Liquid Biopsies",
+                "measuredValue": 12450,
+                "observationDate": "2024-05-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 52
+                },
+                {
+                    "bin": "Asian or Asian British - Chinese",
+                    "count": 27
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 11
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 4
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 2
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "02_000",
+                "projectGrantName": "Tracking EGFR Resistance Mechanisms",
+                "leadResearcher": "Dr. Elena Rostova",
+                "leadResearchInstitute": "Institute of Respiratory Medicine",
+                "grantNumber": "LCRF-091, ERS-332",
+                "projectGrantStartDate": "2018-01-01",
+                "projectGrantEndDate": "2025-12-31",
+                "projectGrantScope": "ctDNA sequencing files, patient treatment timelines, and survival outcomes"
+            }
+        ],
+        "erd": "https://github.com/ThoracicOncology/nsclc_db/blob/main/schema/database_erd.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Molecular_Profiles",
+                    "description": "Longitudinal mutation profiles derived from plasma samples",
+                    "columns": [
+                        {
+                            "name": "resistance_mutations",
+                            "dataType": "list",
+                            "description": "list of acquired mutations associated with TKI resistance",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[T790M]",
+                                    "description": "EGFR gatekeeper mutation",
+                                    "frequency": 850
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 12450
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://thoraciconcology.org/registry/synthetic_tier"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Histopathology Whole Slide Images",
+                "description": "Digitized H&E stained tissue microarrays from initial diagnostic biopsies",
+                "format": "SVS"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Lung Cancer Audit Database",
+                    "pid": "NLCA-04",
+                    "url": "https://healthdatagateway.org/en/dataset/992"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/S1470-2045(22)00123-4"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/S1470-2045(22)00124-5"
+            ],
+            "tools": [
+                "https://github.com/topics/ctdna-variant-calling"
+            ],
+            "investigations": [
+                "GTOC-773-Phase2"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/S1470-2045(20)30456-7",
+                    "title": "Advanced Lung Cancer Genomic Profiling",
+                    "pid": "ALC-112"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Targeted RNA Sequencing",
+            "platform": "Ion Torrent Genexus"
+        },
+        "icons": [
+            "Genomics",
+            "Pathology"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_2_4",
+                "label": "C34 Bronchus and lung",
+                "category": "C30-C39 Respiratory system and intrathoracic organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_2_14",
+                "label": "8070/3 Squamous cell carcinoma, NOS",
+                "category": "805-808 Squamous cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_8",
+                "label": "generally available for UK/EU use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "International collaborations outside the EU not generally permitted."
+            },
+            {
+                "id": "0_2_3_1_8",
+                "label": "Urine tests",
+                "category": "Biopsy Reports and Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_4_1",
+                "label": "Cell and cell-derived treatments",
+                "category": "Treatments",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_0_2",
+                "label": "Genetic material",
+                "category": "Material type",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_03.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_03.json
@@ -1,0 +1,225 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890ae",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890ae",
+            "issued": "2019-02-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.digestiveoncology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890ae"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Colorectal Cancer Microbiome and Surgical Outcomes Registry",
+            "abstract": "Registry data tracking the relationship between gut microbiome composition and postoperative recovery in patients with stages II and III colorectal cancer.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/099888e55",
+                "name": "Digestive Oncology Network",
+                "logo": "https://www.digestiveoncology.org/brand/logo.png",
+                "contactPoint": [
+                    "data@digestiveoncology.org"
+                ],
+                "description": "https://www.digestiveoncology.org/about"
+            },
+            "funders": "Bowel Cancer UK\nNational Institute for Health Research",
+            "populationSize": 1250,
+            "keywords": [
+                "Colorectal",
+                "Cancer",
+                "Microbiome",
+                "Surgery",
+                "Outcomes"
+            ],
+            "doiName": "10.5000/data.33",
+            "contactPoint": "access@digestiveoncology.org",
+            "datasetAliases": [
+                "CRC Microbiome Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking the relationship between gut microbiome composition and postoperative recovery in patients with stages II and III colorectal cancer. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://digestiveoncology.org/protocols/microbiome_sampling.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 50,
+            "typicalAgeRangeMax": 90,
+            "datasetCompleteness": "https://digestiveoncology.org/crc/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2019-02-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-01",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Stool Samples",
+                "measuredValue": 3750,
+                "observationDate": "2023-12-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 76
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 12
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 6
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 3
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 2
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "03_000",
+                "projectGrantName": "Microbiome Influences on CRC Surgery Recovery",
+                "leadResearcher": "Dr. James Aris",
+                "leadResearchInstitute": "University Hospital of Gastrointestinal Diseases",
+                "grantNumber": "BCUK-102, NIHR-884",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-01-01",
+                "projectGrantScope": "16S rRNA sequences, surgical complication logs, and dietary background information"
+            }
+        ],
+        "erd": "https://github.com/DigestiveOncology/crc_db/blob/main/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Surgical_Outcomes",
+                    "description": "Operation details, length of stay, and complication grades",
+                    "columns": [
+                        {
+                            "name": "complications",
+                            "dataType": "list",
+                            "description": "list of Clavien-Dindo classification grades",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Grade_II]",
+                                    "description": "Complication requiring pharmacological treatment",
+                                    "frequency": 210
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 1250
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://digestiveoncology.org/crc/synthetic_data"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Surgical Pathology Slides",
+                "description": "Digitized slides of resected tumor margins",
+                "format": "SVS"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Bowel Cancer Audit",
+                    "pid": "NBOCA-01",
+                    "url": "https://healthdatagateway.org/en/dataset/334"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1053/j.gastro.2022.04.011"
+            ],
+            "publicationAboutDataset": [
+                "10.1053/j.gastro.2022.04.012"
+            ],
+            "tools": [
+                "https://github.com/topics/microbiome-diversity-analysis"
+            ],
+            "investigations": [
+                "DON-551-Substudy1"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1053/j.gastro.2020.11.022",
+                    "title": "Gut Microbiome in Early Stage CRC",
+                    "pid": "GMC-88"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "16S rRNA sequencing",
+            "platform": "Illumina MiSeq"
+        },
+        "icons": [
+            "Microbiome",
+            "Surgical Data"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_1_3",
+                "label": "C18 Colon",
+                "category": "C15-C26 Digestive organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_3",
+                "label": "8140/3 Adenocarcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_0",
+                "label": "no restriction",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "No restriction on use. (DUO_0000004)"
+            },
+            {
+                "id": "0_2_2",
+                "label": "Model Organism",
+                "category": "dataType",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_0",
+                "label": "Chicken",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_0_4",
+                "label": "Lifestyle",
+                "category": "Background",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_04.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_04.json
@@ -1,0 +1,229 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890af",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890af",
+            "issued": "2016-01-01T00:00:00Z",
+            "modified": "2023-12-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.uro-oncology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890af"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Prostate Cancer Active Surveillance and Progression Registry",
+            "abstract": "Registry data monitoring disease progression in men with low-risk localized prostate cancer managed through active surveillance. Includes longitudinal PSA kinetics and multiparametric MRI findings.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/077111p22",
+                "name": "Urological Oncology Collaborative",
+                "logo": "https://www.uro-oncology.org/images/logo.png",
+                "contactPoint": [
+                    "registry@uro-oncology.org"
+                ],
+                "description": "https://www.uro-oncology.org/about-the-collaborative"
+            },
+            "funders": "Prostate Cancer Foundation\nMedical Research Council",
+            "populationSize": 5820,
+            "keywords": [
+                "Prostate",
+                "Cancer",
+                "Active Surveillance",
+                "PSA",
+                "mpMRI"
+            ],
+            "doiName": "10.6000/data.55",
+            "contactPoint": "data-requests@uro-oncology.org",
+            "datasetAliases": [
+                "PCa Active Surveillance Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data monitoring disease progression in men with low-risk localized prostate cancer managed through active surveillance. Includes longitudinal PSA kinetics and multiparametric MRI findings. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://uro-oncology.org/documents/surveillance_protocol_v2.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 50,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://uro-oncology.org/data-quality/completeness-report"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Biannual",
+                "startDate": "2016-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-06-30",
+                "distributionReleaseDate": "2023-12-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Clinical Encounters",
+                "measuredValue": 34920,
+                "observationDate": "2023-06-30",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 70
+                },
+                {
+                    "bin": "Black or Black British - Caribbean",
+                    "count": 16
+                },
+                {
+                    "bin": "Black or Black British - African",
+                    "count": 7
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 3
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 1
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 0
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "04_000",
+                "projectGrantName": "Predictors of Reclassification in Prostate Cancer",
+                "leadResearcher": "Dr. Marcus Thorne",
+                "leadResearchInstitute": "Institute of Urological Sciences",
+                "grantNumber": "PCF-9982, MRC-443",
+                "projectGrantStartDate": "2017-04-01",
+                "projectGrantEndDate": "2024-03-31",
+                "projectGrantScope": "mpMRI images, repeat biopsy pathology reports, and PSA density calculations"
+            }
+        ],
+        "erd": "https://github.com/UroOncology/pca_registry/blob/main/database_schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Biomarker_Tracking",
+                    "description": "Longitudinal records of blood and urine biomarkers",
+                    "columns": [
+                        {
+                            "name": "psa_levels",
+                            "dataType": "list",
+                            "description": "list of timestamped Prostate-Specific Antigen (ng/mL) values",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[PSA_Velocity_High]",
+                                    "description": "PSA velocity exceeding 0.35 ng/mL/year",
+                                    "frequency": 850
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 5820
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://uro-oncology.org/datasets/synthetic_pca"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Multiparametric MRI",
+                "description": "T2-weighted, diffusion-weighted, and dynamic contrast-enhanced prostate imaging",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Prostate Cancer Audit",
+                    "pid": "NPCA-02",
+                    "url": "https://healthdatagateway.org/en/dataset/811"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/j.eururo.2021.10.022"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/j.eururo.2021.10.023"
+            ],
+            "tools": [
+                "https://github.com/topics/prostate-mri-segmentation"
+            ],
+            "investigations": [
+                "UOC-304-Imaging"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/j.eururo.2020.05.014",
+                    "title": "Localized Prostate Cancer Treatment Outcomes",
+                    "pid": "LPCTO-91"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Transcriptome Profiling",
+            "platform": "Affymetrix Human Transcriptome Array 2.0"
+        },
+        "icons": [
+            "Longitudinal Data",
+            "Imaging"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_11_1",
+                "label": "C61 Prostate gland",
+                "category": "C60-C63 Male genital organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_3",
+                "label": "8140/3 Adenocarcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_9",
+                "label": "not available at present",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_1_4",
+                "label": "Kidney function tests",
+                "category": "Biopsy Reports and Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_1_2_2",
+                "label": "Medication",
+                "category": "Treatment",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4",
+                "label": "Techniques",
+                "category": "dataType",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_05.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_05.json
@@ -1,0 +1,236 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b0",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b0",
+            "issued": "2020-03-01T00:00:00Z",
+            "modified": "2024-09-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.skincancerinstitute.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b0"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Melanoma Immunotherapy Response and Single-Cell Profiling Cohort",
+            "abstract": "Registry data evaluating the tumor microenvironment changes in patients with advanced melanoma undergoing immune checkpoint blockade therapy.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/022333f66",
+                "name": "Institute of Skin Cancer Research",
+                "logo": "https://www.skincancerinstitute.org/images/logo.png",
+                "contactPoint": [
+                    "data-access@skincancerinstitute.org"
+                ],
+                "description": "https://www.skincancerinstitute.org/about"
+            },
+            "funders": "Melanoma Research Alliance\nCancer Research Institute",
+            "populationSize": 980,
+            "keywords": [
+                "Melanoma",
+                "Immunotherapy",
+                "Single-cell",
+                "Tumor Microenvironment",
+                "Response"
+            ],
+            "doiName": "10.7000/data.66",
+            "contactPoint": "registry@skincancerinstitute.org",
+            "datasetAliases": [
+                "Melanoma Immune Response Registry"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data evaluating the tumor microenvironment changes in patients with advanced melanoma undergoing immune checkpoint blockade therapy. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://skincancerinstitute.org/documents/scRNAseq_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 25,
+            "typicalAgeRangeMax": 95,
+            "datasetCompleteness": "https://skincancerinstitute.org/melanoma/data-metrics"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2020-03-01",
+                "timeLag": "6 months",
+                "endDate": "2024-03-01",
+                "distributionReleaseDate": "2024-09-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Tissue Biopsies",
+                "measuredValue": 2940,
+                "observationDate": "2024-03-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 76
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 12
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 6
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 3
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 1
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 1
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "05_000",
+                "projectGrantName": "Single-Cell Mapping of Immune Checkpoint Resistance",
+                "leadResearcher": "Dr. Clara Lin",
+                "leadResearchInstitute": "Institute of Skin Cancer Research",
+                "grantNumber": "MRA-112, CRI-445",
+                "projectGrantStartDate": "2020-05-01",
+                "projectGrantEndDate": "2025-04-30",
+                "projectGrantScope": "scRNA-seq data, pre- and post-treatment imaging, and clinical progression logs"
+            }
+        ],
+        "erd": "https://github.com/SkinCancerInstitute/melanoma_registry/blob/main/schema/erd.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Treatment_Toxicity",
+                    "description": "Records of immune-related adverse events during therapy",
+                    "columns": [
+                        {
+                            "name": "adverse_events",
+                            "dataType": "list",
+                            "description": "list of CTCAE graded immune-related adverse events",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Colitis_Grade_3]",
+                                    "description": "Severe immune-mediated colitis",
+                                    "frequency": 85
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 980
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://skincancerinstitute.org/datasets/synthetic_melanoma"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Multiplex Immunofluorescence",
+                "description": "Spatial imaging of T-cell infiltration in tumor sections",
+                "format": "OME-TIFF"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Skin Cancer Database",
+                    "pid": "NSCD-05",
+                    "url": "https://healthdatagateway.org/en/dataset/552"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1038/s41591-022-01992-w"
+            ],
+            "publicationAboutDataset": [
+                "10.1038/s41591-022-01993-x"
+            ],
+            "tools": [
+                "https://github.com/topics/scrnaseq-tumor-microenvironment"
+            ],
+            "investigations": [
+                "ISCR-402-Spatial"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1038/s41591-021-01324-y",
+                    "title": "Advanced Melanoma Genomics",
+                    "pid": "AMG-33"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Single-cell RNA sequencing",
+            "platform": "10x Genomics Chromium"
+        },
+        "icons": [
+            "Immunology",
+            "Transcriptomics"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_5",
+                "label": "C44 Skin",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_15_2",
+                "label": "8720/3 Malignant melanoma, NOS",
+                "category": "872-879 Nevi and melanomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_8",
+                "label": "generally available for UK/EU use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "International collaborations outside the EU not generally permitted."
+            },
+            {
+                "id": "0_2_2_0",
+                "label": "Organism",
+                "category": "Model Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_4_4",
+                "label": "Radiotherapies",
+                "category": "Treatments",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_1_8",
+                "label": "Urine tests",
+                "category": "Biopsy Reports and Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_6",
+                "label": "Saccharomyces cerevisiae",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_06.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_06.json
@@ -1,0 +1,229 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b1",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b1",
+            "issued": "2021-01-01T00:00:00Z",
+            "modified": "2024-04-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.womensneoplasm.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b1"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Ovarian Cancer Organoid and Chemoresistance Cohort",
+            "abstract": "Registry data linking clinical chemotherapy response in high-grade serous ovarian cancer to drug screening results derived from patient-derived organoids.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/011222g77",
+                "name": "Women's Neoplasm Consortium",
+                "logo": "https://www.womensneoplasm.org/assets/brand.png",
+                "contactPoint": [
+                    "data-hub@womensneoplasm.org"
+                ],
+                "description": "https://www.womensneoplasm.org/about-us"
+            },
+            "funders": "Ovarian Cancer Action\nNational Institutes of Health",
+            "populationSize": 640,
+            "keywords": [
+                "Ovarian",
+                "Cancer",
+                "Organoids",
+                "Chemoresistance",
+                "PARP"
+            ],
+            "doiName": "10.8000/data.11",
+            "contactPoint": "requests@womensneoplasm.org",
+            "datasetAliases": [
+                "HGSOC Organoid Registry"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data linking clinical chemotherapy response in high-grade serous ovarian cancer to drug screening results derived from patient-derived organoids. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://womensneoplasm.org/docs/organoid_culture_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 30,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://womensneoplasm.org/cohorts/hgsoc-completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Biannual",
+                "startDate": "2021-01-01",
+                "timeLag": "3 months",
+                "endDate": "2024-01-01",
+                "distributionReleaseDate": "2024-04-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Organoid Lines",
+                "measuredValue": 1280,
+                "observationDate": "2024-01-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 75
+                },
+                {
+                    "bin": "Asian or Asian British - Indian",
+                    "count": 9
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 6
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 6
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 1
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 1
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "06_000",
+                "projectGrantName": "Organoid Modeling for PARP Inhibitor Resistance",
+                "leadResearcher": "Dr. Amina Patel",
+                "leadResearchInstitute": "Institute of Gynecological Oncology",
+                "grantNumber": "OCA-990, NIH-R01-443",
+                "projectGrantStartDate": "2021-03-01",
+                "projectGrantEndDate": "2026-02-28",
+                "projectGrantScope": "drug screening viability data, genomic profiles, and clinical response logs"
+            }
+        ],
+        "erd": "https://github.com/WomensNeoplasm/organoid_db/blob/main/docs/erd.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Drug_Screening",
+                    "description": "IC50 values and viability metrics for various chemotherapy agents",
+                    "columns": [
+                        {
+                            "name": "parp_ic50",
+                            "dataType": "list",
+                            "description": "list of IC50 values (nM) for Olaparib and Niraparib",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[High_Resistance]",
+                                    "description": "IC50 exceeding standard clinical concentration",
+                                    "frequency": 140
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 640
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://womensneoplasm.org/datasets/synthetic_hgsoc"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Brightfield Microscopy Images",
+                "description": "Time-lapse imaging of organoid growth and drug response",
+                "format": "TIFF"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Gynecological Tumor Registry",
+                    "pid": "NGTR-03",
+                    "url": "https://healthdatagateway.org/en/dataset/633"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/j.ygyno.2023.01.015"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/j.ygyno.2023.01.016"
+            ],
+            "tools": [
+                "https://github.com/topics/organoid-image-analysis"
+            ],
+            "investigations": [
+                "WNC-2021-Screening"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/j.ygyno.2022.08.005",
+                    "title": "Advanced Ovarian Cancer Clinical Trials",
+                    "pid": "AOC-CT"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Whole Genome Sequencing",
+            "platform": "PacBio Revio"
+        },
+        "icons": [
+            "Preclinical Models",
+            "Genomics"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_10_5",
+                "label": "C56 Ovary",
+                "category": "C51-C58 Female genital organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_8_3",
+                "label": "8441/3 Serous carcinoma, NOS",
+                "category": "844-849 Cystic, mucinous and serous neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_0",
+                "label": "no restriction",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "No restriction on use. (DUO_0000004)"
+            },
+            {
+                "id": "0_2_3_4_3",
+                "label": "Phase 3",
+                "category": "Clinical Trial",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_4_1",
+                "label": "Cell and cell-derived treatments",
+                "category": "Treatments",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_2_0",
+                "label": "Biomarkers",
+                "category": "Biopsy & Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_07.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_07.json
@@ -1,0 +1,229 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b2",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b2",
+            "issued": "2018-06-01T00:00:00Z",
+            "modified": "2023-12-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.pediatriconcology.net/datasets/087654b3-2c0a-4b32-9c2e-1234567890b2"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Acute Myeloid Leukemia Pediatric Relapse Registry",
+            "abstract": "Registry data tracking post-remission relapse patterns in pediatric acute myeloid leukemia. Includes flow cytometry minimal residual disease assessments.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/033444h88",
+                "name": "Global Pediatric Oncology Network",
+                "logo": "https://www.pediatriconcology.net/logo.png",
+                "contactPoint": [
+                    "data@pediatriconcology.net"
+                ],
+                "description": "https://www.pediatriconcology.net/mission"
+            },
+            "funders": "Leukemia & Lymphoma Society\nChildren's Cancer Research Fund",
+            "populationSize": 1850,
+            "keywords": [
+                "Leukemia",
+                "Pediatric",
+                "AML",
+                "Relapse",
+                "Flow Cytometry"
+            ],
+            "doiName": "10.9000/data.22",
+            "contactPoint": "access@pediatriconcology.net",
+            "datasetAliases": [
+                "Pediatric AML Relapse Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking post-remission relapse patterns in pediatric acute myeloid leukemia. Includes flow cytometry minimal residual disease assessments. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://pediatriconcology.net/docs/mrd_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 0,
+            "typicalAgeRangeMax": 18,
+            "datasetCompleteness": "https://pediatriconcology.net/aml/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-06-01",
+                "timeLag": "6 months",
+                "endDate": "2023-06-01",
+                "distributionReleaseDate": "2023-12-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Bone Marrow Aspirates",
+                "measuredValue": 5550,
+                "observationDate": "2023-06-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 48
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 16
+                },
+                {
+                    "bin": "Asian or Asian British - Pakistani",
+                    "count": 13
+                },
+                {
+                    "bin": "Black or Black British - African",
+                    "count": 10
+                },
+                {
+                    "bin": "Mixed - White and Black African",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "07_000",
+                "projectGrantName": "MRD Tracking in Pediatric AML",
+                "leadResearcher": "Dr. Samira Khan",
+                "leadResearchInstitute": "Children's Institute of Oncology",
+                "grantNumber": "LLS-776, CCRF-221",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "flow cytometry files, cytogenetic profiles, and longitudinal treatment logs"
+            }
+        ],
+        "erd": "https://github.com/PediatricOncology/aml_registry/blob/main/assets/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Minimal_Residual_Disease",
+                    "description": "Longitudinal flow cytometry assessments for residual leukemic blasts",
+                    "columns": [
+                        {
+                            "name": "mrd_status",
+                            "dataType": "list",
+                            "description": "list of categorical and quantitative MRD assessments",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[MRD_Positive]",
+                                    "description": "Residual disease greater than 0.1%",
+                                    "frequency": 420
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 1850
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://pediatriconcology.net/datasets/synthetic_aml"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Multiparameter Flow Cytometry",
+                "description": "Raw FCS files capturing surface marker expression on bone marrow cells",
+                "format": "FCS"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Childhood Cancer Registry",
+                    "pid": "NCCR-08",
+                    "url": "https://healthdatagateway.org/en/dataset/229"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1200/JCO.2022.40.15_suppl.1001"
+            ],
+            "publicationAboutDataset": [
+                "10.1200/JCO.2022.40.15_suppl.1002"
+            ],
+            "tools": [
+                "https://github.com/topics/flow-cytometry-analysis"
+            ],
+            "investigations": [
+                "GPON-109-SubA"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1200/JCO.2021.39.12_suppl.88",
+                    "title": "Pediatric ALL MRD Registry",
+                    "pid": "PALL-MRD"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Whole Transcriptome Sequencing",
+            "platform": "Illumina NextSeq 2000"
+        },
+        "icons": [
+            "Pediatrics",
+            "Hematology"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_4",
+                "label": "C42 Hematopoietic and reticuloendothelial systems",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_45_28",
+                "label": "9861/3 Acute myeloid leukemia, NOS",
+                "category": "980-994 Leukemias",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_4",
+                "label": "not for profit organisation use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": " Limited to not-for-profit organizations.(DUO_0000045)"
+            },
+            {
+                "id": "0_2_2",
+                "label": "Model Organism",
+                "category": "dataType",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_2_0",
+                "label": "bulk",
+                "category": "Spatial resolution",
+                "primaryGroup": "Multi-omic Data",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_2_2",
+                "label": "Magnetic Resonance Imaging",
+                "category": "Imaging Data",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_08.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_08.json
@@ -1,0 +1,225 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b3",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b3",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.globalliver.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b3"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Hepatocellular Carcinoma TACE Response Registry",
+            "abstract": "Registry data evaluating the efficacy and tumor response rates of transarterial chemoembolization in patients with intermediate-stage hepatocellular carcinoma.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/099777k66",
+                "name": "Global Liver Institute",
+                "logo": "https://www.globalliver.org/assets/logo.png",
+                "contactPoint": [
+                    "data-hub@globalliver.org"
+                ],
+                "description": "https://www.globalliver.org/about"
+            },
+            "funders": "Liver Cancer Foundation\nNational Institutes of Health",
+            "populationSize": 2150,
+            "keywords": [
+                "Liver",
+                "Cancer",
+                "HCC",
+                "TACE",
+                "Interventional Radiology"
+            ],
+            "doiName": "10.1200/data.77",
+            "contactPoint": "registry@globalliver.org",
+            "datasetAliases": [
+                "HCC Embolization Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data evaluating the efficacy and tumor response rates of transarterial chemoembolization in patients with intermediate-stage hepatocellular carcinoma. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://globalliver.org/protocols/tace_registry.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 40,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://globalliver.org/hcc/metrics"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Interventional Procedures",
+                "measuredValue": 4300,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "Asian or Asian British - Chinese",
+                    "count": 44
+                },
+                {
+                    "bin": "White - British",
+                    "count": 32
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 11
+                },
+                {
+                    "bin": "Asian or Asian British - Indian",
+                    "count": 6
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 4
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "08_000",
+                "projectGrantName": "Predictors of Complete Response Post-TACE",
+                "leadResearcher": "Dr. Wei Chen",
+                "leadResearchInstitute": "Hepatic Oncology Center",
+                "grantNumber": "LCF-881, NIH-R01-554",
+                "projectGrantStartDate": "2019-04-01",
+                "projectGrantEndDate": "2024-03-31",
+                "projectGrantScope": "Post-procedure MRI, alpha-fetoprotein kinetics, and survival data"
+            }
+        ],
+        "erd": "https://github.com/GlobalLiver/hcc_db/blob/main/docs/erd.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Tumor_Response",
+                    "description": "mRECIST criteria measurements post-procedure",
+                    "columns": [
+                        {
+                            "name": "mrecist_status",
+                            "dataType": "list",
+                            "description": "list of categorical modified RECIST assessment outcomes",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Objective_Response]",
+                                    "description": "Complete or partial response per mRECIST",
+                                    "frequency": 1200
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 2150
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://globalliver.org/datasets/synthetic_hcc"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Hepatic Arteriograms",
+                "description": "Digital subtraction angiography (DSA) images captured during TACE",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Hepatobiliary Tumor Audit",
+                    "pid": "NHTA-01",
+                    "url": "https://healthdatagateway.org/en/dataset/505"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/j.jhep.2022.11.021"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/j.jhep.2022.11.022"
+            ],
+            "tools": [
+                "https://github.com/topics/hcc-radiomics"
+            ],
+            "investigations": [
+                "GLI-202-TACE"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/j.jhep.2021.04.015",
+                    "title": "Advanced HCC Systemic Therapy Registry",
+                    "pid": "AHCC-SYS"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Circulating Tumor DNA Sequencing",
+            "platform": "Guardant360"
+        },
+        "icons": [
+            "Interventional Radiology",
+            "Clinical Data"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_1_7",
+                "label": "C22 Liver and intrahepatic bile ducts",
+                "category": "C15-C26 Digestive organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_34",
+                "label": "8170/3 Hepatocellular carcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_5",
+                "label": "non-commercial use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to not-for-profit use.(DUO_0000046)"
+            },
+            {
+                "id": "0_2_0_1_1",
+                "label": "Normal",
+                "category": "State",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_3_1",
+                "label": "Clinical observations",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_1_2",
+                "label": "Pre-cancerous",
+                "category": "State",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_09.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_09.json
@@ -1,0 +1,232 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b4",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b4",
+            "issued": "2015-05-01T00:00:00Z",
+            "modified": "2024-02-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.endocrineoncology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b4"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Thyroid Cancer Genomic and Follow-up Cohort",
+            "abstract": "Registry data tracking recurrence and genomic markers in papillary thyroid carcinoma post-thyroidectomy and radioiodine ablation.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/088888m77",
+                "name": "Endocrine Oncology Group",
+                "logo": "https://www.endocrineoncology.org/brand.png",
+                "contactPoint": [
+                    "data@endocrineoncology.org"
+                ],
+                "description": "https://www.endocrineoncology.org/about"
+            },
+            "funders": "Thyroid Cancer Trust\nMedical Research Council",
+            "populationSize": 3120,
+            "keywords": [
+                "Thyroid",
+                "Cancer",
+                "Papillary",
+                "Genomics",
+                "Radioiodine"
+            ],
+            "doiName": "10.1300/data.99",
+            "contactPoint": "registry@endocrineoncology.org",
+            "datasetAliases": [
+                "PTC Genomic Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking recurrence and genomic markers in papillary thyroid carcinoma post-thyroidectomy and radioiodine ablation. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://endocrineoncology.org/docs/ptc_registry.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 20,
+            "typicalAgeRangeMax": 80,
+            "datasetCompleteness": "https://endocrineoncology.org/thyroid/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Biannual",
+                "startDate": "2015-05-01",
+                "timeLag": "3 months",
+                "endDate": "2023-11-30",
+                "distributionReleaseDate": "2024-02-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Patients",
+                "measuredValue": 3120,
+                "observationDate": "2023-11-30",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 67
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 19
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 6
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 3
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 3
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "09_000",
+                "projectGrantName": "BRAF Mutations in Thyroid Cancer Recurrence",
+                "leadResearcher": "Dr. Thomas Silva",
+                "leadResearchInstitute": "Institute of Endocrine Sciences",
+                "grantNumber": "TCT-234, MRC-889",
+                "projectGrantStartDate": "2016-01-01",
+                "projectGrantEndDate": "2023-12-31",
+                "projectGrantScope": "Surgical pathology reports, sequencing data, and longitudinal thyroglobulin levels"
+            }
+        ],
+        "erd": "https://github.com/EndocrineOncology/ptc_db/blob/main/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Molecular_Pathology",
+                    "description": "Somatic mutation profiles from resected thyroid nodules",
+                    "columns": [
+                        {
+                            "name": "braf_status",
+                            "dataType": "list",
+                            "description": "list of identified BRAF point mutations",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[V600E]",
+                                    "description": "Valine to glutamic acid substitution at codon 600",
+                                    "frequency": 1450
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 3120
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://endocrineoncology.org/datasets/synthetic_ptc"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Neck Ultrasound Scans",
+                "description": "High-resolution sonograms of the thyroid bed and cervical lymph nodes",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Endocrine Tumor Audit",
+                    "pid": "NETA-04",
+                    "url": "https://healthdatagateway.org/en/dataset/772"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1210/clinem/dgab112"
+            ],
+            "publicationAboutDataset": [
+                "10.1210/clinem/dgab113"
+            ],
+            "tools": [
+                "https://github.com/topics/thyroid-nodule-classification"
+            ],
+            "investigations": [
+                "EOG-505-Sub1"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1210/clinem/dgaa099",
+                    "title": "Medullary Thyroid Carcinoma Database",
+                    "pid": "MTC-DB"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Targeted Gene Panel",
+            "platform": "Illumina MiSeq"
+        },
+        "icons": [
+            "Endocrinology",
+            "Genomics"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_14",
+                "label": "C73-C75 Thyroid and other endocrine glands",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_2_2",
+                "label": "8050/3 Papillary carcinoma, NOS",
+                "category": "805-808 Squamous cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_5",
+                "label": "non-commercial use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to not-for-profit use.(DUO_0000046)"
+            },
+            {
+                "id": "0_2_3_2_0",
+                "label": "Patient-Reported Outcomes",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_4",
+                "label": "Rabbit",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_3",
+                "label": "Mechanobiology",
+                "category": "Techniques",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_0_3",
+                "label": "Other Fluids - eg urine",
+                "category": "Material type",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_10.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_10.json
@@ -1,0 +1,239 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b5",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b5",
+            "issued": "2018-08-01T00:00:00Z",
+            "modified": "2024-02-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.kidneyoncology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b5"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Renal Cell Carcinoma Immunotherapy Efficacy Cohort",
+            "abstract": "Registry data analyzing the durable response rates of combination immune checkpoint inhibitors in metastatic clear cell renal cell carcinoma.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/034876a12",
+                "name": "Kidney Oncology Network",
+                "logo": "https://www.kidneyoncology.org/assets/logo.png",
+                "contactPoint": [
+                    "data-hub@kidneyoncology.org"
+                ],
+                "description": "https://www.kidneyoncology.org/about-us"
+            },
+            "funders": "Kidney Cancer Association\nNational Institutes of Health",
+            "populationSize": 1890,
+            "keywords": [
+                "Kidney",
+                "Cancer",
+                "RCC",
+                "Immunotherapy",
+                "Metastatic"
+            ],
+            "doiName": "10.1400/data.51",
+            "contactPoint": "registry@kidneyoncology.org",
+            "datasetAliases": [
+                "Metastatic ccRCC IO Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data analyzing the durable response rates of combination immune checkpoint inhibitors in metastatic clear cell renal cell carcinoma. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://kidneyoncology.org/protocols/io_efficacy_registry.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 40,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://kidneyoncology.org/rcc/completeness-metrics"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-08-01",
+                "timeLag": "6 months",
+                "endDate": "2023-08-01",
+                "distributionReleaseDate": "2024-02-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Patients",
+                "measuredValue": 1890,
+                "observationDate": "2023-08-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 63
+                },
+                {
+                    "bin": "White - Any other White background",
+                    "count": 15
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 10
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 7
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 2
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "10_000",
+                "projectGrantName": "Biomarkers of Response in IO-Treated ccRCC",
+                "leadResearcher": "Dr. Martin Fischer",
+                "leadResearchInstitute": "Institute of Urologic Oncology",
+                "grantNumber": "KCA-291, NIH-R01-884",
+                "projectGrantStartDate": "2019-02-01",
+                "projectGrantEndDate": "2024-01-31",
+                "projectGrantScope": "Treatment timelines, baseline tumor mutational burden, and survival logs"
+            }
+        ],
+        "erd": "https://github.com/KidneyOncology/ccrcc_db/blob/main/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Adverse_Events",
+                    "description": "Records of immune-related adverse events requiring systemic steroids",
+                    "columns": [
+                        {
+                            "name": "iraes",
+                            "dataType": "list",
+                            "description": "list of CTCAE graded autoimmune toxicities",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Pneumonitis_Grade_2]",
+                                    "description": "Symptomatic pulmonary inflammation",
+                                    "frequency": 115
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 1890
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://kidneyoncology.org/datasets/synthetic_ccrcc"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Abdominal MRI Scans",
+                "description": "Baseline and longitudinal multiparametric MRI of renal masses",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Urologic Cancer Registry",
+                    "pid": "NUCR-09",
+                    "url": "https://healthdatagateway.org/en/dataset/881"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/j.eururo.2023.04.011"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/j.eururo.2023.04.012"
+            ],
+            "tools": [
+                "https://github.com/topics/ccrcc-response-prediction"
+            ],
+            "investigations": [
+                "KON-771-SubA"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/j.eururo.2022.02.015",
+                    "title": "Advanced Renal Cell Carcinoma TKI Registry",
+                    "pid": "ARCC-TKI"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Whole Exome Sequencing",
+            "platform": "Illumina NovaSeq 6000"
+        },
+        "icons": [
+            "Immunology",
+            "Clinical Trials"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_12",
+                "label": "C64-C68 Urinary tract",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_108",
+                "label": "8312/3 Renal cell carcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_7",
+                "label": "return to database or resource",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Requestor must return derived/enriched data to the database/resource.(DUO_0000029)"
+            },
+            {
+                "id": "0_2_1_0_0",
+                "label": "Organ on a Chip",
+                "category": "Model",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_2_2",
+                "label": "spatial",
+                "category": "Spatial resolution",
+                "primaryGroup": "Multi-omic Data",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_1_1",
+                "label": "Liquid Biopsy",
+                "category": "Source",
+                "primaryGroup": "Multi-omic Data",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_3_1",
+                "label": "Clinical observations",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_1_0",
+                "label": "Malignant",
+                "category": "State",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_11.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_11.json
@@ -1,0 +1,232 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b6",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b6",
+            "issued": "2020-06-01T00:00:00Z",
+            "modified": "2024-09-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://www.myelomaresearch.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b6"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Multiple Myeloma Bone Marrow Microenvironment Cohort",
+            "abstract": "Registry data tracking bone marrow microenvironment changes and measurable residual disease in patients undergoing CAR-T cell therapy for relapsed/refractory multiple myeloma.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/033mm4455",
+                "name": "Myeloma Research Institute",
+                "logo": "https://www.myelomaresearch.org/assets/logo.png",
+                "contactPoint": [
+                    "data@myelomaresearch.org"
+                ],
+                "description": "https://www.myelomaresearch.org/about-us"
+            },
+            "funders": "International Myeloma Foundation\nMedical Research Council",
+            "populationSize": 850,
+            "keywords": [
+                "Multiple Myeloma",
+                "Bone Marrow",
+                "Microenvironment",
+                "CAR-T",
+                "MRD"
+            ],
+            "doiName": "10.1500/data.62",
+            "contactPoint": "access@myelomaresearch.org",
+            "datasetAliases": [
+                "Relapsed Myeloma CAR-T Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking bone marrow microenvironment changes and measurable residual disease in patients undergoing CAR-T cell therapy for relapsed/refractory multiple myeloma. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://myelomaresearch.org/protocols/bone_marrow_sampling.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 45,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://myelomaresearch.org/cohorts/completeness-metrics"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Biannual",
+                "startDate": "2020-06-01",
+                "timeLag": "3 months",
+                "endDate": "2024-06-01",
+                "distributionReleaseDate": "2024-09-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Bone Marrow Aspirates",
+                "measuredValue": 2550,
+                "observationDate": "2024-06-01",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 58
+                },
+                {
+                    "bin": "Black or Black British - African",
+                    "count": 17
+                },
+                {
+                    "bin": "Black or Black British - Caribbean",
+                    "count": 11
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 5
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "11_000",
+                "projectGrantName": "Microenvironmental Drivers of CAR-T Resistance",
+                "leadResearcher": "Dr. Hannah Brooks",
+                "leadResearchInstitute": "Institute of Hematologic Oncology",
+                "grantNumber": "IMF-332, MRC-771",
+                "projectGrantStartDate": "2020-09-01",
+                "projectGrantEndDate": "2025-08-31",
+                "projectGrantScope": "scRNA-seq data, flow cytometry logs, and clinical survival tracking"
+            }
+        ],
+        "erd": "https://github.com/MyelomaResearch/mrd_db/blob/main/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Flow_Cytometry_MRD",
+                    "description": "Longitudinal assessments of measurable residual disease post-infusion",
+                    "columns": [
+                        {
+                            "name": "mrd_status",
+                            "dataType": "list",
+                            "description": "list of quantitative MRD levels (cells per million)",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[MRD_Negative_10e5]",
+                                    "description": "Less than one myeloma cell per 100,000 bone marrow cells",
+                                    "frequency": 340
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 850
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://myelomaresearch.org/datasets/synthetic_mm"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Whole Body PET-CT",
+                "description": "Metabolic imaging to assess extramedullary disease burden",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Hematology Registry",
+                    "pid": "NHR-11",
+                    "url": "https://healthdatagateway.org/en/dataset/902"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1182/blood.2023019882"
+            ],
+            "publicationAboutDataset": [
+                "10.1182/blood.2023019883"
+            ],
+            "tools": [
+                "https://github.com/topics/multiple-myeloma-mrd"
+            ],
+            "investigations": [
+                "MRI-882-Phase1"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1182/blood.2022015544",
+                    "title": "Newly Diagnosed Myeloma Genomics",
+                    "pid": "NDMM-GEN"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Single-cell RNA sequencing",
+            "platform": "10x Genomics Chromium"
+        },
+        "icons": [
+            "Hematology",
+            "Cellular Therapy"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_4",
+                "label": "C42 Hematopoietic and reticuloendothelial systems",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_41_1",
+                "label": "9732/3 Plasma cell myeloma",
+                "category": "973 Plasma cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_8",
+                "label": "generally available for UK/EU use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "International collaborations outside the EU not generally permitted."
+            },
+            {
+                "id": "0_2_4_4_0_0",
+                "label": "Epigenomics",
+                "category": "Biological molecules (eg DNA)",
+                "primaryGroup": "Multi-omic Data",
+                "description": "chemical modifications to DNA/histones"
+            },
+            {
+                "id": "0_2_3_2_3",
+                "label": "Survival data",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_2_2",
+                "label": "Side effects",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_0_3",
+                "label": "Metagenomics",
+                "category": "Biological molecules (eg DNA)",
+                "primaryGroup": "Multi-omic Data",
+                "description": "genetic material from multiple organisms (usually microbes) living together"
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_12.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_12.json
@@ -1,0 +1,239 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b7",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b7",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://gi-oncology.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b7"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Gastric Cancer Microbiome and Immunity Cohort",
+            "abstract": "Registry data linking H. pylori eradication therapy outcomes to tumor microenvironment changes in gastric adenocarcinoma.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/01gastric",
+                "name": "Gastrointestinal Oncology Group",
+                "logo": "https://gi-oncology.org/logo.png",
+                "contactPoint": [
+                    "data@gi-oncology.org"
+                ],
+                "description": "https://gi-oncology.org/about"
+            },
+            "funders": "Cancer Research UK\nMedical Research Council",
+            "populationSize": 1500,
+            "keywords": [
+                "Gastric",
+                "Cancer",
+                "Microbiome",
+                "Immunity",
+                "H. pylori"
+            ],
+            "doiName": "10.2001/data.01",
+            "contactPoint": "data@gi-oncology.org",
+            "datasetAliases": [
+                "Stomach Cancer Microenvironment"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data linking H. pylori eradication therapy outcomes to tumor microenvironment changes in gastric adenocarcinoma. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://gi-oncology.org/gastric_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 40,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://gi-oncology.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Endoscopies",
+                "measuredValue": 4500,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 15
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "12_000",
+                "projectGrantName": "Gastric Microbiome Signatures",
+                "leadResearcher": "Dr. A. Chen",
+                "leadResearchInstitute": "GI Institute",
+                "grantNumber": "MRC-111",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "Endoscopy reports and 16S sequencing"
+            }
+        ],
+        "erd": "https://github.com/gi-onc/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Endoscopy_Logs",
+                    "description": "Lesion size and location",
+                    "columns": [
+                        {
+                            "name": "h_pylori_status",
+                            "dataType": "list",
+                            "description": "list of categorical infection statuses",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Positive]",
+                                    "description": "Active H. pylori infection confirmed",
+                                    "frequency": 800
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 1500
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://gi-oncology.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Endoscopic Ultrasound",
+                "description": "Staging images",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National GI Database",
+                    "pid": "NGID-01",
+                    "url": "https://hdg.org/dataset/01"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/gastric.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/gastric.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/gastric"
+            ],
+            "investigations": [
+                "GI-101-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/gastric.2022",
+                    "title": "Esophageal Adenocarcinoma Cohort",
+                    "pid": "EAC-01"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "16S rRNA sequencing",
+            "platform": "Illumina MiSeq"
+        },
+        "icons": [
+            "Microbiome",
+            "Endoscopy"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_1_1",
+                "label": "C16 Stomach",
+                "category": "C15-C26 Digestive organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_3",
+                "label": "8140/3 Adenocarcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_5",
+                "label": "non-commercial use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to not-for-profit use.(DUO_0000046)"
+            },
+            {
+                "id": "0_2_1_2_1",
+                "label": "Gene knock-down",
+                "category": "Treatment",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_4_4",
+                "label": "Phase 4",
+                "category": "Clinical Trial",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_0_6",
+                "label": "Other - eg swab",
+                "category": "Material type",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_0_3",
+                "label": "Other Fluids - eg urine",
+                "category": "Material type",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_3_2",
+                "label": "Radiotherapies",
+                "category": "Treatments",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_13.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_13.json
@@ -1,0 +1,232 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b8",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b8",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://whrc.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b8"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Cervical Cancer HPV Integration Cohort",
+            "abstract": "Registry data monitoring viral integration sites and genomic instability in high-risk HPV-associated cervical carcinomas.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/02cervical",
+                "name": "Women's Health Research Center",
+                "logo": "https://whrc.org/logo.png",
+                "contactPoint": [
+                    "access@whrc.org"
+                ],
+                "description": "https://whrc.org/about"
+            },
+            "funders": "Wellcome Trust",
+            "populationSize": 2200,
+            "keywords": [
+                "Cervical",
+                "Cancer",
+                "HPV",
+                "Integration",
+                "Genomics"
+            ],
+            "doiName": "10.2001/data.02",
+            "contactPoint": "access@whrc.org",
+            "datasetAliases": [
+                "HPV Cervical Registry"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data monitoring viral integration sites and genomic instability in high-risk HPV-associated cervical carcinomas. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://whrc.org/hpv_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 25,
+            "typicalAgeRangeMax": 75,
+            "datasetCompleteness": "https://whrc.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Pap Smears",
+                "measuredValue": 8800,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 15
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "13_000",
+                "projectGrantName": "HPV Integration and Oncogenesis",
+                "leadResearcher": "Dr. M. Garcia",
+                "leadResearchInstitute": "Women's Health Institute",
+                "grantNumber": "WT-222",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "Cytology and genomic sequence data"
+            }
+        ],
+        "erd": "https://github.com/whrc/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Viral_Genomics",
+                    "description": "HPV genotype and integration coordinates",
+                    "columns": [
+                        {
+                            "name": "hpv_genotype",
+                            "dataType": "list",
+                            "description": "list of high-risk HPV types",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[HPV16]",
+                                    "description": "Human Papillomavirus type 16",
+                                    "frequency": 1400
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 2200
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://whrc.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Colposcopy Images",
+                "description": "Digital images of cervix post-acetic acid",
+                "format": "JPEG"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Cervical Screening",
+                    "pid": "NCS-02",
+                    "url": "https://hdg.org/dataset/02"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/cervical.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/cervical.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/hpv"
+            ],
+            "investigations": [
+                "WHRC-201-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/cervical.2022",
+                    "title": "Ovarian Cancer Early Detection",
+                    "pid": "OCED-02"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Whole Genome Sequencing",
+            "platform": "Illumina NovaSeq"
+        },
+        "icons": [
+            "Genomics",
+            "Screening"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_10_2",
+                "label": "C53 Cervix uteri",
+                "category": "C51-C58 Female genital organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_2_14",
+                "label": "8070/3 Squamous cell carcinoma, NOS",
+                "category": "805-808 Squamous cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_3",
+                "label": "ethics approval required",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "DUO_0000021"
+            },
+            {
+                "id": "0_2_4_6",
+                "label": "Spectroscopy",
+                "category": "Techniques",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_1_0",
+                "label": "Malignant",
+                "category": "State",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_0_1_1",
+                "label": "Indels",
+                "category": "Genomics",
+                "primaryGroup": "Biological molecules (eg DNA)",
+                "description": "small insertions or deletions"
+            },
+            {
+                "id": "0_2_2_0_0",
+                "label": "Chicken",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_14.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_14.json
@@ -1,0 +1,232 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890b9",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890b9",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://mho.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890b9"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Testicular Germ Cell Tumor Survivorship Database",
+            "abstract": "Registry data evaluating long-term cardiovascular and metabolic toxicities in survivors of platinum-treated testicular cancer.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/03testicular",
+                "name": "Men's Health Oncology",
+                "logo": "https://mho.org/logo.png",
+                "contactPoint": [
+                    "data@mho.org"
+                ],
+                "description": "https://mho.org/about"
+            },
+            "funders": "Movember Foundation",
+            "populationSize": 3100,
+            "keywords": [
+                "Testicular",
+                "Cancer",
+                "Survivorship",
+                "Toxicity",
+                "Platinum"
+            ],
+            "doiName": "10.2001/data.03",
+            "contactPoint": "data@mho.org",
+            "datasetAliases": [
+                "TGCT Survivor Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data evaluating long-term cardiovascular and metabolic toxicities in survivors of platinum-treated testicular cancer. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://mho.org/survivor_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 18,
+            "typicalAgeRangeMax": 55,
+            "datasetCompleteness": "https://mho.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Follow-up Visits",
+                "measuredValue": 15500,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 15
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "14_000",
+                "projectGrantName": "Platinum Toxicity Tracking",
+                "leadResearcher": "Dr. S. Wright",
+                "leadResearchInstitute": "Andrology Research Unit",
+                "grantNumber": "MOV-333",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "Audiometry, lipid panels, and treatment records"
+            }
+        ],
+        "erd": "https://github.com/mho/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Metabolic_Profiles",
+                    "description": "Longitudinal lipid and glucose measurements",
+                    "columns": [
+                        {
+                            "name": "metabolic_syndrome",
+                            "dataType": "list",
+                            "description": "list of diagnostic criteria met",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Hypertension]",
+                                    "description": "Elevated blood pressure post-therapy",
+                                    "frequency": 850
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 3100
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://mho.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Echocardiograms",
+                "description": "Cardiac function assessments",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Survivorship Registry",
+                    "pid": "NSR-03",
+                    "url": "https://hdg.org/dataset/03"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/tgct.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/tgct.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/survivorship"
+            ],
+            "investigations": [
+                "MHO-301-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/tgct.2022",
+                    "title": "Prostate Cancer Toxicity Cohort",
+                    "pid": "PCTC-03"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Targeted Gene Panel",
+            "platform": "Ion Torrent"
+        },
+        "icons": [
+            "Survivorship",
+            "Cardiology"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_11_2",
+                "label": "C62 Testis",
+                "category": "C60-C63 Male genital organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_25_1",
+                "label": "9061/3 Seminoma, NOS",
+                "category": "906-909 Germ cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_1",
+                "label": "research specific restrictions",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to studies of a certain research type (DUO_0000012)"
+            },
+            {
+                "id": "0_2_2_0_6",
+                "label": "Saccharomyces cerevisiae",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3",
+                "label": "Patient study",
+                "category": "dataType",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_3",
+                "label": "Treatments",
+                "category": "Patient study",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_4_0_0",
+                "label": "Epigenomics",
+                "category": "Biological molecules (eg DNA)",
+                "primaryGroup": "Multi-omic Data",
+                "description": "chemical modifications to DNA/histones"
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_15.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_15.json
@@ -1,0 +1,225 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890ba",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890ba",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://tgic.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890ba"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Esophageal Squamous Cell Carcinoma Biomarker Registry",
+            "abstract": "Registry data tracking the prognostic value of circulating tumor DNA in locally advanced esophageal squamous cell carcinoma treated with chemoradiation.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/04esophageal",
+                "name": "Thoracic and GI Consortium",
+                "logo": "https://tgic.org/logo.png",
+                "contactPoint": [
+                    "registry@tgic.org"
+                ],
+                "description": "https://tgic.org/about"
+            },
+            "funders": "Cancer Research UK",
+            "populationSize": 950,
+            "keywords": [
+                "Esophageal",
+                "Cancer",
+                "ESCC",
+                "ctDNA",
+                "Chemoradiation"
+            ],
+            "doiName": "10.2001/data.04",
+            "contactPoint": "registry@tgic.org",
+            "datasetAliases": [
+                "ESCC Liquid Biopsy Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data tracking the prognostic value of circulating tumor DNA in locally advanced esophageal squamous cell carcinoma treated with chemoradiation. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://tgic.org/escc_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 50,
+            "typicalAgeRangeMax": 80,
+            "datasetCompleteness": "https://tgic.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Blood Draws",
+                "measuredValue": 3800,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 14
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 4
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 4
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "15_000",
+                "projectGrantName": "ctDNA in Esophageal Cancer",
+                "leadResearcher": "Dr. L. Wang",
+                "leadResearchInstitute": "Thoracic Oncology Center",
+                "grantNumber": "CRUK-444",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "ctDNA profiles and PET-CT imaging"
+            }
+        ],
+        "erd": "https://github.com/tgic/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Liquid_Biopsy",
+                    "description": "Variant allele frequencies over time",
+                    "columns": [
+                        {
+                            "name": "ctdna_clearance",
+                            "dataType": "list",
+                            "description": "list of ctDNA status post-treatment",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Cleared]",
+                                    "description": "No detectable ctDNA post-chemoradiation",
+                                    "frequency": 420
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 950
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://tgic.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "PET-CT Scans",
+                "description": "Metabolic response assessments",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "Upper GI Cancer Audit",
+                    "pid": "UGI-04",
+                    "url": "https://hdg.org/dataset/04"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/escc.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/escc.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/ctdna"
+            ],
+            "investigations": [
+                "TGIC-401-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/escc.2022",
+                    "title": "Gastric Cancer ctDNA Registry",
+                    "pid": "GCC-04"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Circulating Tumor DNA Sequencing",
+            "platform": "Illumina HiSeq"
+        },
+        "icons": [
+            "Genomics",
+            "Imaging"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_1",
+                "label": "C15-C26 Digestive organs",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_2_14",
+                "label": "8070/3 Squamous cell carcinoma, NOS",
+                "category": "805-808 Squamous cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_5",
+                "label": "non-commercial use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Limited to not-for-profit use.(DUO_0000046)"
+            },
+            {
+                "id": "0_2_2_3_0",
+                "label": "Behavioural data",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_2_2",
+                "label": "Immunohistochemistry",
+                "category": "Biopsy & Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_1_2_3",
+                "label": "Radiation",
+                "category": "Treatment",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_16.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_16.json
@@ -1,0 +1,239 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890bb",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890bb",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://srn.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890bb"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Soft Tissue Sarcoma Spatial Transcriptomics Cohort",
+            "abstract": "Registry data evaluating the spatial organization of the immune microenvironment in undifferentiated pleomorphic sarcomas.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/05sarcoma",
+                "name": "Sarcoma Research Network",
+                "logo": "https://srn.org/logo.png",
+                "contactPoint": [
+                    "data@srn.org"
+                ],
+                "description": "https://srn.org/about"
+            },
+            "funders": "Sarcoma UK",
+            "populationSize": 450,
+            "keywords": [
+                "Sarcoma",
+                "Cancer",
+                "Spatial",
+                "Transcriptomics",
+                "Microenvironment"
+            ],
+            "doiName": "10.2001/data.05",
+            "contactPoint": "data@srn.org",
+            "datasetAliases": [
+                "UPS Spatial Cohort"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data evaluating the spatial organization of the immune microenvironment in undifferentiated pleomorphic sarcomas. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://srn.org/spatial_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 30,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://srn.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Tissue Microarrays",
+                "measuredValue": 1350,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 14
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 4
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 4
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "16_000",
+                "projectGrantName": "Spatial Architecture of Sarcomas",
+                "leadResearcher": "Dr. R. Patel",
+                "leadResearchInstitute": "Institute of Bone and Soft Tissue",
+                "grantNumber": "SUK-555",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "Spatial transcriptomics data and survival outcomes"
+            }
+        ],
+        "erd": "https://github.com/srn/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Spatial_Signatures",
+                    "description": "Immune infiltration clustering metrics",
+                    "columns": [
+                        {
+                            "name": "macrophage_polarization",
+                            "dataType": "list",
+                            "description": "list of M1/M2 spatial dominance profiles",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[M2_Dominant]",
+                                    "description": "Immunosuppressive microenvironment",
+                                    "frequency": 280
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 450
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://srn.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "H&E Whole Slide Images",
+                "description": "Digitized tissue sections",
+                "format": "SVS"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Sarcoma Registry",
+                    "pid": "NSR-05",
+                    "url": "https://hdg.org/dataset/05"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/sarcoma.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/sarcoma.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/spatial-transcriptomics"
+            ],
+            "investigations": [
+                "SRN-501-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/sarcoma.2022",
+                    "title": "Osteosarcoma Genomic Cohort",
+                    "pid": "OGC-05"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Spatial Transcriptomics",
+            "platform": "10x Genomics Visium"
+        },
+        "icons": [
+            "Pathology",
+            "Transcriptomics"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_8",
+                "label": "C49 Connective, subcutaneous and other soft tissues",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_16_1",
+                "label": "8800/3 Sarcoma, NOS",
+                "category": "880 Soft tissue tumors and sarcomas, NOS",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_4",
+                "label": "not for profit organisation use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": " Limited to not-for-profit organizations.(DUO_0000045)"
+            },
+            {
+                "id": "0_2_4_4_1_2",
+                "label": "Other",
+                "category": "Source",
+                "primaryGroup": "Multi-omic Data",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_4_1",
+                "label": "Phase 1",
+                "category": "Clinical Trial",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_3_0",
+                "label": "Medication",
+                "category": "Treatments",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_0_1",
+                "label": "State",
+                "category": "Biobank Samples",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_2_0",
+                "label": "Patient-Reported Outcomes",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_17.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_17.json
@@ -1,0 +1,239 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890bc",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890bc",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://hnoc.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890bc"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Head and Neck Squamous Cell Carcinoma Radiotherapy Registry",
+            "abstract": "Registry data analyzing swallowing preservation and toxicity in patients receiving intensity-modulated radiotherapy for HNSCC.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/06hnscc",
+                "name": "Head & Neck Oncology Collaborative",
+                "logo": "https://hnoc.org/logo.png",
+                "contactPoint": [
+                    "registry@hnoc.org"
+                ],
+                "description": "https://hnoc.org/about"
+            },
+            "funders": "National Institutes of Health",
+            "populationSize": 1800,
+            "keywords": [
+                "HNSCC",
+                "Cancer",
+                "Radiotherapy",
+                "Toxicity",
+                "Dysphagia"
+            ],
+            "doiName": "10.2001/data.06",
+            "contactPoint": "registry@hnoc.org",
+            "datasetAliases": [
+                "HNSCC IMRT Toxicity"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data analyzing swallowing preservation and toxicity in patients receiving intensity-modulated radiotherapy for HNSCC. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://hnoc.org/rt_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 45,
+            "typicalAgeRangeMax": 80,
+            "datasetCompleteness": "https://hnoc.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Radiotherapy Fractions",
+                "measuredValue": 63000,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 15
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "17_000",
+                "projectGrantName": "Functional Outcomes Post-IMRT",
+                "leadResearcher": "Dr. T. Davies",
+                "leadResearchInstitute": "Radiation Oncology Institute",
+                "grantNumber": "NIH-666",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "RT dose distributions and swallowing assessments"
+            }
+        ],
+        "erd": "https://github.com/hnoc/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Toxicity_Assessments",
+                    "description": "Longitudinal dysphagia and xerostomia scores",
+                    "columns": [
+                        {
+                            "name": "dysphagia_grade",
+                            "dataType": "list",
+                            "description": "list of CTCAE dysphagia grades",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Grade_2]",
+                                    "description": "Symptomatic, altered eating habits",
+                                    "frequency": 650
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 1800
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://hnoc.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "RT Dose Volumes",
+                "description": "Radiation dose distributions",
+                "format": "DICOM-RT"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Radiation Oncology Audit",
+                    "pid": "NROA-06",
+                    "url": "https://hdg.org/dataset/06"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/hnscc.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/hnscc.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/radiomics"
+            ],
+            "investigations": [
+                "HNOC-601-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/hnscc.2022",
+                    "title": "Thyroid Cancer Radiotherapy Data",
+                    "pid": "TCRD-06"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Not Applicable",
+            "platform": "Clinical Data"
+        },
+        "icons": [
+            "Radiotherapy",
+            "Clinical Data"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_0",
+                "label": "C00-C14 Lip, oral cavity and pharynx",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_2_14",
+                "label": "8070/3 Squamous cell carcinoma, NOS",
+                "category": "805-808 Squamous cell neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_2",
+                "label": "collaboration required",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "Requestor must agree to collaboration with the primary study investigator(s).(DUO_0000020)"
+            },
+            {
+                "id": "0_2_4_1",
+                "label": "Crystallography",
+                "category": "Techniques",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0_2",
+                "label": "Fruit fly",
+                "category": "Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_1_1_1",
+                "label": "Patient derived",
+                "category": "Cell Source",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_0",
+                "label": "Background",
+                "category": "Patient study",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_3_1",
+                "label": "Clinical observations",
+                "category": "Longitudinal Follow up",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_18.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_18.json
@@ -1,0 +1,239 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890bd",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890bd",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://pstn.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890bd"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Neuroblastoma MYCN Amplification and Differentiation Cohort",
+            "abstract": "Registry data correlating MYCN amplification status with tumor differentiation and response to retinoid therapy in high-risk pediatric neuroblastoma.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/07neuro",
+                "name": "Pediatric Solid Tumor Network",
+                "logo": "https://pstn.org/logo.png",
+                "contactPoint": [
+                    "data@pstn.org"
+                ],
+                "description": "https://pstn.org/about"
+            },
+            "funders": "Children's Cancer Research Fund",
+            "populationSize": 850,
+            "keywords": [
+                "Neuroblastoma",
+                "Pediatric",
+                "Cancer",
+                "MYCN",
+                "Retinoids"
+            ],
+            "doiName": "10.2001/data.07",
+            "contactPoint": "data@pstn.org",
+            "datasetAliases": [
+                "High-Risk Neuroblastoma Data"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data correlating MYCN amplification status with tumor differentiation and response to retinoid therapy in high-risk pediatric neuroblastoma. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://pstn.org/mycn_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 0,
+            "typicalAgeRangeMax": 10,
+            "datasetCompleteness": "https://pstn.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Biopsies",
+                "measuredValue": 1700,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 14
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 4
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 4
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "18_000",
+                "projectGrantName": "Targeting MYCN in Neuroblastoma",
+                "leadResearcher": "Dr. K. Jones",
+                "leadResearchInstitute": "Children's Hospital Oncology",
+                "grantNumber": "CCRF-777",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "FISH results, histology, and therapy logs"
+            }
+        ],
+        "erd": "https://github.com/pstn/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Cytogenetics",
+                    "description": "FISH and microarray results for MYCN",
+                    "columns": [
+                        {
+                            "name": "mycn_status",
+                            "dataType": "list",
+                            "description": "list of MYCN amplification results",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[Amplified]",
+                                    "description": "Greater than 10 copies of MYCN",
+                                    "frequency": 320
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 850
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://pstn.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "MIBG Scans",
+                "description": "Functional imaging for metastatic spread",
+                "format": "DICOM"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "Pediatric Oncology Database",
+                    "pid": "POD-07",
+                    "url": "https://hdg.org/dataset/07"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/neuro.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/neuro.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/pediatric-oncology"
+            ],
+            "investigations": [
+                "PSTN-701-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/neuro.2022",
+                    "title": "Wilms Tumor Genomic Data",
+                    "pid": "WTGD-07"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Fluorescence In Situ Hybridization",
+            "platform": "Microscopy"
+        },
+        "icons": [
+            "Pediatrics",
+            "Genetics"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_6",
+                "label": "C47 Peripheral nerves and autonomic nervous system",
+                "category": "icdOTopography",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_36_5",
+                "label": "9500/3 Neuroblastoma, NOS",
+                "category": "949-952 Neuroepitheliomatous neoplasms",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_4",
+                "label": "not for profit organisation use only",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": " Limited to not-for-profit organizations.(DUO_0000045)"
+            },
+            {
+                "id": "0_2_3_4_2",
+                "label": "Phase 2",
+                "category": "Clinical Trial",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_1_4",
+                "label": "Kidney function tests",
+                "category": "Biopsy Reports and Lab Results",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_0",
+                "label": "Organism",
+                "category": "Model Organism",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_3_4_1",
+                "label": "Phase 1",
+                "category": "Clinical Trial",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_2_1_3",
+                "label": "Syngeneic",
+                "category": "Organism preparation",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}

--- a/tests/Unit/test_files/cruk_dummy_data/dataset_19.json
+++ b/tests/Unit/test_files/cruk_dummy_data/dataset_19.json
@@ -1,0 +1,235 @@
+{
+    "gwdmVersion": "2.1",
+    "metadata": {
+        "required": {
+            "gatewayId": "087654b3-2c0a-4b32-9c2e-1234567890be",
+            "gatewayPid": "087654b3-2c0a-4b32-9c2e-1234567890be",
+            "issued": "2018-01-01T00:00:00Z",
+            "modified": "2024-06-01T00:00:00Z",
+            "version": "1.0.0",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://gog.org/datasets/087654b3-2c0a-4b32-9c2e-1234567890be"
+                }
+            ]
+        },
+        "summary": {
+            "title": "Endometrial Cancer Molecular Classification Registry",
+            "abstract": "Registry data reclassifying endometrial carcinomas based on POLE mutation, MMR deficiency, and p53 abnormality to guide adjuvant therapy.",
+            "dataCustodian": {
+                "identifier": "https://ror.org/08endo",
+                "name": "Gynecologic Oncology Group",
+                "logo": "https://gog.org/logo.png",
+                "contactPoint": [
+                    "access@gog.org"
+                ],
+                "description": "https://gog.org/about"
+            },
+            "funders": "Medical Research Council",
+            "populationSize": 2600,
+            "keywords": [
+                "Endometrial",
+                "Cancer",
+                "Molecular",
+                "Classification",
+                "MMR"
+            ],
+            "doiName": "10.2001/data.08",
+            "contactPoint": "access@gog.org",
+            "datasetAliases": [
+                "TCGA Endometrial Subtypes"
+            ]
+        },
+        "documentation": {
+            "description": "Registry data reclassifying endometrial carcinomas based on POLE mutation, MMR deficiency, and p53 abnormality to guide adjuvant therapy. This is a synthetic description generated for testing purposes.",
+            "inPipeline": "Available",
+            "associatedMedia": [
+                "https://gog.org/endo_protocol.pdf"
+            ]
+        },
+        "coverage": {
+            "typicalAgeRangeMin": 45,
+            "typicalAgeRangeMax": 85,
+            "datasetCompleteness": "https://gog.org/completeness"
+        },
+        "provenance": {
+            "temporal": {
+                "publishingFrequency": "Annual",
+                "startDate": "2018-01-01",
+                "timeLag": "6 months",
+                "endDate": "2023-12-31",
+                "distributionReleaseDate": "2024-06-01"
+            }
+        },
+        "observations": [
+            {
+                "observedNode": "Surgical Specimens",
+                "measuredValue": 2600,
+                "observationDate": "2023-12-31",
+                "measuredProperty": "Count"
+            }
+        ],
+        "demographicFrequency": {
+            "ethnicity": [
+                {
+                    "bin": "White - British",
+                    "count": 50
+                },
+                {
+                    "bin": "Asian or Asian British",
+                    "count": 25
+                },
+                {
+                    "bin": "Black or Black British",
+                    "count": 15
+                },
+                {
+                    "bin": "Mixed",
+                    "count": 5
+                },
+                {
+                    "bin": "Not stated",
+                    "count": 5
+                }
+            ]
+        },
+        "projectGrants": [
+            {
+                "pid": "19_000",
+                "projectGrantName": "Molecular Typing in Endometrial Cancer",
+                "leadResearcher": "Dr. E. Evans",
+                "leadResearchInstitute": "Institute of Women's Cancer",
+                "grantNumber": "MRC-888",
+                "projectGrantStartDate": "2019-01-01",
+                "projectGrantEndDate": "2024-12-31",
+                "projectGrantScope": "IHC profiles, sequencing, and recurrence data"
+            },
+            {
+                "pid": "19_001",
+                "projectGrantName": "Molecular Typing in Endometrial Cancer in Young People",
+                "leadResearcher": "Dr. E. Evans",
+                "leadResearchInstitute": "Institute of Women's Cancer",
+                "grantNumber": "MRC-889",
+                "projectGrantStartDate": "2020-01-01",
+                "projectGrantEndDate": "2026-12-31",
+                "projectGrantScope": "IHC profiles, sequencing, and recurrence data"
+            }
+        ],
+        "erd": "https://github.com/gog/schema.png",
+        "structuralMetadata": {
+            "tables": [
+                {
+                    "name": "Molecular_Subtypes",
+                    "description": "ProMisE classification results",
+                    "columns": [
+                        {
+                            "name": "mmr_status",
+                            "dataType": "list",
+                            "description": "list of mismatch repair protein expressions",
+                            "sensitive": true,
+                            "values": [
+                                {
+                                    "name": "[dMMR]",
+                                    "description": "Mismatch repair deficient",
+                                    "frequency": 700
+                                }
+                            ]
+                        }
+                    ],
+                    "size": 2600
+                }
+            ],
+            "syntheticDataWebLink": [
+                "https://gog.org/synthetic"
+            ]
+        },
+        "otherDataTypes": [
+            {
+                "title": "Immunohistochemistry Slides",
+                "description": "Stains for MLH1, PMS2, MSH2, MSH6, and p53",
+                "format": "SVS"
+            }
+        ],
+        "enrichmentAndLinkage": {
+            "derivedFrom": [
+                {
+                    "title": "National Gynecologic Database",
+                    "pid": "NGD-08",
+                    "url": "https://hdg.org/dataset/08"
+                }
+            ],
+            "publicationUsingDataset": [
+                "10.1016/endo.2023.01"
+            ],
+            "publicationAboutDataset": [
+                "10.1016/endo.2023.02"
+            ],
+            "tools": [
+                "https://github.com/topics/endometrial"
+            ],
+            "investigations": [
+                "GOG-801-A"
+            ],
+            "similarToDatasets": [
+                {
+                    "url": "10.1016/endo.2022",
+                    "title": "Ovarian Clear Cell Carcinoma Data",
+                    "pid": "OCCC-08"
+                }
+            ]
+        },
+        "omics": {
+            "assay": "Targeted Panel and IHC",
+            "platform": "Illumina MiSeq"
+        },
+        "icons": [
+            "Genomics",
+            "Pathology"
+        ],
+        "datasetFilters": [
+            {
+                "id": "0_0_0_10_3",
+                "label": "C54 Corpus uteri",
+                "category": "C51-C58 Female genital organs",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_0_1_5_161",
+                "label": "8380/3 Endometrioid adenocarcinoma, NOS",
+                "category": "814-838 Adenomas and adenocarcinomas",
+                "primaryGroup": "cancer-type",
+                "description": ""
+            },
+            {
+                "id": "0_1_0",
+                "label": "no restriction",
+                "category": "accessType",
+                "primaryGroup": "access-type",
+                "description": "No restriction on use. (DUO_0000004)"
+            },
+            {
+                "id": "0_2_4_4_0",
+                "label": "Biological molecules (eg DNA)",
+                "category": "Multi-omic Data",
+                "primaryGroup": "Techniques",
+                "description": "genomics/proteomics etc"
+            },
+            {
+                "id": "0_2_0_0_2",
+                "label": "Genetic material",
+                "category": "Material type",
+                "primaryGroup": "data-type",
+                "description": ""
+            },
+            {
+                "id": "0_2_4_3",
+                "label": "Mechanobiology",
+                "category": "Techniques",
+                "primaryGroup": "data-type",
+                "description": ""
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Replace generic random dataset versions with one-to-one CRUK metadata seeding so local dev matches partner_context isolation and project grant demo data.

## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
