### PR TITLE
feat(GAT-9037): Implementation of migration-esq command system

### DIFF
--- a/app/Console/Commands/DeployRun.php
+++ b/app/Console/Commands/DeployRun.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\DeploymentSteps\DeploymentStep;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class DeployRun extends Command
+{
+    protected $signature = 'deploy:run {--status : List all steps with their run status without executing anything}';
+
+    protected $description = 'Run pending deployment steps';
+
+    public function handle(): int
+    {
+        $files = $this->discoverSteps();
+
+        if ($this->option('status')) {
+            return $this->showStatus($files);
+        }
+
+        $this->output->writeln([
+            '',
+            '<comment>NOTE: Deployment steps are run-once and forward-only.</comment>',
+            '<comment>      Steps already recorded in deployment_steps will be skipped.</comment>',
+            '<comment>      There is no rollback — create a new step to undo any change.</comment>',
+            '',
+        ]);
+
+        $ran = $this->getRanSteps();
+        $pending = array_filter($files, fn($key) => !in_array($key, $ran), ARRAY_FILTER_USE_KEY);
+
+        if (empty($pending)) {
+            $this->info('Nothing to run. All deployment steps are up to date.');
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Running %d pending step(s)...', count($pending)));
+
+        foreach ($pending as $key => $path) {
+            $this->output->writeln('');
+            $this->output->write("  <fg=cyan>Running</> {$key} ... ");
+
+            try {
+                $step = require $path;
+
+                if (!$step instanceof DeploymentStep) {
+                    $this->output->writeln('<error>FAILED</error>');
+                    $this->error("  Step file must return an instance of DeploymentStep.");
+                    return self::FAILURE;
+                }
+
+                $step->handle();
+
+                DB::table('deployment_steps')->insert([
+                    'step'   => $key,
+                    'ran_at' => now(),
+                ]);
+
+                $this->output->writeln('<info>DONE</info>');
+            } catch (\Throwable $e) {
+                $this->output->writeln('<error>FAILED</error>');
+                $this->error("  {$e->getMessage()}");
+                $this->error('  Halting. Fix the step and re-run deploy:run.');
+                return self::FAILURE;
+            }
+        }
+
+        $this->output->writeln('');
+        $this->info('All pending deployment steps completed.');
+
+        return self::SUCCESS;
+    }
+
+    private function showStatus(array $files): int
+    {
+        $ran = $this->getRanSteps();
+
+        if (empty($files)) {
+            $this->line('No deployment steps found.');
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($files as $key => $path) {
+            $ranAt = $ran[$key] ?? null;
+            $rows[] = [
+                $key,
+                $ranAt ? '<info>ran</info>' : '<comment>pending</comment>',
+                $ranAt ?? '-',
+            ];
+        }
+
+        $this->table(['Step', 'Status', 'Ran At'], $rows);
+
+        $pendingCount = count(array_filter($rows, fn($r) => str_contains($r[1], 'pending')));
+        $this->line('');
+        $this->line(sprintf('%d step(s) total, %d pending.', count($rows), $pendingCount));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Returns an array keyed by step name (filename without .php), values are full paths.
+     * Sorted alphabetically so date-prefixed names run in order.
+     */
+    private function discoverSteps(): array
+    {
+        $dir = database_path('deployment-steps');
+        $files = glob("{$dir}/*.php") ?: [];
+        sort($files);
+
+        $steps = [];
+        foreach ($files as $path) {
+            $key = basename($path, '.php');
+            $steps[$key] = $path;
+        }
+
+        return $steps;
+    }
+
+    /**
+     * Returns step names already recorded, keyed by step name with ran_at as value.
+     */
+    private function getRanSteps(): array
+    {
+        return DB::table('deployment_steps')
+            ->pluck('ran_at', 'step')
+            ->all();
+    }
+}

--- a/app/Console/Commands/DeployRun.php
+++ b/app/Console/Commands/DeployRun.php
@@ -29,7 +29,7 @@ class DeployRun extends Command
         ]);
 
         $ran = $this->getRanSteps();
-        $pending = array_filter($files, fn($key) => !in_array($key, $ran), ARRAY_FILTER_USE_KEY);
+        $pending = array_filter($files, fn ($key) => !isset($ran[$key]), ARRAY_FILTER_USE_KEY);
 
         if (empty($pending)) {
             $this->info('Nothing to run. All deployment steps are up to date.');
@@ -51,6 +51,7 @@ class DeployRun extends Command
                     return self::FAILURE;
                 }
 
+                $step->setOutput($this->output);
                 $step->handle();
 
                 DB::table('deployment_steps')->insert([
@@ -94,7 +95,7 @@ class DeployRun extends Command
 
         $this->table(['Step', 'Status', 'Ran At'], $rows);
 
-        $pendingCount = count(array_filter($rows, fn($r) => str_contains($r[1], 'pending')));
+        $pendingCount = count(array_filter($rows, fn ($r) => str_contains($r[1], 'pending')));
         $this->line('');
         $this->line(sprintf('%d step(s) total, %d pending.', count($rows), $pendingCount));
 
@@ -107,7 +108,7 @@ class DeployRun extends Command
      */
     private function discoverSteps(): array
     {
-        $dir = database_path('deployment-steps');
+        $dir = config('deployment.steps_path', database_path('deployment-steps'));
         $files = glob("{$dir}/*.php") ?: [];
         sort($files);
 

--- a/app/DeploymentSteps/DeploymentStep.php
+++ b/app/DeploymentSteps/DeploymentStep.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Base class for deployment steps.
  *
  * CONSTRAINTS (by design):
- *   - Run-once: a step that has been recorded in deployment_steps will never run again,
+ *   - Run-once: a step that has been recorded in deployment_steps will and should never run again,
  *     even if its handle() method is changed. To re-run logic, create a new step file.
  *   - Forward-only: there is no rollback mechanism. Steps are intended for data fixes,
  *     seeding, and one-time operations where reversal is impractical or meaningless.

--- a/app/DeploymentSteps/DeploymentStep.php
+++ b/app/DeploymentSteps/DeploymentStep.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\DeploymentSteps;
+
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Base class for deployment steps.
+ *
+ * CONSTRAINTS (by design):
+ *   - Run-once: a step that has been recorded in deployment_steps will never run again,
+ *     even if its handle() method is changed. To re-run logic, create a new step file.
+ *   - Forward-only: there is no rollback mechanism. Steps are intended for data fixes,
+ *     seeding, and one-time operations where reversal is impractical or meaningless.
+ */
+abstract class DeploymentStep
+{
+    public function __construct(protected OutputInterface $output) {}
+
+    abstract public function handle(): void;
+
+    protected function call(string $command, array $arguments = []): int
+    {
+        return Artisan::call($command, $arguments, $this->output);
+    }
+
+    protected function info(string $message): void
+    {
+        $this->output->writeln("<info>{$message}</info>");
+    }
+
+    protected function warn(string $message): void
+    {
+        $this->output->writeln("<comment>{$message}</comment>");
+    }
+
+    protected function error(string $message): void
+    {
+        $this->output->writeln("<error>{$message}</error>");
+    }
+}

--- a/app/DeploymentSteps/DeploymentStep.php
+++ b/app/DeploymentSteps/DeploymentStep.php
@@ -3,6 +3,7 @@
 namespace App\DeploymentSteps;
 
 use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -16,7 +17,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class DeploymentStep
 {
-    public function __construct(protected OutputInterface $output) {}
+    protected OutputInterface $output;
+
+    public function __construct()
+    {
+        $this->output = new NullOutput();
+    }
+
+    final public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
 
     abstract public function handle(): void;
 

--- a/database/migrations/2026_06_23_000000_create_deployment_steps_table.php
+++ b/database/migrations/2026_06_23_000000_create_deployment_steps_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('deployment_steps', function (Blueprint $table) {
+            $table->id();
+            $table->string('step')->unique();
+            $table->timestamp('ran_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('deployment_steps');
+    }
+};

--- a/database/migrations/2026_06_23_000000_create_deployment_steps_table.php
+++ b/database/migrations/2026_06_23_000000_create_deployment_steps_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('deployment_steps', function (Blueprint $table) {

--- a/tests/Feature/DeployRunTest.php
+++ b/tests/Feature/DeployRunTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeployRunTest extends TestCase
+{
+    private string $fixtures;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->fixtures = base_path('tests/Fixtures/deployment-steps');
+    }
+
+    private function useFixture(string $scenario): void
+    {
+        config(['deployment.steps_path' => "{$this->fixtures}/{$scenario}"]);
+    }
+
+    public function test_runs_pending_steps_and_records_them(): void
+    {
+        $this->useFixture('run-all');
+
+        $this->artisan('deploy:run')->assertExitCode(0);
+
+        $this->assertDatabaseHas('deployment_steps', ['step' => '2026_01_01_000001_no_op_a']);
+        $this->assertDatabaseHas('deployment_steps', ['step' => '2026_01_01_000002_no_op_b']);
+        $this->assertSame(2, DB::table('deployment_steps')->count());
+    }
+
+    public function test_skips_already_ran_steps(): void
+    {
+        $this->useFixture('skip-ran');
+
+        DB::table('deployment_steps')->insert([
+            'step'   => '2026_02_01_000001_no_op_c',
+            'ran_at' => now(),
+        ]);
+
+        $this->artisan('deploy:run')->assertExitCode(0);
+
+        // first step must remain a single row — not re-run or duplicated
+        $this->assertSame(
+            1,
+            DB::table('deployment_steps')->where('step', '2026_02_01_000001_no_op_c')->count()
+        );
+        $this->assertDatabaseHas('deployment_steps', ['step' => '2026_02_01_000002_no_op_d']);
+    }
+
+    public function test_reports_nothing_to_run_when_all_steps_already_ran(): void
+    {
+        $this->useFixture('nothing-to-run');
+
+        DB::table('deployment_steps')->insert([
+            ['step' => '2026_03_01_000001_no_op_e', 'ran_at' => now()],
+            ['step' => '2026_03_01_000002_no_op_f', 'ran_at' => now()],
+        ]);
+
+        $this->artisan('deploy:run')
+            ->expectsOutputToContain('Nothing to run')
+            ->assertExitCode(0);
+    }
+
+    public function test_halts_on_failing_step_and_does_not_record_it(): void
+    {
+        $this->useFixture('failure');
+
+        $this->artisan('deploy:run')->assertExitCode(1);
+
+        $this->assertDatabaseHas('deployment_steps', ['step' => '2026_04_01_000001_no_op_g']);
+        $this->assertDatabaseMissing('deployment_steps', ['step' => '2026_04_01_000002_throws']);
+    }
+
+    public function test_status_shows_pending_and_ran_steps(): void
+    {
+        $this->useFixture('status');
+
+        DB::table('deployment_steps')->insert([
+            'step'   => '2026_05_01_000001_no_op_h',
+            'ran_at' => now(),
+        ]);
+
+        $this->artisan('deploy:run --status')
+            ->expectsOutputToContain('2026_05_01_000001_no_op_h')
+            ->expectsOutputToContain('2026_05_01_000002_no_op_i')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Fixtures/deployment-steps/failure/2026_04_01_000001_no_op_g.php
+++ b/tests/Fixtures/deployment-steps/failure/2026_04_01_000001_no_op_g.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/failure/2026_04_01_000002_throws.php
+++ b/tests/Fixtures/deployment-steps/failure/2026_04_01_000002_throws.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+        throw new \RuntimeException('Intentional failure for testing.');
+    }
+};

--- a/tests/Fixtures/deployment-steps/nothing-to-run/2026_03_01_000001_no_op_e.php
+++ b/tests/Fixtures/deployment-steps/nothing-to-run/2026_03_01_000001_no_op_e.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/nothing-to-run/2026_03_01_000002_no_op_f.php
+++ b/tests/Fixtures/deployment-steps/nothing-to-run/2026_03_01_000002_no_op_f.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/run-all/2026_01_01_000001_no_op_a.php
+++ b/tests/Fixtures/deployment-steps/run-all/2026_01_01_000001_no_op_a.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/run-all/2026_01_01_000002_no_op_b.php
+++ b/tests/Fixtures/deployment-steps/run-all/2026_01_01_000002_no_op_b.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/skip-ran/2026_02_01_000001_no_op_c.php
+++ b/tests/Fixtures/deployment-steps/skip-ran/2026_02_01_000001_no_op_c.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/skip-ran/2026_02_01_000002_no_op_d.php
+++ b/tests/Fixtures/deployment-steps/skip-ran/2026_02_01_000002_no_op_d.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/status/2026_05_01_000001_no_op_h.php
+++ b/tests/Fixtures/deployment-steps/status/2026_05_01_000001_no_op_h.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};

--- a/tests/Fixtures/deployment-steps/status/2026_05_01_000002_no_op_i.php
+++ b/tests/Fixtures/deployment-steps/status/2026_05_01_000002_no_op_i.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+    }
+};


### PR DESCRIPTION
> AI disclosure - Claude Sonnet 4.6 was used extensively during the writing of the tests for this solution.

## Screenshots (if relevant)

## Describe your changes

As part of automated deployments, we need a migration-esq mechanism for running commands automatically. This implements that. It should be noted that this is (by design) run-once and forward facing. It's incremental by nature and can't be rolledback.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?
Yes.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
