### PR TITLE
feat(GAT-8130): Implements widget tracking for analytics

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamWidgetController.php
+++ b/app/Http/Controllers/Api/V1/TeamWidgetController.php
@@ -715,6 +715,11 @@ class TeamWidgetController extends Controller
                  'data' => $widget->id,
              ], Config::get('statuscodes.STATUS_CREATED.code'));
 
+        } catch (ValidationException $e) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -1030,6 +1035,11 @@ class TeamWidgetController extends Controller
 
             return response()->json(null, Config::get('statuscodes.STATUS_NO_CONTENT.code', 204));
 
+        } catch (ValidationException $e) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (Exception $e) {
             \Log::error('Error recording widget analytics event', [
                 'team_id'   => $teamId,
@@ -1085,12 +1095,6 @@ class TeamWidgetController extends Controller
             $to      = isset($validated['to']) ? $validated['to'] . ' 23:59:59' : null;
             $groupBy = $validated['group_by'] ?? 'day';
 
-            $dateFormat = match ($groupBy) {
-                'week'  => '%Y-%u',
-                'month' => '%Y-%m',
-                default => '%Y-%m-%d',
-            };
-
             $byEvent = DB::select("
                 SELECT event_type, COUNT(*) as count
                 FROM widget_analytics
@@ -1115,18 +1119,38 @@ class TeamWidgetController extends Controller
                 ORDER BY wa.widget_id, wa.event_type
             ", [$teamId, $from, $from, $to, $to]);
 
-            $overTime = DB::select("
+            // DATE() returns YYYY-MM-DD and is supported by both MySQL and SQLite.
+            // Week/month bucketing is done in PHP to avoid DB-specific date functions.
+            $dailyRows = DB::select("
                 SELECT
-                    DATE_FORMAT(created_at, ?) as period,
+                    DATE(created_at) as day,
                     event_type,
                     COUNT(*) as count
                 FROM widget_analytics
                 WHERE team_id = ?
                   AND (? IS NULL OR created_at >= ?)
                   AND (? IS NULL OR created_at <= ?)
-                GROUP BY period, event_type
-                ORDER BY period
-            ", [$dateFormat, $teamId, $from, $from, $to, $to]);
+                GROUP BY day, event_type
+                ORDER BY day
+            ", [$teamId, $from, $from, $to, $to]);
+
+            $overTime = collect($dailyRows)
+                ->groupBy(fn ($r) => match ($groupBy) {
+                    'month' => substr($r->day, 0, 7),
+                    'week'  => date('Y-W', strtotime($r->day)),
+                    default => $r->day,
+                })
+                ->flatMap(fn ($rows, $period) =>
+                    collect($rows)
+                        ->groupBy('event_type')
+                        ->map(fn ($events, $eventType) => [
+                            'period'     => $period,
+                            'event_type' => $eventType,
+                            'count'      => collect($events)->sum('count'),
+                        ])
+                        ->values()
+                )
+                ->values();
 
             return response()->json([
                 'data' => [

--- a/app/Http/Controllers/Api/V1/TeamWidgetController.php
+++ b/app/Http/Controllers/Api/V1/TeamWidgetController.php
@@ -11,9 +11,12 @@ use App\Models\Dataset;
 use App\Models\Collection;
 use App\Models\Tool;
 use App\Models\Dur;
+use App\Models\WidgetAnalytic;
+use App\Jobs\WidgetAnalyticsJob;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 use App\Http\Traits\LoggingContext;
 
 class TeamWidgetController extends Controller
@@ -517,6 +520,13 @@ class TeamWidgetController extends Controller
                 'description' => "Retrieve data related to team {$teamId}, widget {$id} and domain origin {$domainOrigin}",
             ]);
 
+            WidgetAnalyticsJob::dispatch([
+                'widget_id'     => $widget->id,
+                'team_id'       => $teamId,
+                'event_type'    => WidgetAnalytic::EVENT_WIDGET_LOAD,
+                'source_domain' => $domainOrigin,
+            ]);
+
             return response()->json(['data' => [
                 'datasets' => $datasets,
                 'data_uses' => $dataUses,
@@ -693,6 +703,12 @@ class TeamWidgetController extends Controller
                 }
             }
             $widget = Widget::create($validated);
+
+            WidgetAnalyticsJob::dispatch([
+                'widget_id'  => $widget->id,
+                'team_id'    => $teamId,
+                'event_type' => WidgetAnalytic::EVENT_WIDGET_CREATED,
+            ]);
 
             return response()->json([
                  'message' => Config::get('statuscodes.STATUS_CREATED.message'),
@@ -946,5 +962,197 @@ class TeamWidgetController extends Controller
             throw new Exception($e->getMessage());
         }
 
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/v1/teams/{teamId}/widgets/{id}/track",
+     *     operationId="track_widget_event",
+     *     summary="Record a widget analytics event",
+     *     description="Public endpoint for frontend clients to record user interactions with a widget (page views, code copies, gateway clicks, searches). No authentication required.",
+     *     tags={"Widgets"},
+     *     @OA\Parameter(
+     *         name="teamId",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"event_type"},
+     *             @OA\Property(property="event_type", type="string", enum={"page_view","code_copied","gateway_click","search"}),
+     *             @OA\Property(property="entity_id", type="integer", nullable=true),
+     *             @OA\Property(property="entity_type", type="string", nullable=true, enum={"dataset","tool","collection","dur"}),
+     *             @OA\Property(property="source_domain", type="string", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=204, description="Event recorded"),
+     *     @OA\Response(response=404, description="Widget not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function track(Request $request, int $teamId, int $id): JsonResponse
+    {
+        try {
+            $widget = Widget::where('id', $id)
+                ->where('team_id', $teamId)
+                ->first();
+
+            if (!$widget) {
+                return response()->json(
+                    ['message' => Config::get('statuscodes.STATUS_NOT_FOUND.message')],
+                    Config::get('statuscodes.STATUS_NOT_FOUND.code')
+                );
+            }
+
+            $validated = $request->validate([
+                'event_type'    => 'required|string|in:' . implode(',', WidgetAnalytic::FRONTEND_EVENTS),
+                'entity_id'     => 'nullable|integer',
+                'entity_type'   => 'nullable|string|in:dataset,tool,collection,dur',
+                'source_domain' => 'nullable|string|max:255',
+            ]);
+
+            WidgetAnalyticsJob::dispatch([
+                'widget_id'     => $widget->id,
+                'team_id'       => $teamId,
+                'event_type'    => $validated['event_type'],
+                'entity_id'     => $validated['entity_id'] ?? null,
+                'entity_type'   => $validated['entity_type'] ?? null,
+                'source_domain' => $validated['source_domain'] ?? null,
+            ]);
+
+            return response()->json(null, Config::get('statuscodes.STATUS_NO_CONTENT.code', 204));
+
+        } catch (Exception $e) {
+            \Log::error('Error recording widget analytics event', [
+                'team_id'   => $teamId,
+                'widget_id' => $id,
+                'error'     => $e->getMessage(),
+            ]);
+
+            return response()->json(
+                ['message' => Config::get('statuscodes.STATUS_SERVER_ERROR.message')],
+                Config::get('statuscodes.STATUS_SERVER_ERROR.code')
+            );
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/v1/teams/{teamId}/widgets/analytics",
+     *     operationId="widget_analytics",
+     *     summary="Get widget analytics for a team",
+     *     description="Returns aggregated event counts per widget, per event type, and over time. Supports date range filtering and time-based grouping.",
+     *     tags={"Widgets"},
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(name="teamId", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="from", in="query", required=false, description="Start date (Y-m-d)", @OA\Schema(type="string", example="2026-01-01")),
+     *     @OA\Parameter(name="to", in="query", required=false, description="End date (Y-m-d)", @OA\Schema(type="string", example="2026-06-30")),
+     *     @OA\Parameter(name="group_by", in="query", required=false, description="Time granularity", @OA\Schema(type="string", enum={"day","week","month"}, default="day")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Analytics data",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="by_event", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="by_widget", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="over_time", type="array", @OA\Items(type="object"))
+     *         )
+     *     )
+     * )
+     */
+    public function analytics(Request $request, int $teamId): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
+        try {
+            $validated = $request->validate([
+                'from'     => 'nullable|date_format:Y-m-d',
+                'to'       => 'nullable|date_format:Y-m-d',
+                'group_by' => 'nullable|string|in:day,week,month',
+            ]);
+
+            $from    = $validated['from'] ?? null;
+            $to      = isset($validated['to']) ? $validated['to'] . ' 23:59:59' : null;
+            $groupBy = $validated['group_by'] ?? 'day';
+
+            $dateFormat = match ($groupBy) {
+                'week'  => '%Y-%u',
+                'month' => '%Y-%m',
+                default => '%Y-%m-%d',
+            };
+
+            $byEvent = DB::select("
+                SELECT event_type, COUNT(*) as count
+                FROM widget_analytics
+                WHERE team_id = ?
+                  AND (? IS NULL OR created_at >= ?)
+                  AND (? IS NULL OR created_at <= ?)
+                GROUP BY event_type
+            ", [$teamId, $from, $from, $to, $to]);
+
+            $byWidget = DB::select("
+                SELECT
+                    wa.widget_id,
+                    w.widget_name,
+                    wa.event_type,
+                    COUNT(*) as count
+                FROM widget_analytics wa
+                INNER JOIN widgets w ON w.id = wa.widget_id
+                WHERE wa.team_id = ?
+                  AND (? IS NULL OR wa.created_at >= ?)
+                  AND (? IS NULL OR wa.created_at <= ?)
+                GROUP BY wa.widget_id, w.widget_name, wa.event_type
+                ORDER BY wa.widget_id, wa.event_type
+            ", [$teamId, $from, $from, $to, $to]);
+
+            $overTime = DB::select("
+                SELECT
+                    DATE_FORMAT(created_at, ?) as period,
+                    event_type,
+                    COUNT(*) as count
+                FROM widget_analytics
+                WHERE team_id = ?
+                  AND (? IS NULL OR created_at >= ?)
+                  AND (? IS NULL OR created_at <= ?)
+                GROUP BY period, event_type
+                ORDER BY period
+            ", [$dateFormat, $teamId, $from, $from, $to, $to]);
+
+            return response()->json([
+                'data' => [
+                    'by_event'  => $byEvent,
+                    'by_widget' => $byWidget,
+                    'over_time' => $overTime,
+                ],
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (ValidationException $e) {
+            return response()->json([
+                'message' => 'Validation failed',
+                'errors'  => $e->errors(),
+            ], Config::get('statuscodes.STATUS_BAD_REQUEST.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id'     => (int)$jwtUser['id'],
+                'team_id'     => $teamId,
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+            \Log::info($e->getMessage(), $loggingContext);
+
+            throw new Exception($e->getMessage());
+        }
     }
 }

--- a/app/Jobs/WidgetAnalyticsJob.php
+++ b/app/Jobs/WidgetAnalyticsJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WidgetAnalytic;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Horizon\Contracts\Silenced;
+
+class WidgetAnalyticsJob implements ShouldQueue, Silenced
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public $tries = 3;
+
+    protected array $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function handle(): void
+    {
+        WidgetAnalytic::create($this->data);
+    }
+
+    public function tags(): array
+    {
+        return ['widget_analytics'];
+    }
+}

--- a/app/Models/WidgetAnalytic.php
+++ b/app/Models/WidgetAnalytic.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WidgetAnalytic extends Model
+{
+    public const UPDATED_AT = null;
+
+    public const EVENT_PAGE_VIEW      = 'page_view';
+    public const EVENT_WIDGET_CREATED = 'widget_created';
+    public const EVENT_CODE_COPIED    = 'code_copied';
+    public const EVENT_WIDGET_LOAD    = 'widget_load';
+    public const EVENT_GATEWAY_CLICK  = 'gateway_click';
+    public const EVENT_SEARCH         = 'search';
+
+    public const FRONTEND_EVENTS = [
+        self::EVENT_PAGE_VIEW,
+        self::EVENT_CODE_COPIED,
+        self::EVENT_GATEWAY_CLICK,
+        self::EVENT_SEARCH,
+    ];
+
+    protected $table = 'widget_analytics';
+
+    protected $fillable = [
+        'widget_id',
+        'team_id',
+        'event_type',
+        'entity_id',
+        'entity_type',
+        'source_domain',
+    ];
+
+    public function widget(): BelongsTo
+    {
+        return $this->belongsTo(Widget::class);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -289,6 +289,32 @@ return [
             'teamId' => '[0-9]+',
         ],
     ],
+    [
+        'name' => 'track_widget_event',
+        'method' => 'post',
+        'path' => '/teams/{teamId}/widgets/{id}/track',
+        'methodController' => 'TeamWidgetController@track',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+            'id' => '[0-9]+',
+        ],
+    ],
+    [
+        'name' => 'widget_analytics',
+        'method' => 'get',
+        'path' => '/teams/{teamId}/widgets/analytics',
+        'methodController' => 'TeamWidgetController@analytics',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,widgets.read',
+        ],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+        ],
+    ],
 
     // features
     [

--- a/database/factories/WidgetFactory.php
+++ b/database/factories/WidgetFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Widget>
+ */
+class WidgetFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'team_id'            => Team::factory(),
+            'widget_name'        => fake()->words(3, true),
+            'size_width'         => fake()->numberBetween(300, 1200),
+            'size_height'        => fake()->numberBetween(200, 800),
+            'unit'               => fake()->randomElement(['px', '%', 'rem']),
+            'include_search_bar' => fake()->boolean(),
+            'include_cohort_link' => fake()->boolean(),
+            'keep_proportions'   => fake()->boolean(),
+            'permitted_domains'  => implode(',', [
+                fake()->domainName(),
+                fake()->domainName(),
+            ]),
+            'branding_primary'   => fake()->hexColor(),
+            'branding_secondary' => fake()->hexColor(),
+            'branding_neutral'   => fake()->hexColor(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_26_000000_create_widget_analytics_table.php
+++ b/database/migrations/2026_06_26_000000_create_widget_analytics_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('widget_analytics', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('widget_id');
+            $table->foreign('widget_id')->references('id')->on('widgets')->onDelete('cascade');
+            $table->unsignedBigInteger('team_id');
+            $table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
+            $table->enum('event_type', [
+                'page_view',
+                'widget_created',
+                'code_copied',
+                'widget_load',
+                'gateway_click',
+                'search',
+            ]);
+            $table->unsignedBigInteger('entity_id')->nullable();
+            $table->string('entity_type')->nullable();
+            $table->string('source_domain')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['widget_id', 'event_type', 'created_at']);
+            $table->index(['team_id', 'event_type', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('widget_analytics');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -74,6 +74,8 @@ class DatabaseSeeder extends Seeder
             LibrarySeeder::class,
             EnquiryThreadHasDatasetVersionSeeder::class,
             DatasetVersionHasSpatialCoverageSeeder::class,
+            WidgetSeeder::class,
+            WidgetAnalyticSeeder::class,
         ]);
     }
 }

--- a/database/seeders/WidgetAnalyticSeeder.php
+++ b/database/seeders/WidgetAnalyticSeeder.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Widget;
+use App\Models\WidgetAnalytic;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class WidgetAnalyticSeeder extends Seeder
+{
+    // Approximate event distribution for realistic demo data
+    private array $eventWeights = [
+        WidgetAnalytic::EVENT_WIDGET_LOAD    => 40,
+        WidgetAnalytic::EVENT_PAGE_VIEW      => 20,
+        WidgetAnalytic::EVENT_GATEWAY_CLICK  => 20,
+        WidgetAnalytic::EVENT_SEARCH         => 10,
+        WidgetAnalytic::EVENT_CODE_COPIED    => 5,
+        WidgetAnalytic::EVENT_WIDGET_CREATED => 5,
+    ];
+
+    private array $sampleDomains = [
+        'partner-health.org',
+        'university-research.ac.uk',
+        'nhs-data-portal.nhs.uk',
+        'genomics-england.co.uk',
+        'clinical-trials.net',
+    ];
+
+    private array $entityTypes = ['dataset', 'tool', 'collection', 'dur'];
+
+    public function run(): void
+    {
+        $widgets = Widget::all();
+
+        if ($widgets->isEmpty()) {
+            $this->command->warn('No widgets found — run WidgetSeeder first.');
+            return;
+        }
+
+        $weightedEvents = $this->buildWeightedEventPool();
+        $rows = [];
+
+        foreach ($widgets as $widget) {
+            // Spread ~90 days of history, more recent days get more events
+            for ($daysAgo = 90; $daysAgo >= 0; $daysAgo--) {
+                $dailyVolume = (int) round(fake()->numberBetween(0, 8) * (1 + (90 - $daysAgo) / 90));
+
+                for ($i = 0; $i < $dailyVolume; $i++) {
+                    $eventType  = $weightedEvents[array_rand($weightedEvents)];
+                    $createdAt  = now()->subDays($daysAgo)->subSeconds(fake()->numberBetween(0, 86399));
+
+                    $row = [
+                        'widget_id'     => $widget->id,
+                        'team_id'       => $widget->team_id,
+                        'event_type'    => $eventType,
+                        'entity_id'     => null,
+                        'entity_type'   => null,
+                        'source_domain' => null,
+                        'created_at'    => $createdAt,
+                    ];
+
+                    if (in_array($eventType, [WidgetAnalytic::EVENT_WIDGET_LOAD, WidgetAnalytic::EVENT_GATEWAY_CLICK, WidgetAnalytic::EVENT_SEARCH])) {
+                        $row['source_domain'] = fake()->randomElement($this->sampleDomains);
+                    }
+
+                    if ($eventType === WidgetAnalytic::EVENT_GATEWAY_CLICK) {
+                        $row['entity_type'] = fake()->randomElement($this->entityTypes);
+                        $row['entity_id']   = fake()->numberBetween(1, 100);
+                    }
+
+                    $rows[] = $row;
+
+                    if (count($rows) >= 500) {
+                        DB::table('widget_analytics')->insert($rows);
+                        $rows = [];
+                    }
+                }
+            }
+        }
+
+        if (!empty($rows)) {
+            DB::table('widget_analytics')->insert($rows);
+        }
+    }
+
+    private function buildWeightedEventPool(): array
+    {
+        $pool = [];
+        foreach ($this->eventWeights as $event => $weight) {
+            for ($i = 0; $i < $weight; $i++) {
+                $pool[] = $event;
+            }
+        }
+        return $pool;
+    }
+}

--- a/database/seeders/WidgetSeeder.php
+++ b/database/seeders/WidgetSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Team;
+use App\Models\Widget;
+use Illuminate\Database\Seeder;
+
+class WidgetSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $teams = Team::inRandomOrder()->limit(5)->get();
+
+        foreach ($teams as $team) {
+            Widget::factory()
+                ->count(fake()->numberBetween(1, 3))
+                ->create(['team_id' => $team->id]);
+        }
+    }
+}

--- a/tests/Feature/TeamWidgetTest.php
+++ b/tests/Feature/TeamWidgetTest.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Tests\Feature;
+
+use Config;
+use Tests\TestCase;
+use App\Models\Team;
+use App\Models\Widget;
+use App\Models\WidgetAnalytic;
+use App\Jobs\WidgetAnalyticsJob;
+use Illuminate\Support\Facades\Queue;
+use Tests\Traits\MockExternalApis;
+
+class TeamWidgetTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected $header = [];
+    protected Team $team;
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+
+        Widget::flushEventListeners();
+
+        $this->team = Team::first();
+    }
+
+    public function test_can_list_widgets_for_a_team(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        $response = $this->get("api/v1/teams/{$this->team->id}/widgets", $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    0 => [
+                        'id',
+                        'widget_name',
+                        'size_width',
+                        'size_height',
+                        'updated_at',
+                        'unit',
+                        'team_id',
+                        'team_name',
+                        'include_search_bar',
+                        'branding_primary',
+                        'branding_secondary',
+                        'branding_neutral',
+                    ],
+                ],
+            ]);
+
+        $widget->forceDelete();
+    }
+
+    public function test_can_retrieve_a_single_widget(): void
+    {
+        $widget = Widget::factory()->create([
+            'team_id'     => $this->team->id,
+            'widget_name' => 'Retrieve Test Widget',
+        ]);
+
+        $response = $this->get("api/v1/teams/{$this->team->id}/widgets/{$widget->id}", $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'widget_name',
+                    'team_id',
+                    'included_datasets',
+                    'included_data_uses',
+                    'included_scripts',
+                    'included_collections',
+                    'permitted_domains',
+                ],
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals('Retrieve Test Widget', $content['data']['widget_name']);
+
+        $widget->forceDelete();
+    }
+
+    public function test_retrieve_returns_404_for_unknown_widget(): void
+    {
+        $response = $this->get("api/v1/teams/{$this->team->id}/widgets/999999", $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+    }
+
+    public function test_can_create_a_widget(): void
+    {
+        Queue::fake();
+
+        $response = $this->json(
+            'POST',
+            "api/v1/teams/{$this->team->id}/widgets",
+            [
+                'widget_name'        => 'New Test Widget',
+                'size_width'         => 800,
+                'size_height'        => 600,
+                'unit'               => 'px',
+                'include_search_bar' => true,
+                'include_cohort_link' => false,
+                'keep_proportions'   => true,
+                'permitted_domains'  => ['example.com', 'example.org'],
+                'branding_primary'   => '#ff0000',
+                'branding_secondary' => '#00ff00',
+                'branding_neutral'   => '#0000ff',
+            ],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'))
+            ->assertJsonStructure(['message', 'data']);
+
+        $widgetId = $response->decodeResponseJson()['data'];
+
+        Queue::assertPushed(WidgetAnalyticsJob::class, function ($job) {
+            $data = $this->getJobData($job);
+            return $data['event_type'] === WidgetAnalytic::EVENT_WIDGET_CREATED;
+        });
+
+        Widget::find($widgetId)?->forceDelete();
+    }
+
+    public function test_create_widget_requires_widget_name(): void
+    {
+        $response = $this->json(
+            'POST',
+            "api/v1/teams/{$this->team->id}/widgets",
+            ['size_width' => 800],
+            $this->header
+        );
+
+        $response->assertStatus(422);
+    }
+
+    public function test_can_update_a_widget(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        $response = $this->json(
+            'PATCH',
+            "api/v1/teams/{$this->team->id}/widgets/{$widget->id}",
+            ['widget_name' => 'Updated Widget Name', 'size_width' => 1024],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure(['message', 'data']);
+
+        $content = $response->decodeResponseJson();
+        $this->assertEquals('Updated Widget Name', $content['data']['widget_name']);
+        $this->assertEquals(1024, $content['data']['size_width']);
+
+        $widget->forceDelete();
+    }
+
+    public function test_update_returns_404_for_unknown_widget(): void
+    {
+        $response = $this->json(
+            'PATCH',
+            "api/v1/teams/{$this->team->id}/widgets/999999",
+            ['widget_name' => 'Ghost'],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+    }
+
+    public function test_can_delete_a_widget(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        $response = $this->json(
+            'DELETE',
+            "api/v1/teams/{$this->team->id}/widgets/{$widget->id}",
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure(['message']);
+
+        $this->assertSoftDeleted('widgets', ['id' => $widget->id]);
+    }
+
+    public function test_delete_returns_404_for_unknown_widget(): void
+    {
+        $response = $this->json(
+            'DELETE',
+            "api/v1/teams/{$this->team->id}/widgets/999999",
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+    }
+
+    public function test_track_records_valid_frontend_event(): void
+    {
+        Queue::fake();
+
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        $response = $this->json(
+            'POST',
+            "api/v1/teams/{$this->team->id}/widgets/{$widget->id}/track",
+            [
+                'event_type'    => WidgetAnalytic::EVENT_GATEWAY_CLICK,
+                'entity_id'     => 42,
+                'entity_type'   => 'dataset',
+                'source_domain' => 'partner-site.org',
+            ]
+        );
+
+        $response->assertStatus(204);
+
+        Queue::assertPushed(WidgetAnalyticsJob::class, function ($job) use ($widget) {
+            $data = $this->getJobData($job);
+            return $data['event_type'] === WidgetAnalytic::EVENT_GATEWAY_CLICK
+                && $data['widget_id'] === $widget->id
+                && $data['entity_id'] === 42
+                && $data['entity_type'] === 'dataset'
+                && $data['source_domain'] === 'partner-site.org';
+        });
+
+        $widget->forceDelete();
+    }
+
+    public function test_track_rejects_invalid_event_type(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        $response = $this->json(
+            'POST',
+            "api/v1/teams/{$this->team->id}/widgets/{$widget->id}/track",
+            ['event_type' => 'not_a_real_event']
+        );
+
+        $response->assertStatus(422);
+
+        $widget->forceDelete();
+    }
+
+    public function test_track_rejects_backend_only_event_types(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        // widget_created and widget_load are backend-only; the frontend must not be able to fake them
+        foreach ([WidgetAnalytic::EVENT_WIDGET_CREATED, WidgetAnalytic::EVENT_WIDGET_LOAD] as $event) {
+            $response = $this->json(
+                'POST',
+                "api/v1/teams/{$this->team->id}/widgets/{$widget->id}/track",
+                ['event_type' => $event]
+            );
+
+            $response->assertStatus(422);
+        }
+
+        $widget->forceDelete();
+    }
+
+    public function test_track_returns_404_for_unknown_widget(): void
+    {
+        $response = $this->json(
+            'POST',
+            "api/v1/teams/{$this->team->id}/widgets/999999/track",
+            ['event_type' => WidgetAnalytic::EVENT_PAGE_VIEW]
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_NOT_FOUND.code'));
+    }
+
+    public function test_analytics_returns_aggregated_data(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        WidgetAnalytic::insert([
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_WIDGET_LOAD, 'entity_id' => null, 'entity_type' => null, 'source_domain' => 'example.com', 'created_at' => now()->subDays(2)],
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_WIDGET_LOAD, 'entity_id' => null, 'entity_type' => null, 'source_domain' => 'example.com', 'created_at' => now()->subDays(1)],
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_GATEWAY_CLICK, 'entity_id' => 1, 'entity_type' => 'dataset', 'source_domain' => 'example.com', 'created_at' => now()],
+        ]);
+
+        $response = $this->get("api/v1/teams/{$this->team->id}/widgets/analytics", $this->header);
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'))
+            ->assertJsonStructure([
+                'data' => [
+                    'by_event',
+                    'by_widget',
+                    'over_time',
+                ],
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $byEvent = collect($content['data']['by_event'])->keyBy('event_type');
+        $this->assertGreaterThanOrEqual(2, $byEvent[WidgetAnalytic::EVENT_WIDGET_LOAD]['count']);
+        $this->assertGreaterThanOrEqual(1, $byEvent[WidgetAnalytic::EVENT_GATEWAY_CLICK]['count']);
+
+        WidgetAnalytic::where('widget_id', $widget->id)->delete();
+        $widget->forceDelete();
+    }
+
+    public function test_analytics_respects_date_range_filter(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        WidgetAnalytic::insert([
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_WIDGET_LOAD, 'entity_id' => null, 'entity_type' => null, 'source_domain' => null, 'created_at' => now()->subDays(60)],
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_WIDGET_LOAD, 'entity_id' => null, 'entity_type' => null, 'source_domain' => null, 'created_at' => now()->subDays(5)],
+        ]);
+
+        $from = now()->subDays(10)->format('Y-m-d');
+        $to   = now()->format('Y-m-d');
+
+        $response = $this->get(
+            "api/v1/teams/{$this->team->id}/widgets/analytics?from={$from}&to={$to}",
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $content  = $response->decodeResponseJson();
+        $byEvent  = collect($content['data']['by_event'])->keyBy('event_type');
+        // Only the event within the date window should appear
+        $this->assertEquals(1, $byEvent[WidgetAnalytic::EVENT_WIDGET_LOAD]['count'] ?? 0);
+
+        WidgetAnalytic::where('widget_id', $widget->id)->delete();
+        $widget->forceDelete();
+    }
+
+    public function test_analytics_returns_400_with_errors_on_invalid_params(): void
+    {
+        $response = $this->get(
+            "api/v1/teams/{$this->team->id}/widgets/analytics?from=not-a-date&group_by=decade",
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_BAD_REQUEST.code'))
+            ->assertJsonStructure(['message', 'errors']);
+
+        $errors = $response->decodeResponseJson()['errors'];
+        $this->assertArrayHasKey('from', $errors);
+        $this->assertArrayHasKey('group_by', $errors);
+    }
+
+    public function test_analytics_supports_monthly_grouping(): void
+    {
+        $widget = Widget::factory()->create(['team_id' => $this->team->id]);
+
+        WidgetAnalytic::insert([
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_PAGE_VIEW, 'entity_id' => null, 'entity_type' => null, 'source_domain' => null, 'created_at' => now()->subMonths(1)],
+            ['widget_id' => $widget->id, 'team_id' => $this->team->id, 'event_type' => WidgetAnalytic::EVENT_PAGE_VIEW, 'entity_id' => null, 'entity_type' => null, 'source_domain' => null, 'created_at' => now()],
+        ]);
+
+        $response = $this->get(
+            "api/v1/teams/{$this->team->id}/widgets/analytics?group_by=month",
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $content  = $response->decodeResponseJson();
+        $periods  = collect($content['data']['over_time'])->pluck('period')->unique()->values()->all();
+        $this->assertGreaterThanOrEqual(2, count($periods));
+
+        WidgetAnalytic::where('widget_id', $widget->id)->delete();
+        $widget->forceDelete();
+    }
+
+    // Extracts the protected $data property from a queued job for assertions
+    private function getJobData(WidgetAnalyticsJob $job): array
+    {
+        $reflection = new \ReflectionClass($job);
+        $property = $reflection->getProperty('data');
+        $property->setAccessible(true);
+        return $property->getValue($job);
+    }
+}


### PR DESCRIPTION
> AI disclaimer: Sonnet 4.6 was used in the creation of this PR. Claude was instructed to build the tests that prove the solution and add various documentation (swagger annotations) where appropriate.

## Screenshots (if relevant)
<img width="1339" height="1137" alt="image" src="https://github.com/user-attachments/assets/8711154f-3d8c-4012-aa6d-e9eb821b056c" />

## Describe your changes
Implements several current and future aspects for tracking capabilities for widget usage. Current automated tracking are `widget_load` and `widget_created`. Future available tracking operations include: `search`, `gateway_click`, `page_view` and `code_copied` that will need the widget FE to be updated and call `/track` on the API.

I also noticed that the original widget code, lacked factories, seeders etc, so while building tests, this was handled.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8130

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
Yes.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
