### PR TITLE
feat(GAT-9032): Adds new custodian dashboard feature flag. Also adds …

### DIFF
--- a/app/Console/Commands/MakeDeploymentStep.php
+++ b/app/Console/Commands/MakeDeploymentStep.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class MakeDeploymentStep extends Command
+{
+    protected $signature = 'make:deployment-step {name : Snake-case description, e.g. reindex_datasets}';
+
+    protected $description = 'Scaffold a new deployment step file';
+
+    public function handle(): int
+    {
+        $name     = Str::snake($this->argument('name'));
+        $prefix   = now()->format('Y_m_d_His');
+        $filename = "{$prefix}_{$name}.php";
+        $dir      = config('deployment.steps_path', database_path('deployment-steps'));
+        $path     = "{$dir}/{$filename}";
+
+        if (file_exists($path)) {
+            $this->error("File already exists: {$path}");
+            return self::FAILURE;
+        }
+
+        file_put_contents($path, $this->stub());
+
+        $this->info("Created: {$path}");
+
+        return self::SUCCESS;
+    }
+
+    private function stub(): string
+    {
+        return <<<PHP
+        <?php
+
+        use App\DeploymentSteps\DeploymentStep;
+
+        return new class () extends DeploymentStep {
+            public function handle(): void
+            {
+                //
+            }
+        };
+        PHP;
+    }
+}

--- a/database/seeders/FeatureSeeder.php
+++ b/database/seeders/FeatureSeeder.php
@@ -16,6 +16,7 @@ class FeatureSeeder extends Seeder
         'RQuest' => true,
         'CohortDiscoveryService' => false,
         'V2_SearchAggregation' => false,
+        'V3_CustodianDashboard' => false,
     ];
 
     public function run(): void


### PR DESCRIPTION
…artisan command to scaffold new deployment-steps

## Screenshots (if relevant)

## Describe your changes
Adds in a feature flag for protecting the custodian dashboard will in development. Also adds artisan command to scaffold new deployment-step files `php artisan make:deployment-step <some_name>`

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9032

## Environment / Configuration changes (if applicable)
None

## Requires migrations being run?
No, but does require `php artisan db:seed --class=FeatureSeeder` being run.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
