### PR TITLE
feat(GAT-9075): Typesense service and mocks initial commit

### DIFF
--- a/app/Providers/TypesenseServiceProvider.php
+++ b/app/Providers/TypesenseServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\TypesenseService;
+use Illuminate\Support\ServiceProvider;
+
+class TypesenseServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(TypesenseService::class, function () {
+            return new TypesenseService();
+        });
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Services/TypesenseService.php
+++ b/app/Services/TypesenseService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services;
+
+use Typesense\Client;
+
+class TypesenseService
+{
+    private Client $client;
+
+    public function __construct(?Client $client = null)
+    {
+        if ($client !== null) {
+            $this->client = $client;
+            return;
+        }
+
+        $settings = config('scout.typesense.client-settings');
+
+        $this->client = new Client([
+            'api_key'                      => $settings['api_key'],
+            'nodes'                        => $settings['nodes'],
+            'nearest_node'                 => $settings['nearest_node'] ?? null,
+            'connection_timeout_seconds'   => $settings['connection_timeout_seconds'] ?? 2,
+            'healthcheck_interval_seconds' => $settings['healthcheck_interval_seconds'] ?? 30,
+            'num_retries'                  => $settings['num_retries'] ?? 3,
+            'retry_interval_seconds'       => $settings['retry_interval_seconds'] ?? 1,
+        ]);
+    }
+
+    /**
+     * Search via Scout — respects the model's typesenseSearchParameters() and
+     * typesenseCollectionSchema(). Additional $options are merged on top of the
+     * model defaults (query_by, facet_by, filter_by, pagination, etc.).
+     *
+     * Returns the raw Typesense response array.
+     */
+    public function search(string $modelClass, string $query, array $options = []): array
+    {
+        return $this->executeScoutSearch($modelClass, $query ?: '*', $options);
+    }
+
+    protected function executeScoutSearch(string $modelClass, string $query, array $options): array
+    {
+        return $modelClass::search($query)->options($options)->raw();
+    }
+
+    /**
+     * Search directly against a named collection, bypassing Scout.
+     * Use when you need precise control over parameters or are querying
+     * a collection that isn't backed by an Eloquent model.
+     */
+    public function rawSearch(string $collection, string $query, array $params = []): array
+    {
+        return $this->client->collections[$collection]->documents->search(
+            array_merge(['q' => $query ?: '*'], $params)
+        );
+    }
+
+    public function listCollections(): array
+    {
+        return $this->client->collections->retrieve();
+    }
+
+    public function collectionExists(string $collection): bool
+    {
+        try {
+            $this->client->collections[$collection]->retrieve();
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    public function getCollection(string $collection): array
+    {
+        return $this->client->collections[$collection]->retrieve();
+    }
+
+    /**
+     * Create a collection from a raw schema array.
+     * To create from a model's typesenseCollectionSchema(), use createCollectionFromModel().
+     */
+    public function createCollection(array $schema): array
+    {
+        return $this->client->collections->create($schema);
+    }
+
+    /**
+     * Create a Typesense collection using the schema defined on a Searchable model.
+     */
+    public function createCollectionFromModel(string $modelClass): array
+    {
+        $model = new $modelClass();
+        return $this->createCollection($model->typesenseCollectionSchema());
+    }
+
+    public function dropCollection(string $collection): array
+    {
+        return $this->client->collections[$collection]->delete();
+    }
+
+    /**
+     * Upsert a single document. The document must include the collection's
+     * default_sorting_field if one is defined.
+     */
+    public function upsertDocument(string $collection, array $document): array
+    {
+        return $this->client->collections[$collection]->documents->upsert($document);
+    }
+
+    public function deleteDocument(string $collection, string $id): array
+    {
+        return $this->client->collections[$collection]->documents[$id]->delete();
+    }
+
+    public function getDocument(string $collection, string $id): array
+    {
+        return $this->client->collections[$collection]->documents[$id]->retrieve();
+    }
+
+    /**
+     * Returns the number of documents currently indexed in a collection.
+     */
+    public function documentCount(string $collection): int
+    {
+        return $this->getCollection($collection)['num_documents'] ?? 0;
+    }
+
+    public function health(): array
+    {
+        return $this->client->health->retrieve();
+    }
+
+    public function metrics(): array
+    {
+        return $this->client->metrics->retrieve();
+    }
+
+    /**
+     * Returns the underlying Typesense client for any operations not covered
+     * by the methods above.
+     */
+    public function client(): Client
+    {
+        return $this->client;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "staudenmeir/belongs-to-through": "^2.5",
         "staudenmeir/eloquent-has-many-deep": "^1.7",
         "swaggest/json-diff": "^3.12",
+        "typesense/typesense-php": "^4.9",
         "webklex/laravel-imap": "^6.0"
     },
     "require-dev": {

--- a/config/app.php
+++ b/config/app.php
@@ -205,6 +205,7 @@ return [
         App\Providers\CloudLoggerProvider::class,
         App\Providers\CloudPubSubProvider::class,
         App\Providers\ElasticClientControllerServiceProvider::class,
+        App\Providers\TypesenseServiceProvider::class,
         App\Providers\HelperServiceProvider::class,
         App\Providers\AppFeatureServiceProvider::class,
         App\Providers\SearchServiceProvider::class,

--- a/tests/Unit/Services/TypesenseServiceTest.php
+++ b/tests/Unit/Services/TypesenseServiceTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use Tests\TestCase;
+use Mockery;
+use Mockery\MockInterface;
+use App\Services\TypesenseService;
+use Typesense\Client;
+use Typesense\Collection;
+use Typesense\Collections;
+use Typesense\Document;
+use Typesense\Documents;
+use Typesense\Health;
+use Typesense\Metrics;
+
+class TypesenseServiceTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Mock hierarchy builder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a full Typesense client mock hierarchy and returns the service
+     * wired to it, along with each mock for per-test configuration.
+     *
+     * @return array{service: TypesenseService, client: MockInterface, collections: MockInterface, collection: MockInterface, documents: MockInterface, document: MockInterface, health: MockInterface, metrics: MockInterface}
+     */
+    private function makeService(): array
+    {
+        $mockDocument = Mockery::mock(Document::class);
+        $mockDocument->shouldReceive('retrieve')->byDefault()->andReturn(['id' => '1', 'title' => 'Test']);
+        $mockDocument->shouldReceive('delete')->byDefault()->andReturn(['id' => '1']);
+
+        $mockDocuments = Mockery::mock(Documents::class);
+        $mockDocuments->shouldReceive('search')->byDefault()->andReturn(['found' => 0, 'hits' => []]);
+        $mockDocuments->shouldReceive('upsert')->byDefault()->andReturn(['id' => '1']);
+        $mockDocuments->shouldReceive('offsetGet')->byDefault()->andReturn($mockDocument);
+
+        $mockCollection = Mockery::mock(Collection::class);
+        $mockCollection->shouldReceive('retrieve')->byDefault()->andReturn(['name' => 'dataset_versions', 'num_documents' => 42]);
+        $mockCollection->shouldReceive('delete')->byDefault()->andReturn(['name' => 'dataset_versions']);
+        $mockCollection->documents = $mockDocuments;
+
+        $mockCollections = Mockery::mock(Collections::class);
+        $mockCollections->shouldReceive('retrieve')->byDefault()->andReturn([['name' => 'dataset_versions'], ['name' => 'tools']]);
+        $mockCollections->shouldReceive('create')->byDefault()->andReturn(['name' => 'new_collection']);
+        $mockCollections->shouldReceive('offsetGet')->byDefault()->andReturn($mockCollection);
+
+        $mockHealth = Mockery::mock(Health::class);
+        $mockHealth->shouldReceive('retrieve')->byDefault()->andReturn(['ok' => true]);
+
+        $mockMetrics = Mockery::mock(Metrics::class);
+        $mockMetrics->shouldReceive('retrieve')->byDefault()->andReturn(['latency_ms' => 1]);
+
+        $mockClient = Mockery::mock(Client::class);
+        $mockClient->collections = $mockCollections;
+        $mockClient->health      = $mockHealth;
+        $mockClient->metrics     = $mockMetrics;
+
+        $service = new TypesenseService($mockClient);
+
+        return compact('service', 'mockClient', 'mockCollections', 'mockCollection', 'mockDocuments', 'mockDocument', 'mockHealth', 'mockMetrics');
+    }
+
+    // -------------------------------------------------------------------------
+    // client()
+    // -------------------------------------------------------------------------
+
+    public function test_client_returns_the_underlying_typesense_client(): void
+    {
+        ['service' => $service, 'mockClient' => $mockClient] = $this->makeService();
+
+        $this->assertSame($mockClient, $service->client());
+    }
+
+    // -------------------------------------------------------------------------
+    // rawSearch
+    // -------------------------------------------------------------------------
+
+    public function test_rawSearch_passes_query_and_params_to_typesense(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments] = $this->makeService();
+
+        $expected = ['found' => 1, 'hits' => [['document' => ['id' => '844']]]];
+        $params   = ['query_by' => 'title,abstract', 'per_page' => 10];
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('search')
+            ->once()
+            ->with(array_merge(['q' => 'cancer'], $params))
+            ->andReturn($expected);
+
+        $result = $service->rawSearch('dataset_versions', 'cancer', $params);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_rawSearch_converts_empty_query_to_wildcard(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('search')
+            ->once()
+            ->with(['q' => '*'])
+            ->andReturn(['found' => 1437, 'hits' => []]);
+
+        $service->rawSearch('dataset_versions', '', []);
+    }
+
+    public function test_rawSearch_merges_params_after_q_so_caller_can_override(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('search')
+            ->once()
+            ->with(['q' => 'cancer', 'per_page' => 5])
+            ->andReturn(['found' => 0, 'hits' => []]);
+
+        $service->rawSearch('dataset_versions', 'cancer', ['per_page' => 5]);
+    }
+
+    // -------------------------------------------------------------------------
+    // search (Scout delegation — unit-tests the wildcard conversion only;
+    // full search behaviour is covered by Feature/V2/SearchAggregationTest)
+    // -------------------------------------------------------------------------
+
+    public function test_search_converts_empty_query_to_wildcard(): void
+    {
+        // Spy on the TypesenseService to assert the query reaching Scout is '*'.
+        // We partially mock the service so we can intercept executeScoutSearch()
+        // without pulling in a real Typesense engine.
+        $mocks = $this->makeService();
+
+        $service = Mockery::mock(TypesenseService::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+
+        $service->shouldReceive('executeScoutSearch')
+            ->once()
+            ->with(\Mockery::any(), '*', \Mockery::any())
+            ->andReturn(['found' => 0, 'hits' => []]);
+
+        $service->search('App\Models\DatasetVersion', '', []);
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection management
+    // -------------------------------------------------------------------------
+
+    public function test_listCollections_returns_all_collections(): void
+    {
+        ['service' => $service] = $this->makeService();
+
+        $result = $service->listCollections();
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('dataset_versions', $result[0]['name']);
+        $this->assertEquals('tools', $result[1]['name']);
+    }
+
+    public function test_collectionExists_returns_true_when_collection_is_found(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockCollection->shouldReceive('retrieve')->once()->andReturn(['name' => 'dataset_versions']);
+
+        $this->assertTrue($service->collectionExists('dataset_versions'));
+    }
+
+    public function test_collectionExists_returns_false_when_collection_is_not_found(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('missing')->andReturnUsing(function () {
+            throw new \Exception('Not found', 404);
+        });
+
+        $this->assertFalse($service->collectionExists('missing'));
+    }
+
+    public function test_getCollection_returns_collection_info(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection] = $this->makeService();
+
+        $expected = ['name' => 'dataset_versions', 'num_documents' => 1437, 'fields' => []];
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockCollection->shouldReceive('retrieve')->once()->andReturn($expected);
+
+        $this->assertEquals($expected, $service->getCollection('dataset_versions'));
+    }
+
+    public function test_createCollection_passes_schema_to_typesense(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections] = $this->makeService();
+
+        $schema = ['name' => 'new_collection', 'fields' => [['name' => 'id', 'type' => 'string']]];
+
+        $mockCollections->shouldReceive('create')->once()->with($schema)->andReturn($schema);
+
+        $result = $service->createCollection($schema);
+
+        $this->assertEquals($schema, $result);
+    }
+
+    public function test_createCollectionFromModel_uses_model_schema(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections] = $this->makeService();
+
+        $schema = ['name' => 'test_collection', 'fields' => [['name' => 'id', 'type' => 'string']]];
+
+        $modelClass = new class () {
+            public function typesenseCollectionSchema(): array
+            {
+                return ['name' => 'test_collection', 'fields' => [['name' => 'id', 'type' => 'string']]];
+            }
+        };
+
+        $mockCollections->shouldReceive('create')->once()->with($schema)->andReturn($schema);
+
+        $result = $service->createCollectionFromModel($modelClass::class);
+
+        $this->assertEquals($schema, $result);
+    }
+
+    public function test_dropCollection_calls_delete_on_the_collection(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockCollection->shouldReceive('delete')->once()->andReturn(['name' => 'dataset_versions']);
+
+        $result = $service->dropCollection('dataset_versions');
+
+        $this->assertEquals(['name' => 'dataset_versions'], $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Document operations
+    // -------------------------------------------------------------------------
+
+    public function test_upsertDocument_passes_document_to_typesense(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments] = $this->makeService();
+
+        $document = ['id' => '42', 'title' => 'UK Biobank'];
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('upsert')->once()->with($document)->andReturn($document);
+
+        $result = $service->upsertDocument('dataset_versions', $document);
+
+        $this->assertEquals($document, $result);
+    }
+
+    public function test_deleteDocument_removes_document_by_id(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments, 'mockDocument' => $mockDocument] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('offsetGet')->with('42')->andReturn($mockDocument);
+        $mockDocument->shouldReceive('delete')->once()->andReturn(['id' => '42']);
+
+        $result = $service->deleteDocument('dataset_versions', '42');
+
+        $this->assertEquals(['id' => '42'], $result);
+    }
+
+    public function test_getDocument_retrieves_document_by_id(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection, 'mockDocuments' => $mockDocuments, 'mockDocument' => $mockDocument] = $this->makeService();
+
+        $expected = ['id' => '844', 'title' => 'NHS GGC Diabetes'];
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockDocuments->shouldReceive('offsetGet')->with('844')->andReturn($mockDocument);
+        $mockDocument->shouldReceive('retrieve')->once()->andReturn($expected);
+
+        $result = $service->getDocument('dataset_versions', '844');
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_documentCount_reads_num_documents_from_collection_info(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockCollection->shouldReceive('retrieve')->once()->andReturn(['name' => 'dataset_versions', 'num_documents' => 1437]);
+
+        $this->assertEquals(1437, $service->documentCount('dataset_versions'));
+    }
+
+    public function test_documentCount_returns_zero_when_key_is_missing(): void
+    {
+        ['service' => $service, 'mockCollections' => $mockCollections, 'mockCollection' => $mockCollection] = $this->makeService();
+
+        $mockCollections->shouldReceive('offsetGet')->with('dataset_versions')->andReturn($mockCollection);
+        $mockCollection->shouldReceive('retrieve')->once()->andReturn(['name' => 'dataset_versions']);
+
+        $this->assertEquals(0, $service->documentCount('dataset_versions'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Health / diagnostics
+    // -------------------------------------------------------------------------
+
+    public function test_health_returns_typesense_health_status(): void
+    {
+        ['service' => $service, 'mockHealth' => $mockHealth] = $this->makeService();
+
+        $mockHealth->shouldReceive('retrieve')->once()->andReturn(['ok' => true]);
+
+        $this->assertEquals(['ok' => true], $service->health());
+    }
+
+    public function test_metrics_returns_typesense_metrics(): void
+    {
+        ['service' => $service, 'mockMetrics' => $mockMetrics] = $this->makeService();
+
+        $mockMetrics->shouldReceive('retrieve')->once()->andReturn(['latency_ms' => 2]);
+
+        $this->assertEquals(['latency_ms' => 2], $service->metrics());
+    }
+}


### PR DESCRIPTION
> AI usage disclaimer - Claude Sonnet 4.6 was use in the writing of this PR. Claude was instructed to build unit/feature tests to prove the additional service functions as expected.

## Screenshots (if relevant)
N/A

## Describe your changes
Adds in a new Typesense service for use when the entities are moved over from Elastic. Not currently in use by anything.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9075

## Environment / Configuration changes (if applicable)
Not yet, but full Typesense config will need adding to envs/infra.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
