### PR TITLE
feat(GAT-9078): groundwork changes for Typesense usage

### DIFF
--- a/app/Models/Base/BaseTypesenseModel.php
+++ b/app/Models/Base/BaseTypesenseModel.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Base;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+/**
+ * @property int $id
+ */
+abstract class BaseTypesenseModel extends Model
+{
+    use Searchable;
+
+    public function getScoutKeyName()
+    {
+        return 'id';
+    }
+    public function getScoutKey()
+    {
+        return (string) $this->id;
+    }
+    public function searchableAs()
+    {
+        return config('scout.prefix') . $this->getTable();
+    }
+
+    abstract public function typesenseCollectionSchema(): array;
+    abstract public function typesenseSearchParameters(): array;
+}

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -7,6 +7,7 @@ use App\Http\Traits\DatasetFetch;
 use App\Models\Traits\SortManager;
 use App\Models\Traits\EntityCounter;
 use App\Observers\CollectionObserver;
+use App\Models\Base\BaseTypesenseModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Validator;
@@ -18,7 +19,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-
 use Laravel\Scout\Searchable;
 
 /**
@@ -45,7 +45,7 @@ use Laravel\Scout\Searchable;
  * )
  */
 #[ObservedBy([CollectionObserver::class])]
-class Collection extends Model
+class Collection extends BaseTypesenseModel
 {
     use HasFactory;
     use Notifiable;
@@ -279,4 +279,22 @@ class Collection extends Model
         )->withPivot('role');
     }
 
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
+    }
 }

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -19,6 +19,8 @@ use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
+use Laravel\Scout\Searchable;
+
 /**
  * @OA\Schema(
  *   schema="Collection",
@@ -52,6 +54,7 @@ class Collection extends Model
     use DatasetFetch;
     use SortManager;
     use EntityCounter;
+    use Searchable;
 
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_DRAFT = 'DRAFT';

--- a/app/Models/DataProviderColl.php
+++ b/app/Models/DataProviderColl.php
@@ -2,18 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Base\BaseTypesenseModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-use Laravel\Scout\Searchable;
-
-class DataProviderColl extends Model
+class DataProviderColl extends BaseTypesenseModel
 {
     use HasFactory;
     use SoftDeletes;
-    use Searchable;
 
     protected $fillable = [
         'enabled',
@@ -72,5 +70,24 @@ class DataProviderColl extends Model
             Team::class,
             'data_provider_coll_has_teams'
         );
+    }
+
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
     }
 }

--- a/app/Models/DataProviderColl.php
+++ b/app/Models/DataProviderColl.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+use Laravel\Scout\Searchable;
+
 class DataProviderColl extends Model
 {
     use HasFactory;
     use SoftDeletes;
+    use Searchable;
 
     protected $fillable = [
         'enabled',

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Base\BaseTypesenseModel;
 use Illuminate\Database\Eloquent\Model;
 use App\Observers\DatasetVersionObserver;
 use Illuminate\Database\Eloquent\Builder;
@@ -13,8 +14,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-
-use Laravel\Scout\Searchable;
 
 /**
  * @OA\Schema(
@@ -43,12 +42,11 @@ use Laravel\Scout\Searchable;
  * )
  */
 #[ObservedBy(DatasetVersionObserver::class)]
-class DatasetVersion extends Model
+class DatasetVersion extends BaseTypesenseModel
 {
     use HasFactory;
     use SoftDeletes;
     use Prunable;
-    use Searchable;
 
     /**
      * Table associated with this model
@@ -251,5 +249,24 @@ class DatasetVersion extends Model
         return $this->belongsTo(Dataset::class, 'dataset_id', 'id')
             ->where('status', 'ACTIVE')
             ->select(['id', 'status']);
+    }
+
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
     }
 }

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+use Laravel\Scout\Searchable;
+
 /**
  * @OA\Schema(
  *   schema="DatasetVersion",
@@ -46,6 +48,7 @@ class DatasetVersion extends Model
     use HasFactory;
     use SoftDeletes;
     use Prunable;
+    use Searchable;
 
     /**
      * Table associated with this model

--- a/app/Models/Dur.php
+++ b/app/Models/Dur.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Base\BaseTypesenseModel;
 use App\Http\Traits\DatasetFetch;
 use App\Models\Traits\EntityCounter;
 use App\Models\Traits\SortManager;
@@ -15,8 +16,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
-
-use Laravel\Scout\Searchable;
 
 /**
  * @OA\Schema(
@@ -75,7 +74,7 @@ use Laravel\Scout\Searchable;
  * )
  */
 #[ObservedBy([DurObserver::class])]
-class Dur extends Model
+class Dur extends BaseTypesenseModel
 {
     use HasFactory;
     use SoftDeletes;
@@ -83,7 +82,6 @@ class Dur extends Model
     use DatasetFetch;
     use SortManager;
     use EntityCounter;
-    use Searchable;
 
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_DRAFT = 'DRAFT';
@@ -371,4 +369,22 @@ class Dur extends Model
         ->where('collections.status', 'ACTIVE');
     }
 
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
+    }
 }

--- a/app/Models/Dur.php
+++ b/app/Models/Dur.php
@@ -16,6 +16,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+use Laravel\Scout\Searchable;
+
 /**
  * @OA\Schema(
  *   schema="Dur",
@@ -81,6 +83,7 @@ class Dur extends Model
     use DatasetFetch;
     use SortManager;
     use EntityCounter;
+    use Searchable;
 
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_DRAFT = 'DRAFT';

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Traits\DatasetFetch;
+use App\Models\Base\BaseTypesenseModel;
 use App\Models\Traits\SortManager;
 use App\Models\Traits\EntityCounter;
 use App\Observers\PublicationObserver;
@@ -12,7 +13,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-
 use Laravel\Scout\Searchable;
 
 /**
@@ -42,7 +42,7 @@ use Laravel\Scout\Searchable;
  * )
  */
 #[ObservedBy([PublicationObserver::class])]
-class Publication extends Model
+class Publication extends BaseTypesenseModel
 {
     use HasFactory;
     use SoftDeletes;
@@ -167,5 +167,24 @@ class Publication extends Model
             Keyword::class,
             'publication_has_keywords'
         );
+    }
+
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
     }
 }

--- a/app/Models/Publication.php
+++ b/app/Models/Publication.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+use Laravel\Scout\Searchable;
+
 /**
  * @OA\Schema(
  *   schema="Publication",
@@ -48,6 +50,7 @@ class Publication extends Model
     use DatasetFetch;
     use SortManager;
     use EntityCounter;
+    use Searchable;
 
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_DRAFT = 'DRAFT';

--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -6,6 +6,7 @@ use App\Http\Traits\DatasetFetch;
 use App\Models\Traits\EntityCounter;
 use App\Models\Traits\SortManager;
 use App\Observers\ToolObserver;
+use App\Models\Base\BaseTypesenseModel;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -44,7 +45,7 @@ use Illuminate\Notifications\Notifiable;
  * )
  */
 #[ObservedBy([ToolObserver::class])]
-class Tool extends Model
+class Tool extends BaseTypesenseModel
 {
     use HasFactory;
     use Notifiable;
@@ -225,5 +226,24 @@ class Tool extends Model
             'dataset_versions.dataset_id',
             Dataset::where('status', 'ACTIVE')->select('id')
         );
+    }
+
+    public function typesenseSearchParameters(): array
+    {
+        return [
+            'query_by' => '', // TODO
+            'query_by_weights' => '', // TODO
+        ];
+    }
+
+    public function typesenseCollectionSchema(): array
+    {
+        return [
+            'name' => $this->searchableAs(),
+            'fields' => [
+                // TODO
+                [ 'name' => '', 'type' => '' ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
## Screenshots (if relevant)
N/A

## Describe your changes
Begins to implement changes required for Typesense usage. Current candidates for migration are: Collections, DataCustodianNetwork (DataProviderColl), DatasetVersion, Tool, DUR and Publication.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9078

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
