### PR TITLE
fix(GAT-8925): Fix incorrect config read on cohort expiry command

### DIFF
--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -200,7 +200,7 @@ class CohortUserExpiry extends Command
 
         if ($expiryField === 'nhse_sde_request_expire_at') {
             $basedOnUpdatedAt = $cohort->nhse_sde_updated_at
-                ? $cohort->nhse_sde_updated_at->copy()->addDays((int) Config::get('cohort.cohort_access_expiry_time_in_days'))
+                ? $cohort->nhse_sde_updated_at->copy()->addDays((int) Config::get('cohort.cohort_nhse_sde_access_expiry_time_in_days'))
                 : null;
         } else {
             $basedOnUpdatedAt = $cohort->updated_at->copy()->addDays((int) Config::get('cohort.cohort_access_expiry_time_in_days'));

--- a/tests/Feature/CohortRequestTest.php
+++ b/tests/Feature/CohortRequestTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 //use App\Models\UserHasWorkgroup;
 //use App\Models\Workgroup;
 use Config;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
@@ -208,6 +209,58 @@ class CohortRequestTest extends TestCase
         ]);
 
         $responseGetOne->assertStatus(200);
+    }
+
+    /**
+     * NHSE SDE request approval should set nhse_sde_request_expire_at to 5 years
+     * (1825 days, per COHORT_NHSE_SDE_ACCESS_EXPIRY_TIME_IN_DAYS in .env) from now.
+     *
+     */
+    public function test_update_cohort_request_nhse_sde_approval_sets_five_year_expiry(): void
+    {
+        Mail::fake();
+
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 1825);
+
+        // create
+        $responseCreate = $this->json(
+            'POST',
+            self::TEST_URL,
+            [
+                'details' => 'Test cohort request',
+            ],
+            $this->header,
+        );
+
+        $responseCreate->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
+
+        $id = $responseCreate->decodeResponseJson()['data'];
+
+        $now = Carbon::now();
+        $responseUpdate = $this->json(
+            'PUT',
+            self::TEST_URL.'/'.$id,
+            [
+                'request_status' => 'PENDING',
+                'nhse_sde_request_status' => 'APPROVED',
+                'details' => 'Praesentium ut et quae suscipit ut quo adipisci. Enim ut tenetur ad omnis ut consequatur. Aliquid officiis expedita rerum - nhse sde approved.',
+            ],
+            $this->header,
+        );
+
+        $responseUpdate->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+
+        $cohortRequest = CohortRequest::where('id', $id)->first();
+
+        $this->assertNotNull($cohortRequest->nhse_sde_request_expire_at);
+
+        $expectedExpiry = $now->copy()->addDays(1825);
+        $this->assertEqualsWithDelta(
+            $expectedExpiry->timestamp,
+            $cohortRequest->nhse_sde_request_expire_at->timestamp,
+            5,
+            'nhse_sde_request_expire_at should be exactly 1825 days (5 years) from the time of approval.'
+        );
     }
 
     public function test_update_cohort_request_with_cds_enabled_success(): void

--- a/tests/Unit/CohortUserExpiryTest.php
+++ b/tests/Unit/CohortUserExpiryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Config;
 use Tests\TestCase;
 use App\Jobs\SendEmailJob;
 use App\Jobs\TermExtraction;
@@ -124,18 +125,21 @@ class CohortUserExpiryTest extends TestCase
 
     public function test_it_can_expire_nhse_sde_requests(): void
     {
+        Config::set('cohort.cohort_access_expiry_time_in_days', 50);
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 400);
+
         $req = CohortRequest::create([
             'user_id' => 1,
             'request_status' => 'APPROVED',
             'nhse_sde_request_status' => 'APPROVED',
             'request_expire_at' => null,
             'nhse_sde_request_expire_at' => null,
-            'created_at' => Carbon::now()->subDays(181),
+            'created_at' => Carbon::now()->subDays(401),
         ]);
 
         $cr = CohortRequest::find($req->id);
-        $cr->updated_at = Carbon::now()->subDays(100); // standard access not yet expired
-        $cr->nhse_sde_updated_at = Carbon::now()->subDays(181); // NHSE SDE access expired
+        $cr->updated_at = Carbon::now()->subDays(10); // standard: well within its own 50-day window
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(401); // NHSE SDE access expired (past its own 400-day window)
         $cr->save();
 
         $perms = Permission::where([
@@ -173,18 +177,21 @@ class CohortUserExpiryTest extends TestCase
     {
         Mail::fake();
 
+        Config::set('cohort.cohort_access_expiry_time_in_days', 50);
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 400);
+
         $req = CohortRequest::create([
             'user_id' => 1,
             'request_status' => 'APPROVED',
             'nhse_sde_request_status' => 'APPROVED',
             'request_expire_at' => null,
             'nhse_sde_request_expire_at' => null,
-            'created_at' => Carbon::now()->subDays(181),
+            'created_at' => Carbon::now()->subDays(100),
         ]);
 
         $cr = CohortRequest::find($req->id);
-        $cr->updated_at = Carbon::now()->subDays(100);
-        $cr->nhse_sde_updated_at = Carbon::now()->subDays(100); // still within the window
+        $cr->updated_at = Carbon::now()->subDays(10);
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(100);
         $cr->save();
 
         $perms = Permission::where([
@@ -213,18 +220,21 @@ class CohortUserExpiryTest extends TestCase
 
     public function test_nhse_sde_expiry_does_not_affect_standard_request(): void
     {
+        Config::set('cohort.cohort_access_expiry_time_in_days', 50);
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 400);
+
         $req = CohortRequest::create([
             'user_id' => 1,
             'request_status' => 'APPROVED',
             'nhse_sde_request_status' => 'APPROVED',
             'request_expire_at' => null,
             'nhse_sde_request_expire_at' => null,
-            'created_at' => Carbon::now()->subDays(181),
+            'created_at' => Carbon::now()->subDays(401),
         ]);
 
         $cr = CohortRequest::find($req->id);
-        $cr->updated_at = Carbon::now()->subDays(100); // standard NOT expired
-        $cr->nhse_sde_updated_at = Carbon::now()->subDays(181); // NHSE SDE expired
+        $cr->updated_at = Carbon::now()->subDays(10); // standard NOT expired (within its own 50-day window)
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(401); // NHSE SDE expired (past its own 400-day window)
         $cr->save();
 
         $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
@@ -292,20 +302,23 @@ class CohortUserExpiryTest extends TestCase
 
     public function test_it_sends_warning_email_when_nhse_sde_request_nearing_expiry(): void
     {
+        Config::set('cohort.cohort_access_expiry_time_in_days', 50);
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 400);
+
         $req = CohortRequest::create([
             'user_id' => 1,
             'request_status' => 'APPROVED',
             'nhse_sde_request_status' => 'APPROVED',
             'request_expire_at' => null,
             'nhse_sde_request_expire_at' => null,
-            'created_at' => Carbon::now()->subDays(179),
+            'created_at' => Carbon::now()->subDays(399),
         ]);
 
-        // Both within warning window (1 day left each), but let's make standard not in window
-        // and NHSE SDE in window to isolate the test.
+        // Make standard not in window and NHSE SDE in window (1 day left of its
+        // own 400-day window) to isolate the test.
         $cr = CohortRequest::find($req->id);
-        $cr->updated_at = Carbon::now()->subDays(100); // standard: 80 days left, not in warning
-        $cr->nhse_sde_updated_at = Carbon::now()->subDays(179); // NHSE SDE: 1 day left, in warning
+        $cr->updated_at = Carbon::now()->subDays(10); // standard: 40 days left, not in warning
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(399); // NHSE SDE: 1 day left, in warning
         $cr->save();
 
         $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
@@ -349,6 +362,8 @@ class CohortUserExpiryTest extends TestCase
 
     public function test_explicit_nhse_sde_expire_at_date_triggers_expiry(): void
     {
+        Config::set('cohort.cohort_nhse_sde_access_expiry_time_in_days', 400);
+
         $req = CohortRequest::create([
             'user_id' => 1,
             'request_status' => 'APPROVED',
@@ -360,7 +375,7 @@ class CohortUserExpiryTest extends TestCase
 
         $cr = CohortRequest::find($req->id);
         $cr->updated_at = Carbon::now()->subDays(10);
-        $cr->nhse_sde_updated_at = Carbon::now()->subDays(10); // time-based expiry is 170 days away
+        $cr->nhse_sde_updated_at = Carbon::now()->subDays(10); // time-based expiry is ~390 days away
         $cr->save();
 
         $perms = Permission::where([
@@ -376,7 +391,7 @@ class CohortUserExpiryTest extends TestCase
         $this->artisan('app:cohort-user-expiry')->assertExitCode(0);
 
         // Explicit nhse_sde_request_expire_at was yesterday → must expire even though
-        // nhse_sde_updated_at + 180 days is still far in the future.
+        // nhse_sde_updated_at + 400 days is still far in the future.
         $this->assertDatabaseHas('cohort_requests', [
             'id' => $req->id,
             'nhse_sde_request_status' => 'EXPIRED',


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

The wrong config value was being used when calculating the expiry date for nhse sde.

Also created a test to cover the nhse sde approval on `PUT /api/v1/cohort_requests/{id}`

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-8925

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
