### PR TITLE
feat(GAT-9149): Prevents AppCheck returning a NoSQL vulnerability inc…

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -909,6 +909,12 @@ class SearchController extends Controller
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
+        // Explicitly to prevent AppCheck vulnerability scan which exposes
+        // a false positive.
+        if ($request->query('view_type', null) !== null) {
+            return response()->json('bad request', 400);
+        }
+
         $input = $request->all();
         $download = array_key_exists('download', $input) ? $input['download'] : false;
         $sort = $request->query('sort', 'score:desc');

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -762,6 +762,18 @@ class SearchTest extends TestCase
         $response->assertStatus(400);
     }
 
+    public function test_publications_search_returns_400_for_view_type_param(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL_SEARCH . '/publications?view_type=list',
+            ['query' => 'term'],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(400);
+    }
+
     /**
      * Search using a query with success
      *


### PR DESCRIPTION
…orrectly

## Screenshots (if relevant)

## Describe your changes
Small explicit rejection for AppCheck surfacing a NoSQL injection vulnerability in error. Now returns a 400 if `view_type` is sent to this endpoint, as it is unused.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9149

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
