### PR TITLE
feat(GAT-9018): add queryable gwdm_version column to dataset_versions

### DIFF
--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -77,6 +77,10 @@ class DatasetVersion extends BaseTypesenseModel
         // from the reconstructed GWDM metadata at write time.
         'title',
         'short_title',
+        // Queryable GWDM schema version for this row (see migration
+        // 2026_06_17_000001). Replaces reading from metadata->gwdmVersion, which
+        // is absent on delta rows and unindexed on all rows.
+        'gwdm_version',
     ];
 
     /**
@@ -239,16 +243,14 @@ class DatasetVersion extends BaseTypesenseModel
             'dataset_version_source_id',
             'dataset_version_target_id',
             'linkage_type',
-        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id,
-        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(metadata), '$.metadata.summary.title')) as title,
-        short_title as shortTitle");
+        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle");
     }
 
     public function dataset(): BelongsTo
     {
         return $this->belongsTo(Dataset::class, 'dataset_id', 'id')
             ->where('status', 'ACTIVE')
-            ->select(['id', 'status']);
+            ->select(['id', 'status', 'team_id']);
     }
 
     public function shouldBeSearchable(): bool

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -3,22 +3,23 @@
 namespace App\Models;
 
 use App\Models\Base\BaseTypesenseModel;
-use Illuminate\Database\Eloquent\Model;
 use App\Observers\DatasetVersionObserver;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @OA\Schema(
  *   schema="DatasetVersion",
  *   description="A versioned snapshot of dataset metadata in GWDM format",
+ *
  *   @OA\Property(property="id", type="integer", example=101),
  *   @OA\Property(property="dataset_id", type="integer", example=1),
  *   @OA\Property(property="version", type="integer", example=3),
@@ -35,8 +36,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  *     type="array",
  *     nullable=true,
  *     description="RFC 6902 JSON Patch array used to reconstruct this version from the previous snapshot. Null for full snapshots (v1 and every 10th version).",
+ *
  *     @OA\Items(type="object")
  *   ),
+ *
  *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-01-15T10:30:00Z"),
  *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-06-01T08:00:00Z"),
  * )
@@ -45,8 +48,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 class DatasetVersion extends BaseTypesenseModel
 {
     use HasFactory;
-    use SoftDeletes;
     use Prunable;
+    use SoftDeletes;
 
     /**
      * Table associated with this model
@@ -57,7 +60,7 @@ class DatasetVersion extends BaseTypesenseModel
 
     protected $casts = [
         'metadata' => 'array',
-        'patch'    => 'array',
+        'patch' => 'array',
     ];
 
     /**
@@ -85,8 +88,6 @@ class DatasetVersion extends BaseTypesenseModel
 
     /**
      * Get and Set the metadata.
-     *
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function metadata(): Attribute
     {
@@ -96,6 +97,7 @@ class DatasetVersion extends BaseTypesenseModel
                 if (is_string($response)) {
                     $response = json_decode($response, true);
                 }
+
                 return $response;
             },
             set: fn ($value) => is_array($value) ? json_encode($value) : $value,
@@ -109,8 +111,7 @@ class DatasetVersion extends BaseTypesenseModel
      * to the encoding of the string being added to the db field.
      * Needs further investigation as this is just a workaround.
      *
-     * @param $value The original value prior to pre-processing
-     *
+     * @param  $value  The original value prior to pre-processing
      * @return array The json metadata string as an array
      */
     // public function getMetadataAttribute($value): array
@@ -132,12 +133,8 @@ class DatasetVersion extends BaseTypesenseModel
     // }
 
     /**
-    * Scope a query to filter on metadata summary title
-    *
-    * @param Builder $query
-    * @param string $filterTitle
-    * @return Builder
-    */
+     * Scope a query to filter on metadata summary title
+     */
     public function scopeFilterTitle(Builder $query, string $filterTitle): Builder
     {
         return $query->where('title', 'LIKE', "%{$filterTitle}%");
@@ -158,7 +155,6 @@ class DatasetVersion extends BaseTypesenseModel
     {
         return $this->belongsToMany(SpatialCoverage::class, 'dataset_version_has_spatial_coverage');
     }
-
 
     /**
      * The tools that belong to the dataset version.
@@ -228,10 +224,10 @@ class DatasetVersion extends BaseTypesenseModel
     }
 
     /**
-    * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
-    * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
-    * we can easily switch. - Jamie B
-    */
+     * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
+     * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
+     * we can easily switch. - Jamie B
+     */
     public function reducedLinkedDatasetVersions(): BelongsToMany
     {
         return $this->belongsToMany(
@@ -243,14 +239,14 @@ class DatasetVersion extends BaseTypesenseModel
             'dataset_version_source_id',
             'dataset_version_target_id',
             'linkage_type',
-        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle");
+        )->selectRaw('dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle');
     }
 
     public function dataset(): BelongsTo
     {
         return $this->belongsTo(Dataset::class, 'dataset_id', 'id')
             ->where('status', 'ACTIVE')
-            ->select(['id', 'status', 'team_id']);
+            ->select(['id', 'status']);
     }
 
     public function shouldBeSearchable(): bool
@@ -285,47 +281,47 @@ class DatasetVersion extends BaseTypesenseModel
     {
         $meta = $this->metadata ?? [];
 
-        $keywords   = data_get($meta, 'metadata.summary.keywords', '');
-        $dataType   = data_get($meta, 'metadata.summary.datasetType', '');
+        $keywords = data_get($meta, 'metadata.summary.keywords', '');
+        $dataType = data_get($meta, 'metadata.summary.datasetType', '');
         $conformsTo = data_get($meta, 'metadata.accessibility.formatAndStandards.conformsTo', '');
         $structural = data_get($meta, 'metadata.structuralMetadata', []);
         if (is_string($structural)) {
             $structural = json_decode($structural, true) ?? [];
         }
-        if (!is_array($structural)) {
+        if (! is_array($structural)) {
             $structural = [];
         }
 
         return [
-            'id'                            => (string) $this->id,
-            'dataset_id'                    => (string) $this->dataset_id,
-            'title'                         => $this->title ?? '',
-            'shortTitle'                    => $this->short_title ?? '',
-            'abstract'                      => data_get($meta, 'metadata.summary.abstract', ''),
-            'description'                   => data_get($meta, 'metadata.summary.description', ''),
-            'keywords'                      => array_values(array_filter(explode(';,;', $keywords))),
-            'publisherName'                 => data_get(
+            'id' => (string) $this->id,
+            'dataset_id' => (string) $this->dataset_id,
+            'title' => $this->title ?? '',
+            'shortTitle' => $this->short_title ?? '',
+            'abstract' => data_get($meta, 'metadata.summary.abstract', ''),
+            'description' => data_get($meta, 'metadata.summary.description', ''),
+            'keywords' => array_values(array_filter(explode(';,;', $keywords))),
+            'publisherName' => data_get(
                 $meta,
                 'metadata.summary.publisher.name',
                 data_get($meta, 'metadata.summary.publisher.publisherName', '')
             ),
-            'dataType'                      => array_values(array_filter(explode(';,;', $dataType))),
-            'populationSize'                => (int) data_get($meta, 'metadata.summary.populationSize', -1),
-            'geographicLocation'            => $this->spatialCoverage->pluck('region')->all(),
-            'datasetDOI'                    => data_get($meta, 'metadata.summary.doiName', ''),
-            'conformsTo'                    => array_values(array_filter(explode(';,;', $conformsTo))),
-            'structuralTableNames'          => collect($structural)
-                                                ->pluck('name')
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnNames'         => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnDescriptions'  => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
+            'dataType' => array_values(array_filter(explode(';,;', $dataType))),
+            'populationSize' => (int) data_get($meta, 'metadata.summary.populationSize', -1),
+            'geographicLocation' => $this->spatialCoverage->pluck('region')->all(),
+            'datasetDOI' => data_get($meta, 'metadata.summary.doiName', ''),
+            'conformsTo' => array_values(array_filter(explode(';,;', $conformsTo))),
+            'structuralTableNames' => collect($structural)
+                ->pluck('name')
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnNames' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnDescriptions' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
         ];
     }
 

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -3,23 +3,22 @@
 namespace App\Models;
 
 use App\Models\Base\BaseTypesenseModel;
-use App\Observers\DatasetVersionObserver;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Observers\DatasetVersionObserver;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @OA\Schema(
  *   schema="DatasetVersion",
  *   description="A versioned snapshot of dataset metadata in GWDM format",
- *
  *   @OA\Property(property="id", type="integer", example=101),
  *   @OA\Property(property="dataset_id", type="integer", example=1),
  *   @OA\Property(property="version", type="integer", example=3),
@@ -36,10 +35,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  *     type="array",
  *     nullable=true,
  *     description="RFC 6902 JSON Patch array used to reconstruct this version from the previous snapshot. Null for full snapshots (v1 and every 10th version).",
- *
  *     @OA\Items(type="object")
  *   ),
- *
  *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-01-15T10:30:00Z"),
  *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-06-01T08:00:00Z"),
  * )
@@ -48,8 +45,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class DatasetVersion extends BaseTypesenseModel
 {
     use HasFactory;
-    use Prunable;
     use SoftDeletes;
+    use Prunable;
 
     /**
      * Table associated with this model
@@ -60,7 +57,7 @@ class DatasetVersion extends BaseTypesenseModel
 
     protected $casts = [
         'metadata' => 'array',
-        'patch' => 'array',
+        'patch'    => 'array',
     ];
 
     /**
@@ -88,6 +85,8 @@ class DatasetVersion extends BaseTypesenseModel
 
     /**
      * Get and Set the metadata.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function metadata(): Attribute
     {
@@ -97,7 +96,6 @@ class DatasetVersion extends BaseTypesenseModel
                 if (is_string($response)) {
                     $response = json_decode($response, true);
                 }
-
                 return $response;
             },
             set: fn ($value) => is_array($value) ? json_encode($value) : $value,
@@ -111,7 +109,8 @@ class DatasetVersion extends BaseTypesenseModel
      * to the encoding of the string being added to the db field.
      * Needs further investigation as this is just a workaround.
      *
-     * @param  $value  The original value prior to pre-processing
+     * @param $value The original value prior to pre-processing
+     *
      * @return array The json metadata string as an array
      */
     // public function getMetadataAttribute($value): array
@@ -133,8 +132,12 @@ class DatasetVersion extends BaseTypesenseModel
     // }
 
     /**
-     * Scope a query to filter on metadata summary title
-     */
+    * Scope a query to filter on metadata summary title
+    *
+    * @param Builder $query
+    * @param string $filterTitle
+    * @return Builder
+    */
     public function scopeFilterTitle(Builder $query, string $filterTitle): Builder
     {
         return $query->where('title', 'LIKE', "%{$filterTitle}%");
@@ -155,6 +158,7 @@ class DatasetVersion extends BaseTypesenseModel
     {
         return $this->belongsToMany(SpatialCoverage::class, 'dataset_version_has_spatial_coverage');
     }
+
 
     /**
      * The tools that belong to the dataset version.
@@ -224,10 +228,10 @@ class DatasetVersion extends BaseTypesenseModel
     }
 
     /**
-     * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
-     * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
-     * we can easily switch. - Jamie B
-     */
+    * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
+    * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
+    * we can easily switch. - Jamie B
+    */
     public function reducedLinkedDatasetVersions(): BelongsToMany
     {
         return $this->belongsToMany(
@@ -281,47 +285,47 @@ class DatasetVersion extends BaseTypesenseModel
     {
         $meta = $this->metadata ?? [];
 
-        $keywords = data_get($meta, 'metadata.summary.keywords', '');
-        $dataType = data_get($meta, 'metadata.summary.datasetType', '');
+        $keywords   = data_get($meta, 'metadata.summary.keywords', '');
+        $dataType   = data_get($meta, 'metadata.summary.datasetType', '');
         $conformsTo = data_get($meta, 'metadata.accessibility.formatAndStandards.conformsTo', '');
         $structural = data_get($meta, 'metadata.structuralMetadata', []);
         if (is_string($structural)) {
             $structural = json_decode($structural, true) ?? [];
         }
-        if (! is_array($structural)) {
+        if (!is_array($structural)) {
             $structural = [];
         }
 
         return [
-            'id' => (string) $this->id,
-            'dataset_id' => (string) $this->dataset_id,
-            'title' => $this->title ?? '',
-            'shortTitle' => $this->short_title ?? '',
-            'abstract' => data_get($meta, 'metadata.summary.abstract', ''),
-            'description' => data_get($meta, 'metadata.summary.description', ''),
-            'keywords' => array_values(array_filter(explode(';,;', $keywords))),
-            'publisherName' => data_get(
+            'id'                            => (string) $this->id,
+            'dataset_id'                    => (string) $this->dataset_id,
+            'title'                         => $this->title ?? '',
+            'shortTitle'                    => $this->short_title ?? '',
+            'abstract'                      => data_get($meta, 'metadata.summary.abstract', ''),
+            'description'                   => data_get($meta, 'metadata.summary.description', ''),
+            'keywords'                      => array_values(array_filter(explode(';,;', $keywords))),
+            'publisherName'                 => data_get(
                 $meta,
                 'metadata.summary.publisher.name',
                 data_get($meta, 'metadata.summary.publisher.publisherName', '')
             ),
-            'dataType' => array_values(array_filter(explode(';,;', $dataType))),
-            'populationSize' => (int) data_get($meta, 'metadata.summary.populationSize', -1),
-            'geographicLocation' => $this->spatialCoverage->pluck('region')->all(),
-            'datasetDOI' => data_get($meta, 'metadata.summary.doiName', ''),
-            'conformsTo' => array_values(array_filter(explode(';,;', $conformsTo))),
-            'structuralTableNames' => collect($structural)
-                ->pluck('name')
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
-            'structuralColumnNames' => collect($structural)
-                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
-            'structuralColumnDescriptions' => collect($structural)
-                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
+            'dataType'                      => array_values(array_filter(explode(';,;', $dataType))),
+            'populationSize'                => (int) data_get($meta, 'metadata.summary.populationSize', -1),
+            'geographicLocation'            => $this->spatialCoverage->pluck('region')->all(),
+            'datasetDOI'                    => data_get($meta, 'metadata.summary.doiName', ''),
+            'conformsTo'                    => array_values(array_filter(explode(';,;', $conformsTo))),
+            'structuralTableNames'          => collect($structural)
+                                                ->pluck('name')
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
+            'structuralColumnNames'         => collect($structural)
+                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
+            'structuralColumnDescriptions'  => collect($structural)
+                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
         ];
     }
 

--- a/database/deployment-steps/2026_07_14_140156_backfill_gwdm_version.php
+++ b/database/deployment-steps/2026_07_14_140156_backfill_gwdm_version.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Back-fill dataset_versions.gwdm_version from the JSON metadata envelope.
+ *
+ * The column (migration 2026_06_17_000001) defaults to '2.0', which is correct for
+ * new rows but wrong for legacy rows written under GWDM 1.x / 2.0 — their real
+ * version lives in metadata->gwdmVersion. This step copies it across so version
+ * resolution (handler selection, snapshot-on-schema-change, backfill source
+ * selection) reads the true schema version for existing data.
+ *
+ * COALESCE falls back to '2.0' where the JSON path is absent (delta rows store a
+ * reduced envelope, legacy rows may have a bare/empty metadata array).
+ *
+ * MySQL-only: JSON_UNQUOTE/JSON_EXTRACT are unavailable in SQLite (the test DB),
+ * where the '2.0' column default already covers fixtures — so this is a no-op there.
+ */
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+        if (DB::connection()->getDriverName() !== 'mysql') {
+            $this->info('Skipping gwdm_version back-fill: connection is not MySQL.');
+
+            return;
+        }
+
+        $affected = DB::update("
+            UPDATE dataset_versions
+            SET gwdm_version = COALESCE(
+                JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
+                '2.0'
+            )
+            WHERE deleted_at IS NULL
+        ");
+
+        $this->info("Back-filled gwdm_version on {$affected} dataset_versions row(s).");
+    }
+};

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -25,10 +25,6 @@ return new class () extends Migration {
             $table->index('gwdm_version');
         });
 
-        // Data back-fill of existing rows from metadata->gwdmVersion is handled by a
-        // deployment step (database/deployment-steps/*_backfill_gwdm_version.php),
-        // which runs via `php artisan deploy:run` after migrations. New rows get the
-        // '2.0' column default until the service layer sets an explicit version.
     }
 
     public function down(): void

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a queryable gwdm_version column to dataset_versions.
+ *
+ * Previously the GWDM version was only stored inside the JSON metadata envelope
+ * (metadata->gwdmVersion), which is unindexed and NULL on delta rows (where
+ * metadata stores only {gwdmVersion, original_metadata} without the full GWDM).
+ *
+ * This column is the authoritative discriminator for:
+ *   - Which GWDM schema version a row was written under
+ *   - Selecting the latest version for a specific schema context
+ *     (e.g. "give me the most recent GWDM 2.1 row for dataset 42")
+ *   - Future GWDM 3.0 rows that use structured SQL columns instead of JSON
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->string('gwdm_version', 20)->default('2.0')->after('version');
+            $table->index('gwdm_version');
+        });
+
+        // Back-fill from the JSON envelope.
+        //
+        // Snapshot rows (patch IS NULL) have gwdmVersion set in metadata->gwdmVersion.
+        // Delta rows (patch IS NOT NULL) store a reduced envelope where metadata = []
+        // or metadata = {gwdmVersion, original_metadata} — JSON_EXTRACT may return NULL.
+        //
+        // COALESCE falls back to '2.0' for any row where the JSON path is absent
+        // (delta rows, legacy rows, or rows where metadata is a bare empty array).
+        // This is always correct because no GWDM 2.1+ data exists in the DB today.
+        //
+        // Guarded to MySQL only — JSON_UNQUOTE/JSON_EXTRACT are not available in
+        // SQLite (used by the test suite). The column default of '2.0' covers
+        // test fixtures correctly.
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("
+                UPDATE dataset_versions
+                SET gwdm_version = COALESCE(
+                    JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
+                    '2.0'
+                )
+                WHERE deleted_at IS NULL
+            ");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->dropIndex(['gwdm_version']);
+            $table->dropColumn('gwdm_version');
+        });
+    }
+};

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -26,29 +25,10 @@ return new class () extends Migration {
             $table->index('gwdm_version');
         });
 
-        // Back-fill from the JSON envelope.
-        //
-        // Snapshot rows (patch IS NULL) have gwdmVersion set in metadata->gwdmVersion.
-        // Delta rows (patch IS NOT NULL) store a reduced envelope where metadata = []
-        // or metadata = {gwdmVersion, original_metadata} — JSON_EXTRACT may return NULL.
-        //
-        // COALESCE falls back to '2.0' for any row where the JSON path is absent
-        // (delta rows, legacy rows, or rows where metadata is a bare empty array).
-        // This is always correct because no GWDM 2.1+ data exists in the DB today.
-        //
-        // Guarded to MySQL only — JSON_UNQUOTE/JSON_EXTRACT are not available in
-        // SQLite (used by the test suite). The column default of '2.0' covers
-        // test fixtures correctly.
-        if (DB::connection()->getDriverName() === 'mysql') {
-            DB::statement("
-                UPDATE dataset_versions
-                SET gwdm_version = COALESCE(
-                    JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
-                    '2.0'
-                )
-                WHERE deleted_at IS NULL
-            ");
-        }
+        // Data back-fill of existing rows from metadata->gwdmVersion is handled by a
+        // deployment step (database/deployment-steps/*_backfill_gwdm_version.php),
+        // which runs via `php artisan deploy:run` after migrations. New rows get the
+        // '2.0' column default until the service layer sets an explicit version.
     }
 
     public function down(): void

--- a/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
+++ b/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * PR1 coverage for the queryable gwdm_version column on dataset_versions
+ * (migration 2026_06_17_000001) and the reduced-relation selectRaw change on
+ * DatasetVersion that now reads the title column directly rather than extracting
+ * it from the JSON metadata envelope.
+ */
+class DatasetVersionGwdmVersionColumnTest extends TestCase
+{
+    private function seededDatasetId(): int
+    {
+        return Dataset::query()->firstOrFail()->id;
+    }
+
+    public function test_gwdm_version_column_exists_and_defaults_to_2_0(): void
+    {
+        $this->assertTrue(Schema::hasColumn('dataset_versions', 'gwdm_version'));
+
+        $dv = DatasetVersion::withoutEvents(fn () => DatasetVersion::create([
+            'dataset_id' => $this->seededDatasetId(),
+            'version' => 1,
+            'metadata' => json_encode(['gwdmVersion' => '2.0']),
+        ]));
+
+        // No explicit gwdm_version supplied -> the column default applies.
+        $this->assertSame('2.0', $dv->fresh()->gwdm_version);
+    }
+
+    public function test_gwdm_version_is_mass_assignable(): void
+    {
+        $dv = DatasetVersion::withoutEvents(fn () => DatasetVersion::create([
+            'dataset_id' => $this->seededDatasetId(),
+            'version' => 1,
+            'gwdm_version' => '2.1',
+            'metadata' => json_encode(['gwdmVersion' => '2.1']),
+        ]));
+
+        $this->assertSame('2.1', $dv->fresh()->gwdm_version);
+    }
+
+    public function test_reduced_linked_dataset_versions_reads_title_column_for_delta_row(): void
+    {
+        $datasetId = $this->seededDatasetId();
+
+        [$source, $target] = DatasetVersion::withoutEvents(function () use ($datasetId) {
+            $source = DatasetVersion::create([
+                'dataset_id' => $datasetId,
+                'version' => 101,
+                'metadata' => json_encode(['gwdmVersion' => '2.0']),
+                'title' => 'Source Title',
+                'short_title' => 'ST',
+            ]);
+
+            // Delta row: patch present, title lives only in the column (not in the
+            // reduced metadata envelope). The selectRaw must still surface it.
+            $target = DatasetVersion::create([
+                'dataset_id' => $datasetId,
+                'version' => 102,
+                'patch' => json_encode([]),
+                'metadata' => json_encode(['gwdmVersion' => '2.0']),
+                'title' => 'Target Title',
+                'short_title' => 'TT',
+            ]);
+
+            return [$source, $target];
+        });
+
+        DB::table('dataset_version_has_dataset_version')->insert([
+            'dataset_version_source_id' => $source->id,
+            'dataset_version_target_id' => $target->id,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => true,
+        ]);
+
+        $linked = $source->reducedLinkedDatasetVersions()->first();
+
+        $this->assertNotNull($linked);
+        $this->assertSame('Target Title', $linked->title);
+        $this->assertSame('TT', $linked->shortTitle);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

N/A — schema + model change only.

## Describe your changes

**PR 1 of 5** splitting the GWDM 3.0 branch (`feat/GAT-9018`) into ordered, independently-reviewable PRs. This is the base of the stack.

Adds a queryable `gwdm_version` column to `dataset_versions`:
- Migration `2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php` — indexed `varchar(20)` column, default `'2.0'`. **Schema only, no data mutation.**
- Deployment step `database/deployment-steps/2026_07_14_140156_backfill_gwdm_version.php` — back-fills existing rows from `metadata->gwdmVersion` (MySQL-guarded `COALESCE`, `'2.0'` fallback). Runs via `php artisan deploy:run` after migrations on deploy (`docker/start.sh`); run-once, forward-only; no-op on SQLite where the column default suffices. This keeps data back-fills out of migrations, per the repo's deployment-steps system.
- `DatasetVersion` model: adds `gwdm_version` to `$fillable`; switches `reducedLinkedDatasetVersions()` `selectRaw` to read the `title` column directly instead of `JSON_EXTRACT` (the old MySQL-only JSON functions could not run under SQLite); widens the constrained `dataset()` relation select to include `team_id` (consumed by team-scoped `checkAccess($input, $dataset->team_id, …)` in the V2/V3 controllers landing in later PRs of this stack).

Rationale: the GWDM version previously lived only inside the JSON metadata envelope — unindexed on all rows and NULL on delta rows. A real column makes it the authoritative discriminator for version/schema selection and future GWDM 3.0 rows.

## Issue ticket link

[GAT-9018](https://hdruk.atlassian.net/browse/GAT-9018)

## Environment / Configuration changes (if applicable)

None.

## Requires migrations being run?

Yes — `2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php`, plus `php artisan deploy:run` to execute the `backfill_gwdm_version` deployment step (both run automatically on deploy via `docker/start.sh`).

## If not using the pre-push hook. Confirm tests pass:

- `pest tests/Feature/DatasetVersionGwdmVersionColumnTest.php` — 3 passed (column default `'2.0'`, mass-assignability, reduced-relation reads the `title` column for a delta row).
- `composer run phpstan` — clean (0 errors).

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate) — N/A
- [ ] I have added appropriate Behat tests to confirm AC (if applicable) — N/A
- [ ] I have added Swagger annotations for new endpoints (if applicable) — no new endpoints
- [ ] I have added audit logs for new operation logic (if applicable) — N/A
- [ ] I have added new environment variables to the .env.example file (if applicable) — N/A
- [ ] I have added new environment variables to terraform repository (if applicable) — N/A


[GAT-9018]: https://hdruk.atlassian.net/browse/GAT-9018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ