### PR TITLE
feat(GAT-9216):  [POC]  activate GWDM 3.0 handler + V3 version endpoints

### DIFF
--- a/app/Http/Controllers/Api/V3/DatasetController.php
+++ b/app/Http/Controllers/Api/V3/DatasetController.php
@@ -127,6 +127,45 @@ class DatasetController extends Controller
     }
 
     /**
+     * GET /api/v3/datasets/{id}/metadata-versions
+     *
+     * Return a summary of which GWDM schema versions are present across all
+     * dataset_version rows for this dataset, and how many rows belong to each.
+     */
+    public function metadataVersions(Request $request, int $id): JsonResponse
+    {
+        try {
+            $dataset = Dataset::find($id);
+
+            if (!$dataset) {
+                return response()->json(['message' => 'Dataset not found'], 404);
+            }
+
+            $summary    = $this->datasetService->getMetadataVersionSummary($dataset);
+            $validation = $this->datasetService->validateAllVersions($dataset);
+
+            Auditor::log([
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => 'Dataset ' . $id . ' metadata version summary retrieved',
+            ]);
+
+            return response()->json([
+                'message' => 'success',
+                'data'    => array_merge($summary, ['validation' => $validation]),
+            ]);
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
      * GET /api/v3/datasets/{id}/version/{version}
      *
      * Return the fully reconstructed metadata envelope for a specific

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -319,9 +319,15 @@ trait IndexElastic
                 $latestVersion = $dataset->latestVersion();
                 if ($latestVersion) {
                     $datasetVersionIds[] = $latestVersion->id;
-                    $metadata = $latestVersion->metadata;
-                    $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
-                    $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
+                    // Reconstruct via the handler system rather than reading the raw
+                    // metadata column: GWDM 3.0 rows store their sections in SQL (or
+                    // the denormalised cache), so the JSON blob has no 'metadata' key
+                    // to read directly. Mirrors the reconstruction reindexElastic() does.
+                    $metadata = $this->reconstructedLatestEnvelope($dataset);
+                    $datasetTitles[] = $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], '');
+                    // datasetType may be a delimited string (2.x) or an array (3.0);
+                    // normalizeDelimitedList() handles both.
+                    $types = $this->normalizeDelimitedList($this->getValueByPossibleKeys($metadata, ['metadata.summary.datasetType'], ''));
                     foreach ($types as $t) {
                         if (!in_array($t, $dataTypes)) {
                             $dataTypes[] = $t;

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -40,6 +40,26 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-01-15T10:30:00Z"),
  *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-06-01T08:00:00Z"),
  * )
+ *
+ * GWDM 3.0 SQL section relations, hydrated dynamically via setRelation() by
+ * Gwdm30Handler::preloadSections()/preloadSectionsForVersions() (there are no
+ * relation methods on this model; these declarations type the read access):
+ * @property-read \App\Models\Gwdm30\Summary|null $gwdm30Summary
+ * @property-read \App\Models\Gwdm30\Coverage|null $gwdm30Coverage
+ * @property-read \App\Models\Gwdm30\Provenance|null $gwdm30Provenance
+ * @property-read \App\Models\Gwdm30\Accessibility|null $gwdm30Accessibility
+ * @property-read \App\Models\Gwdm30\LinkageMeta|null $gwdm30LinkageMeta
+ * @property-read \App\Models\Gwdm30\Omics|null $gwdm30Omics
+ * @property-read \App\Models\Gwdm30\Erd|null $gwdm30Erd
+ * @property-read \App\Models\Gwdm30\Required|null $gwdm30Required
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\Observation> $gwdm30Observations
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\DemographicFrequency> $gwdm30DemographicFrequencies
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\Distribution> $gwdm30Distributions
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\QualityAnnotation> $gwdm30QualityAnnotations
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\StructuralTable> $gwdm30StructuralTables
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\TissueSampleCollection> $gwdm30TissueSampleCollections
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\ProjectGrant> $gwdm30ProjectGrants
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Gwdm30\DatasetFilter> $gwdm30DatasetFilters
  */
 #[ObservedBy(DatasetVersionObserver::class)]
 class DatasetVersion extends BaseTypesenseModel

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -376,6 +376,14 @@ class DatasetService
             ->orderBy('version')
             ->get();
 
+        // Batch-preload GWDM 3.0 SQL sections across all versions up front so the
+        // per-row afterRead() below reads hydrated relations instead of issuing
+        // ~16 queries per 3.0 row (N+1).
+        $versions30 = $versions->where('gwdm_version', '3.0');
+        if ($versions30->isNotEmpty()) {
+            $this->handlerFactory->resolve('3.0')->preloadSectionsForVersions($versions30);
+        }
+
         $results = [];
         $schemaName = Config::get('metadata.GWDM.name');
 
@@ -997,7 +1005,14 @@ class DatasetService
             ->value('gwdm_version');
         $schemaChanged = $previousGwdmVersion !== null && $previousGwdmVersion !== $targetGwdmVersion;
 
-        $isSnapshot = ($newVersionNumber % self::SNAPSHOT_INTERVAL === 0) || $schemaChanged;
+        // GWDM 3.0 stores its section content in dedicated SQL tables, not in the
+        // JSON envelope — a delta patch would (a) be reconstructed from SQL anyway
+        // and (b) duplicate the section values (incl. any PII) into the immutable
+        // patch column, where they would survive SQL-row erasure. So 3.0 rows are
+        // always snapshots (patch = null); reconstruction reads them straight from SQL.
+        $isPii3xVersion = $targetGwdmVersion === '3.0';
+
+        $isSnapshot = ($newVersionNumber % self::SNAPSHOT_INTERVAL === 0) || $schemaChanged || $isPii3xVersion;
 
         // Persist the version row and its handler-owned structured tables in a
         // single transaction. Without this, a failure inside afterStore() (e.g.

--- a/app/Services/Gwdm/Gwdm30Handler.php
+++ b/app/Services/Gwdm/Gwdm30Handler.php
@@ -1,0 +1,958 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Gwdm30\Accessibility;
+use App\Models\Gwdm30\Coverage;
+use App\Models\Gwdm30\DatasetFilter;
+use App\Models\Gwdm30\DemographicFrequency;
+use App\Models\Gwdm30\Distribution;
+use App\Models\Gwdm30\Erd;
+use App\Models\Gwdm30\LinkageMeta;
+use App\Models\Gwdm30\Observation;
+use App\Models\Gwdm30\Omics;
+use App\Models\Gwdm30\ProjectGrant;
+use App\Models\Gwdm30\Provenance;
+use App\Models\Gwdm30\QualityAnnotation;
+use App\Models\Gwdm30\Required;
+use App\Models\Gwdm30\StructuralColumn;
+use App\Models\Gwdm30\StructuralTable;
+use App\Models\Gwdm30\StructuralValue;
+use App\Models\Gwdm30\Summary;
+use App\Models\Gwdm30\TissueSampleCollection;
+use App\Models\PublicationHasDatasetVersion;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Handler for GWDM 3.0.
+ *
+ * Extends Gwdm2xHandler because the 3.0 metadata schema is a superset of
+ * 2.x: the required block, publisher field format, and linkage extraction
+ * are all identical. Only the persistence strategy differs — every GWDM
+ * section is written to dedicated SQL tables rather than solely to the
+ * JSON metadata blob.
+ *
+ * extractLinkages() is inherited from Gwdm2xHandler unchanged — both 2.x
+ * and 3.0 write dataset linkages to dataset_version_has_dataset_version.
+ */
+class Gwdm30Handler extends Gwdm2xHandler
+{
+    public function afterStore(Dataset $dataset, DatasetVersion $dv, array $gwdm): void
+    {
+        $this->persist($dv, $gwdm);
+
+        // Write dataset/publication linkage junctions synchronously from the input
+        // metadata. Unlike 2.x, these arrays are NOT recoverable later: persist()
+        // stores only the linkage *meta* subset, and readLinkages() rebuilds the
+        // datasetLinkage/publication sections from the junction tables themselves.
+        // The async LinkageExtraction job (extractLinkages) is therefore a no-op
+        // for 3.0 — see the override below.
+        $this->writeLinkages($dv, $gwdm);
+    }
+
+    /**
+     * No-op for GWDM 3.0: linkage junctions are written synchronously in
+     * afterStore() from the input metadata (see above). Running the async job's
+     * reconstruction here would read the junctions back from themselves and do
+     * redundant work.
+     */
+    public function extractLinkages(DatasetVersion $dv): void
+    {
+        // intentionally empty
+    }
+
+    public function afterRead(DatasetVersion $dv): array
+    {
+        return $this->read($dv);
+    }
+
+    public function buildEnvelope(array $gwdm, array $originalMetadata): array
+    {
+        return [
+            'gwdmVersion'       => $this->version(),
+            'original_metadata' => $originalMetadata,
+        ];
+    }
+
+    public function extractStoredGwdm(array $storedData): array
+    {
+        return [];
+    }
+
+    // ── Write path ────────────────────────────────────────────────────────────
+
+    private function persist(DatasetVersion $dv, array $gwdm): void
+    {
+        $access = $gwdm['accessibility']['access'] ?? [];
+        $usage = $gwdm['accessibility']['usage'] ?? [];
+        $fmts = $gwdm['accessibility']['formatAndStandards'] ?? [];
+        $summary = $gwdm['summary'] ?? [];
+        $coverage = $gwdm['coverage'] ?? [];
+        $origin = $gwdm['provenance']['origin'] ?? [];
+        $temporal = $gwdm['provenance']['temporal'] ?? [];
+        $retention = $gwdm['provenance']['retentionPeriod'] ?? [];
+        $observations = $gwdm['observations'] ?? [];
+        $linkageMeta = $gwdm['linkage'] ?? [];
+        $omics = $gwdm['omics'] ?? [];
+        $demo = $gwdm['demographicFrequency'] ?? [];
+        $distributions = $gwdm['distributions'] ?? [];
+        $qualityAnnotations = $gwdm['qualityAnnotations'] ?? [];
+        $required = $gwdm['required'] ?? [];
+        $structuralMetadata = $gwdm['structuralMetadata'] ?? [];
+        $tissuesSampleCollection = $gwdm['tissuesSampleCollection'] ?? [];
+        $projectGrants = $gwdm['projectGrants'] ?? [];
+        $datasetFilters = $gwdm['datasetFilters'] ?? [];
+        $erd = $gwdm['erd'] ?? [];
+
+        DB::transaction(function () use ($dv, $access, $usage, $fmts, $summary, $coverage, $origin, $temporal, $retention, $observations, $linkageMeta, $omics, $demo, $distributions, $qualityAnnotations, $required, $structuralMetadata, $tissuesSampleCollection, $projectGrants, $datasetFilters, $erd) {
+            Accessibility::where('dataset_version_id', $dv->id)->delete();
+            Accessibility::create([
+                'dataset_version_id' => $dv->id,
+                'access_rights' => $this->ensureArray($access['accessRights'] ?? null),
+                'access_service' => $access['accessService'] ?? null,
+                'access_service_category' => $this->ensureArray($access['accessServiceCategory'] ?? null),
+                'access_request_cost' => $access['accessRequestCost'] ?? null,
+                'delivery_lead_time' => $access['deliveryLeadTime'] ?? null,
+                'jurisdiction' => $this->ensureArray($access['jurisdiction'] ?? null),
+                'data_controller' => $access['dataController'] ?? null,
+                'data_processor' => $access['dataProcessor'] ?? null,
+                'legal_basis' => $access['legalBasis'] ?? null,
+                'personal_data' => $access['personalData'] ?? null,
+                'applicable_legislation' => $access['applicableLegislation'] ?? null,
+                'data_use_limitation' => $this->ensureArray($usage['dataUseLimitation'] ?? null),
+                'data_use_requirements' => $this->ensureArray($usage['dataUseRequirements'] ?? null),
+                'resource_creator' => $usage['resourceCreator']['name'] ?? null,
+                'resource_creator_gateway_id' => $usage['resourceCreator']['gatewayId'] ?? null,
+                'resource_creator_ror_id' => $usage['resourceCreator']['rorId'] ?? null,
+                'vocabulary_encoding_schemes' => $this->ensureArray($fmts['vocabularyEncodingSchemes'] ?? null),
+                'conforms_to' => $this->ensureArray($fmts['conformsTo'] ?? null),
+                'languages' => $this->ensureArray($fmts['languages'] ?? null),
+                'formats' => $this->ensureArray($fmts['formats'] ?? null),
+            ]);
+
+            Summary::where('dataset_version_id', $dv->id)->delete();
+            Summary::create([
+                'dataset_version_id' => $dv->id,
+                'abstract' => $summary['abstract'] ?? null,
+                'contact_point' => $summary['contactPoint'] ?? null,
+                'keywords' => $this->ensureArray($summary['keywords'] ?? null),
+                'controlled_keywords' => $this->ensureArray($summary['controlledKeywords'] ?? null),
+                'dataset_type' => $this->ensureArray($summary['datasetType'] ?? null),
+                'dataset_sub_type' => $this->ensureArray($summary['datasetSubType'] ?? null),
+                'in_pipeline' => $summary['inPipeline'] ?? null,
+                'funders' => $this->ensureArray($summary['funders'] ?? null),
+                'dataset_aliases' => $this->ensureArray($summary['datasetAliases'] ?? null),
+                'description' => $summary['description'] ?? null,
+                'doi_name' => $summary['doiName'] ?? null,
+                'license_url' => $summary['licenseUrl'] ?? null,
+                'landing_page' => $summary['landingPage'] ?? null,
+                'creator_name' => $summary['creator']['name'] ?? null,
+                'creator_ror_id' => $summary['creator']['rorId'] ?? null,
+                'creator_orcid_id' => $summary['creator']['orcidId'] ?? null,
+                'creator_gateway_id' => $summary['creator']['gatewayId'] ?? null,
+                'theme' => $this->ensureArray($summary['theme'] ?? null),
+                'publisher_name' => $summary['publisher']['name'] ?? null,
+                'publisher_gateway_id' => $summary['publisher']['gatewayId'] ?? null,
+                'publisher_ror_id' => $summary['publisher']['rorId'] ?? null,
+                'population_size' => isset($summary['populationSize']) ? (int) $summary['populationSize'] : null,
+            ]);
+
+            Coverage::where('dataset_version_id', $dv->id)->delete();
+            Coverage::create([
+                'dataset_version_id' => $dv->id,
+                'spatial' => $this->ensureArray($coverage['spatial'] ?? null),
+                'min_typical_age' => isset($coverage['minTypicalAge']) ? (int) $coverage['minTypicalAge'] : null,
+                'max_typical_age' => isset($coverage['maxTypicalAge']) ? (int) $coverage['maxTypicalAge'] : null,
+                'population_coverage' => $coverage['populationCoverage'] ?? null,
+                'number_of_unique_individuals' => isset($coverage['numberOfUniqueIndividuals']) ? (int) $coverage['numberOfUniqueIndividuals'] : null,
+                'number_of_records' => isset($coverage['numberOfRecords']) ? (int) $coverage['numberOfRecords'] : null,
+                'pathway' => $coverage['pathway'] ?? null,
+                'followup' => $coverage['followUp'] ?? null,
+                'dataset_completeness' => $coverage['datasetCompleteness'] ?? null,
+            ]);
+
+            Provenance::where('dataset_version_id', $dv->id)->delete();
+            Provenance::create([
+                'dataset_version_id' => $dv->id,
+                'origin_purpose' => $this->ensureArray($origin['purpose'] ?? null),
+                'origin_source' => $this->ensureArray($origin['source'] ?? null),
+                'origin_collection_situation' => $this->ensureArray($origin['collectionSituation'] ?? null),
+                'origin_image_contrast' => $origin['imageContrast'] ?? null,
+                'temporal_start_date' => $temporal['startDate'] ?? null,
+                'temporal_end_date' => $temporal['endDate'] ?? null,
+                'temporal_time_lag' => $temporal['timeLag'] ?? null,
+                'temporal_accrual_periodicity' => $temporal['accrualPeriodicity'] ?? null,
+                'temporal_distribution_release_date' => $temporal['distributionReleaseDate'] ?? null,
+                'retention_period_start' => $retention['startDate'] ?? null,
+                'retention_period_end' => $retention['endDate'] ?? null,
+            ]);
+
+            Observation::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $observations as $obs) {
+                if (! is_array($obs) || empty($obs['observedNode'])) {
+                    continue;
+                }
+                Observation::create([
+                    'dataset_version_id' => $dv->id,
+                    'observed_node' => $obs['observedNode'],
+                    'measured_value' => $obs['measuredValue'] ?? null,
+                    'observation_date' => $obs['observationDate'] ?? null,
+                    'measured_property' => $obs['measuredProperty'] ?? null,
+                    'disambiguating_description' => $obs['disambiguatingDescription'] ?? null,
+                ]);
+            }
+
+            LinkageMeta::where('dataset_version_id', $dv->id)->delete();
+            LinkageMeta::create([
+                'dataset_version_id' => $dv->id,
+                'is_generated_using' => $this->ensureArray($linkageMeta['isGeneratedUsing'] ?? null),
+                'associated_media' => $this->ensureArray($linkageMeta['associatedMedia'] ?? null),
+                'data_uses' => $this->ensureArray($linkageMeta['dataUses'] ?? null),
+                'is_reference_in' => $this->ensureArray($linkageMeta['isReferenceIn'] ?? null),
+                'tools' => $this->ensureArray($linkageMeta['tools'] ?? null),
+                'investigations' => $this->ensureArray($linkageMeta['investigations'] ?? null),
+                'synthetic_data_web_link' => $this->ensureArray($linkageMeta['syntheticDataWebLink'] ?? null),
+            ]);
+
+            Omics::where('dataset_version_id', $dv->id)->delete();
+            Omics::create([
+                'dataset_version_id' => $dv->id,
+                'assay' => $omics['assay'] ?? null,
+                'platform' => $omics['platform'] ?? null,
+            ]);
+
+            DemographicFrequency::where('dataset_version_id', $dv->id)->delete();
+            foreach (($demo['age'] ?? []) as $row) {
+                DemographicFrequency::create([
+                    'dataset_version_id' => $dv->id,
+                    'category' => 'age',
+                    'bin' => $row['bin'],
+                    'bin_vocabulary' => null,
+                    'count' => $row['count'],
+                ]);
+            }
+            foreach (($demo['ethnicity'] ?? []) as $row) {
+                DemographicFrequency::create([
+                    'dataset_version_id' => $dv->id,
+                    'category' => 'ethnicity',
+                    'bin' => $row['bin'],
+                    'bin_vocabulary' => null,
+                    'count' => $row['count'],
+                ]);
+            }
+            foreach (($demo['disease'] ?? []) as $row) {
+                DemographicFrequency::create([
+                    'dataset_version_id' => $dv->id,
+                    'category' => 'disease',
+                    'bin' => $row['diseaseCode'],
+                    'bin_vocabulary' => $row['diseaseCodeVocabulary'] ?? null,
+                    'count' => $row['count'],
+                ]);
+            }
+
+            Distribution::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $distributions as $dist) {
+                if (! is_array($dist)) {
+                    continue;
+                }
+                Distribution::create([
+                    'dataset_version_id' => $dv->id,
+                    'title' => $dist['title'] ?? null,
+                    'description' => $dist['description'] ?? null,
+                    'access_url' => $dist['accessUrl'] ?? null,
+                    'download_url' => $dist['downloadUrl'] ?? null,
+                    'media_type' => $dist['mediaType'] ?? null,
+                    'format' => $dist['format'] ?? null,
+                    'byte_size' => isset($dist['byteSize']) ? (int) $dist['byteSize'] : null,
+                    'license_url' => $dist['licenseUrl'] ?? null,
+                    'access_service' => $dist['accessService'] ?? null,
+                    'issued' => $dist['issued'] ?? null,
+                    'modified' => $dist['modified'] ?? null,
+                ]);
+            }
+
+            QualityAnnotation::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $qualityAnnotations as $qa) {
+                if (! is_array($qa)) {
+                    continue;
+                }
+                QualityAnnotation::create([
+                    'dataset_version_id' => $dv->id,
+                    'annotation_type' => $qa['annotationType'] ?? null,
+                    'quality_dimension' => $qa['qualityDimension'] ?? null,
+                    'quality_value' => $qa['qualityValue'] ?? null,
+                    'quality_description' => $qa['qualityDescription'] ?? null,
+                    'certification_url' => $qa['certificationUrl'] ?? null,
+                    'annotation_date' => $qa['annotationDate'] ?? null,
+                ]);
+            }
+
+            Required::where('dataset_version_id', $dv->id)->delete();
+            if (! empty($required)) {
+                Required::create([
+                    'dataset_version_id' => $dv->id,
+                    'gateway_id' => $required['gatewayId'] ?? null,
+                    'gateway_pid' => $required['gatewayPid'] ?? null,
+                    'issued' => $required['issued'] ?? null,
+                    'modified' => $required['modified'] ?? null,
+                    'version' => $required['version'] ?? null,
+                    'revisions' => $required['revisions'] ?? null,
+                ]);
+            }
+
+            StructuralTable::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $structuralMetadata as $tbl) {
+                if (! is_array($tbl)) {
+                    continue;
+                }
+                $tableRow = StructuralTable::create([
+                    'dataset_version_id' => $dv->id,
+                    'name' => $tbl['name'] ?? null,
+                    'description' => $tbl['description'] ?? null,
+                ]);
+                foreach ((array) ($tbl['columns'] ?? []) as $col) {
+                    if (! is_array($col)) {
+                        continue;
+                    }
+                    $colRow = StructuralColumn::create([
+                        'gwdm30_structural_table_id' => $tableRow->id,
+                        'name' => $col['name'] ?? null,
+                        'data_type' => $col['dataType'] ?? null,
+                        'description' => $col['description'] ?? null,
+                        'sensitive' => $col['sensitive'] ?? false,
+                    ]);
+                    foreach ((array) ($col['values'] ?? []) as $val) {
+                        if (! is_array($val)) {
+                            continue;
+                        }
+                        StructuralValue::create([
+                            'gwdm30_structural_column_id' => $colRow->id,
+                            'name' => $val['name'] ?? null,
+                            'description' => $val['description'] ?? null,
+                            'frequency' => isset($val['frequency']) ? (int) $val['frequency'] : null,
+                        ]);
+                    }
+                }
+            }
+
+            TissueSampleCollection::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $tissuesSampleCollection as $tsc) {
+                if (! is_array($tsc)) {
+                    continue;
+                }
+                $tsm = $tsc['tissueSampleMetadata'] ?? [];
+                $donor = $tsm['sampleDonor'] ?? [];
+                TissueSampleCollection::create([
+                    'dataset_version_id' => $dv->id,
+                    'collection_id' => $tsc['id'] ?? null,
+                    'data_categories' => $this->ensureArray($tsc['dataCategories'] ?? null),
+                    'material_type' => $this->ensureArray($tsc['materialType'] ?? null),
+                    'access_conditions' => $this->ensureArray($tsc['accessConditions'] ?? null),
+                    'collection_type' => $this->ensureArray($tsc['collectionType'] ?? null),
+                    'disease' => $this->ensureArray($tsc['disease'] ?? null),
+                    'storage_temperature' => $this->ensureArray($tsc['storageTemperature'] ?? null),
+                    'sample_age_range' => $this->ensureArray($tsc['sampleAgeRange'] ?? null),
+                    'tsm_id' => $tsm['id'] ?? null,
+                    'tsm_sample_type' => $this->ensureArray($tsm['sampleType'] ?? null),
+                    'tsm_storage_temperature' => $tsm['storageTemperature'] ?? null,
+                    'tsm_creation_date' => $tsm['creationDate'] ?? null,
+                    'tsm_anatomical_site_ontology_code' => $this->ensureArray($tsm['anatomicalSiteOntologyCode'] ?? null),
+                    'tsm_anatomical_site_ontology_description' => $this->ensureArray($tsm['anatomicalSiteOntologyDescription'] ?? null),
+                    'tsm_anatomical_site_free_text' => $this->ensureArray($tsm['anatomicalSiteFreeText'] ?? null),
+                    'tsm_sample_content_diagnosis' => $this->ensureArray($tsm['sampleContentDiagnosis'] ?? null),
+                    'tsm_use_restrictions' => $this->ensureArray($tsm['useRestrictions'] ?? null),
+                    'tsm_donor_id' => $donor['id'] ?? null,
+                    'tsm_donor_sex' => $donor['sex'] ?? null,
+                    'tsm_donor_birth_date' => $donor['birthDate'] ?? null,
+                    'tsm_donor_data_categories' => $this->ensureArray($donor['dataCategories'] ?? null),
+                ]);
+            }
+
+            ProjectGrant::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $projectGrants as $grant) {
+                if (! is_array($grant)) {
+                    continue;
+                }
+                ProjectGrant::create([
+                    'dataset_version_id' => $dv->id,
+                    'pid' => $grant['pid'] ?? null,
+                    'project_grant_name' => $grant['projectGrantName'] ?? null,
+                    'lead_researcher' => $grant['leadResearcher'] ?? null,
+                    'lead_research_institute' => $grant['leadResearchInstitute'] ?? null,
+                    'grant_number' => $grant['grantNumber'] ?? null,
+                    'project_grant_start_date' => $grant['projectGrantStartDate'] ?? null,
+                    'project_grant_end_date' => $grant['projectGrantEndDate'] ?? null,
+                    'project_grant_scope' => $grant['projectGrantScope'] ?? null,
+                ]);
+            }
+
+            DatasetFilter::where('dataset_version_id', $dv->id)->delete();
+            foreach ((array) $datasetFilters as $filter) {
+                if (! is_array($filter)) {
+                    continue;
+                }
+                DatasetFilter::create([
+                    'dataset_version_id' => $dv->id,
+                    'filter_id' => $filter['id'] ?? null,
+                    'label' => $filter['label'] ?? null,
+                    'category' => $filter['category'] ?? null,
+                    'primary_group' => $filter['primaryGroup'] ?? null,
+                    'description' => $filter['description'] ?? null,
+                ]);
+            }
+
+            Erd::where('dataset_version_id', $dv->id)->delete();
+            if (! empty($erd)) {
+                Erd::create([
+                    'dataset_version_id' => $dv->id,
+                    'description' => $erd['description'] ?? null,
+                ]);
+            }
+        });
+    }
+
+    // ── Read path ─────────────────────────────────────────────────────────────
+
+    public function preloadSections(DatasetVersion $dv): void
+    {
+        $id = $dv->id;
+        $dv->setRelation('gwdm30Summary',                 Summary::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Coverage',                Coverage::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Provenance',              Provenance::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Accessibility',           Accessibility::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30LinkageMeta',             LinkageMeta::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Omics',                   Omics::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Erd',                     Erd::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Required',                Required::where('dataset_version_id', $id)->first());
+        $dv->setRelation('gwdm30Observations',            Observation::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30DemographicFrequencies',  DemographicFrequency::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30Distributions',           Distribution::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30QualityAnnotations',      QualityAnnotation::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30StructuralTables',        StructuralTable::where('dataset_version_id', $id)->with(['columns.values'])->orderBy('id')->get());
+        $dv->setRelation('gwdm30TissueSampleCollections', TissueSampleCollection::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30ProjectGrants',           ProjectGrant::where('dataset_version_id', $id)->orderBy('id')->get());
+        $dv->setRelation('gwdm30DatasetFilters',          DatasetFilter::where('dataset_version_id', $id)->orderBy('id')->get());
+    }
+
+    private function read(DatasetVersion $dv): array
+    {
+        $sections = array_merge(
+            $this->readRequired($dv),
+            $this->readSummary($dv),
+            $this->readCoverage($dv),
+            $this->readProvenance($dv),
+            $this->readAccessibility($dv),
+            $this->readObservations($dv),
+            $this->readOmics($dv),
+            $this->readDemographicFrequency($dv),
+            $this->readDistributions($dv),
+            $this->readQualityAnnotations($dv),
+            $this->readStructuralMetadata($dv),
+            $this->readTissuesSampleCollection($dv),
+            $this->readProjectGrants($dv),
+            $this->readDatasetFilters($dv),
+            $this->readErd($dv),
+        );
+
+        $linkageSection = $this->readLinkages($dv);
+        $linkageMetaSection = $this->readLinkageMeta($dv);
+
+        if (! empty($linkageSection) || ! empty($linkageMetaSection)) {
+            $sections['linkage'] = array_merge(
+                $linkageSection['linkage'] ?? [],
+                $linkageMetaSection['linkage'] ?? [],
+            );
+        }
+
+        return $sections;
+    }
+
+    private function readSummary(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Summary') ? $dv->gwdm30Summary : Summary::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+        return [
+            'summary' => [
+                'title'      => $dv->title,
+                'shortTitle' => $dv->short_title,
+                'abstract' => $row->abstract,
+                'contactPoint' => $row->contact_point,
+                'keywords' => $row->keywords,
+                'controlledKeywords' => $row->controlled_keywords,
+                'datasetAliases' => $row->dataset_aliases,
+                'datasetType' => $row->dataset_type,
+                'datasetSubType' => $row->dataset_sub_type,
+                'inPipeline' => $row->in_pipeline,
+                'funders' => $row->funders,
+                'description' => $row->description,
+                'doiName' => $row->doi_name,
+                'licenseUrl' => $row->license_url,
+                'landingPage' => $row->landing_page,
+                'creator' => [
+                    'name' => $row->creator_name,
+                    'rorId' => $row->creator_ror_id,
+                    'orcidId' => $row->creator_orcid_id,
+                    'gatewayId' => $row->creator_gateway_id,
+                ],
+                'theme' => $row->theme,
+                'publisher' => [
+                    'name' => $row->publisher_name,
+                    'gatewayId' => $row->publisher_gateway_id,
+                    'rorId' => $row->publisher_ror_id,
+                ],
+                'populationSize' => $row->population_size,
+            ],
+        ];
+    }
+
+    private function readCoverage(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Coverage') ? $dv->gwdm30Coverage : Coverage::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'coverage' => [
+                'spatial' => $row->spatial,
+                'minTypicalAge' => $row->min_typical_age,
+                'maxTypicalAge' => $row->max_typical_age,
+                'populationCoverage' => $row->population_coverage,
+                'numberOfUniqueIndividuals' => $row->number_of_unique_individuals,
+                'numberOfRecords' => $row->number_of_records,
+                'pathway' => $row->pathway,
+                'followUp' => $row->followup,
+                'datasetCompleteness' => $row->dataset_completeness,
+            ],
+        ];
+    }
+
+    private function readProvenance(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Provenance') ? $dv->gwdm30Provenance : Provenance::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'provenance' => [
+                'origin' => [
+                    'purpose' => $row->origin_purpose,
+                    'source' => $row->origin_source,
+                    'collectionSituation' => $row->origin_collection_situation,
+                    'imageContrast' => $row->origin_image_contrast,
+                ],
+                'temporal' => [
+                    'startDate' => $row->temporal_start_date?->toDateString(),
+                    'endDate' => $row->temporal_end_date?->toDateString(),
+                    'timeLag' => $row->temporal_time_lag,
+                    'accrualPeriodicity' => $row->temporal_accrual_periodicity,
+                    'distributionReleaseDate' => $row->temporal_distribution_release_date?->toDateString(),
+                ],
+                'retentionPeriod' => [
+                    'startDate' => $row->retention_period_start?->toDateString(),
+                    'endDate' => $row->retention_period_end?->toDateString(),
+                ],
+            ],
+        ];
+    }
+
+    private function readAccessibility(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Accessibility') ? $dv->gwdm30Accessibility : Accessibility::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'accessibility' => [
+                'access' => [
+                    'accessRights' => $row->access_rights,
+                    'accessService' => $row->access_service,
+                    'accessServiceCategory' => $row->access_service_category,
+                    'accessRequestCost' => $row->access_request_cost,
+                    'deliveryLeadTime' => $row->delivery_lead_time,
+                    'jurisdiction' => $row->jurisdiction,
+                    'dataController' => $row->data_controller,
+                    'dataProcessor' => $row->data_processor,
+                    'legalBasis' => $row->legal_basis,
+                    'personalData' => $row->personal_data,
+                    'applicableLegislation' => $row->applicable_legislation,
+                ],
+                'usage' => [
+                    'dataUseLimitation' => $row->data_use_limitation,
+                    'dataUseRequirements' => $row->data_use_requirements,
+                    'resourceCreator' => [
+                        'name' => $row->resource_creator,
+                        'gatewayId' => $row->resource_creator_gateway_id,
+                        'rorId' => $row->resource_creator_ror_id,
+                    ],
+                ],
+                'formatAndStandards' => [
+                    'vocabularyEncodingSchemes' => $row->vocabulary_encoding_schemes,
+                    'conformsTo' => $row->conforms_to,
+                    'languages' => $row->languages,
+                    'formats' => $row->formats,
+                ],
+            ],
+        ];
+    }
+
+    private function readObservations(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30Observations') ? $dv->gwdm30Observations : Observation::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'observations' => $rows->map(fn ($obs) => [
+                'observedNode' => $obs->observed_node,
+                'measuredValue' => $obs->measured_value,
+                'observationDate' => $obs->observation_date?->toDateString(),
+                'measuredProperty' => $obs->measured_property,
+                'disambiguatingDescription' => $obs->disambiguating_description,
+            ])->values()->all(),
+        ];
+    }
+
+    private function readLinkageMeta(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30LinkageMeta') ? $dv->gwdm30LinkageMeta : LinkageMeta::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'linkage' => [
+                'isGeneratedUsing' => $row->is_generated_using,
+                'associatedMedia' => $row->associated_media,
+                'dataUses' => $row->data_uses,
+                'isReferenceIn' => $row->is_reference_in,
+                'tools' => $row->tools,
+                'investigations' => $row->investigations,
+                'syntheticDataWebLink' => $row->synthetic_data_web_link,
+            ],
+        ];
+    }
+
+    private function readOmics(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Omics') ? $dv->gwdm30Omics : Omics::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'omics' => [
+                'assay' => $row->assay,
+                'platform' => $row->platform,
+            ],
+        ];
+    }
+
+    private function readDemographicFrequency(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30DemographicFrequencies') ? $dv->gwdm30DemographicFrequencies : DemographicFrequency::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        $age = [];
+        $ethnicity = [];
+        $disease = [];
+
+        foreach ($rows as $row) {
+            if ($row->category === 'age') {
+                $age[] = ['bin' => $row->bin, 'count' => $row->count];
+            } elseif ($row->category === 'ethnicity') {
+                $ethnicity[] = ['bin' => $row->bin, 'count' => $row->count];
+            } elseif ($row->category === 'disease') {
+                $disease[] = [
+                    'diseaseCode' => $row->bin,
+                    'diseaseCodeVocabulary' => $row->bin_vocabulary,
+                    'count' => $row->count,
+                ];
+            }
+        }
+
+        return [
+            'demographicFrequency' => [
+                'age' => $age,
+                'ethnicity' => $ethnicity,
+                'disease' => $disease,
+            ],
+        ];
+    }
+
+    private function readDistributions(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30Distributions') ? $dv->gwdm30Distributions : Distribution::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'distributions' => $rows->map(fn ($dist) => [
+                'title' => $dist->title,
+                'description' => $dist->description,
+                'accessUrl' => $dist->access_url,
+                'downloadUrl' => $dist->download_url,
+                'mediaType' => $dist->media_type,
+                'format' => $dist->format,
+                'byteSize' => $dist->byte_size,
+                'licenseUrl' => $dist->license_url,
+                'accessService' => $dist->access_service,
+                'issued' => $dist->issued?->toDateString(),
+                'modified' => $dist->modified?->toDateString(),
+            ])->values()->all(),
+        ];
+    }
+
+    private function readQualityAnnotations(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30QualityAnnotations') ? $dv->gwdm30QualityAnnotations : QualityAnnotation::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'qualityAnnotations' => $rows->map(fn ($qa) => [
+                'annotationType' => $qa->annotation_type,
+                'qualityDimension' => $qa->quality_dimension,
+                'qualityValue' => $qa->quality_value,
+                'qualityDescription' => $qa->quality_description,
+                'certificationUrl' => $qa->certification_url,
+                'annotationDate' => $qa->annotation_date?->toDateString(),
+            ])->values()->all(),
+        ];
+    }
+
+    private function readLinkages(DatasetVersion $dv): array
+    {
+        $resolvedDatasets = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_has_dataset_version.dataset_version_source_id', $dv->id)
+            ->where('dataset_version_has_dataset_version.direct_linkage', 1)
+            ->where('dataset_version_has_dataset_version.description', self::LINKAGE_DESCRIPTION)
+            ->whereNotNull('dataset_version_has_dataset_version.dataset_version_target_id')
+            ->join('dataset_versions as tdv', 'tdv.id', '=', 'dataset_version_has_dataset_version.dataset_version_target_id')
+            ->join('datasets as td', 'td.id', '=', 'tdv.dataset_id')
+            ->select(
+                'dataset_version_has_dataset_version.linkage_type',
+                'tdv.short_title',
+                'td.pid',
+                'td.id as dataset_id',
+            )
+            ->get();
+
+        $unresolvedDatasets = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_source_id', $dv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->whereNull('dataset_version_target_id')
+            ->get();
+
+        $publications = PublicationHasDatasetVersion::query()
+            ->where('publication_has_dataset_version.dataset_version_id', $dv->id)
+            ->where('publication_has_dataset_version.description', self::LINKAGE_DESCRIPTION)
+            ->leftJoin('publications', 'publications.id', '=', 'publication_has_dataset_version.publication_id')
+            ->get();
+
+        if ($resolvedDatasets->isEmpty() && $unresolvedDatasets->isEmpty() && $publications->isEmpty()) {
+            return [];
+        }
+
+        $datasetLinkage = [];
+        foreach ($resolvedDatasets as $row) {
+            $datasetLinkage[$row->linkage_type][] = [
+                'url' => config('gateway.gateway_url').'/en/dataset/'.$row->dataset_id,
+                'pid' => $row->pid,
+                'title' => $row->short_title,
+            ];
+        }
+        foreach ($unresolvedDatasets as $row) {
+            $datasetLinkage[$row->linkage_type][] = [
+                'url' => $row->raw_url,
+                'pid' => $row->raw_pid,
+                'title' => $row->raw_title,
+            ];
+        }
+
+        $aboutDataset = [];
+        $usingDataset = [];
+        foreach ($publications as $row) {
+            $doi = $row->paper_doi ?? $row->raw_doi;
+            if (! $doi) {
+                continue;
+            }
+            if ($row->link_type === 'ABOUT') {
+                $aboutDataset[] = $doi;
+            } else {
+                $usingDataset[] = $doi;
+            }
+        }
+
+        return [
+            'linkage' => [
+                'datasetLinkage' => $datasetLinkage,
+                'publicationAboutDataset' => $aboutDataset,
+                'publicationUsingDataset' => $usingDataset,
+            ],
+        ];
+    }
+
+    private function readRequired(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Required') ? $dv->gwdm30Required : Required::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'required' => [
+                'gatewayId' => $row->gateway_id,
+                'gatewayPid' => $row->gateway_pid,
+                'issued' => $row->issued?->toIso8601String(),
+                'modified' => $row->modified?->toIso8601String(),
+                'version' => $row->version,
+                'revisions' => $row->revisions ?? [],
+            ],
+        ];
+    }
+
+    private function readStructuralMetadata(DatasetVersion $dv): array
+    {
+        $tables = $dv->relationLoaded('gwdm30StructuralTables')
+            ? $dv->gwdm30StructuralTables
+            : StructuralTable::where('dataset_version_id', $dv->id)->with(['columns.values'])->orderBy('id')->get();
+
+        if ($tables->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'structuralMetadata' => $tables->map(fn (StructuralTable $tbl) => [
+                'name' => $tbl->name,
+                'description' => $tbl->description,
+                'columns' => $tbl->columns->map(fn (StructuralColumn $col) => [
+                    'name' => $col->name,
+                    'dataType' => $col->data_type,
+                    'description' => $col->description,
+                    'sensitive' => $col->sensitive,
+                    'values' => $col->values->map(fn (StructuralValue $val) => [
+                        'name' => $val->name,
+                        'description' => $val->description,
+                        'frequency' => $val->frequency,
+                    ])->values()->all(),
+                ])->values()->all(),
+            ])->values()->all(),
+        ];
+    }
+
+    private function readTissuesSampleCollection(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30TissueSampleCollections') ? $dv->gwdm30TissueSampleCollections : TissueSampleCollection::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'tissuesSampleCollection' => $rows->map(fn ($r) => [
+                'id' => $r->collection_id,
+                'dataCategories' => $r->data_categories,
+                'materialType' => $r->material_type,
+                'accessConditions' => $r->access_conditions,
+                'collectionType' => $r->collection_type,
+                'disease' => $r->disease,
+                'storageTemperature' => $r->storage_temperature,
+                'sampleAgeRange' => $r->sample_age_range,
+                'tissueSampleMetadata' => [
+                    'id' => $r->tsm_id,
+                    'sampleType' => $r->tsm_sample_type,
+                    'storageTemperature' => $r->tsm_storage_temperature,
+                    'creationDate' => $r->tsm_creation_date?->toDateString(),
+                    'anatomicalSiteOntologyCode' => $r->tsm_anatomical_site_ontology_code,
+                    'anatomicalSiteOntologyDescription' => $r->tsm_anatomical_site_ontology_description,
+                    'anatomicalSiteFreeText' => $r->tsm_anatomical_site_free_text,
+                    'sampleContentDiagnosis' => $r->tsm_sample_content_diagnosis,
+                    'useRestrictions' => $r->tsm_use_restrictions,
+                    'sampleDonor' => [
+                        'id' => $r->tsm_donor_id,
+                        'sex' => $r->tsm_donor_sex,
+                        'birthDate' => $r->tsm_donor_birth_date?->toDateString(),
+                        'dataCategories' => $r->tsm_donor_data_categories,
+                    ],
+                ],
+            ])->values()->all(),
+        ];
+    }
+
+    private function readProjectGrants(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30ProjectGrants') ? $dv->gwdm30ProjectGrants : ProjectGrant::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'projectGrants' => $rows->map(fn ($r) => [
+                'pid' => $r->pid,
+                'projectGrantName' => $r->project_grant_name,
+                'leadResearcher' => $r->lead_researcher,
+                'leadResearchInstitute' => $r->lead_research_institute,
+                'grantNumber' => $r->grant_number,
+                'projectGrantStartDate' => $r->project_grant_start_date,
+                'projectGrantEndDate' => $r->project_grant_end_date,
+                'projectGrantScope' => $r->project_grant_scope,
+            ])->values()->all(),
+        ];
+    }
+
+    private function readDatasetFilters(DatasetVersion $dv): array
+    {
+        $rows = $dv->relationLoaded('gwdm30DatasetFilters') ? $dv->gwdm30DatasetFilters : DatasetFilter::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        if ($rows->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'datasetFilters' => $rows->map(fn ($r) => [
+                'id' => $r->filter_id,
+                'label' => $r->label,
+                'category' => $r->category,
+                'primaryGroup' => $r->primary_group,
+                'description' => $r->description,
+            ])->values()->all(),
+        ];
+    }
+
+    private function readErd(DatasetVersion $dv): array
+    {
+        $row = $dv->relationLoaded('gwdm30Erd') ? $dv->gwdm30Erd : Erd::where('dataset_version_id', $dv->id)->first();
+        if (! $row) {
+            return [];
+        }
+
+        return [
+            'erd' => [
+                'description' => $row->description,
+            ],
+        ];
+    }
+
+    /** Ensure a value that may arrive as a string (GWDM 2.1 legacy) is returned as an array. */
+    private function ensureArray(mixed $value): ?array
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return is_array($value) ? $value : [$value];
+    }
+}

--- a/app/Services/Gwdm/Gwdm30Handler.php
+++ b/app/Services/Gwdm/Gwdm30Handler.php
@@ -24,6 +24,7 @@ use App\Models\Gwdm30\StructuralValue;
 use App\Models\Gwdm30\Summary;
 use App\Models\Gwdm30\TissueSampleCollection;
 use App\Models\PublicationHasDatasetVersion;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -435,6 +436,55 @@ class Gwdm30Handler extends Gwdm2xHandler
         $dv->setRelation('gwdm30TissueSampleCollections', TissueSampleCollection::where('dataset_version_id', $id)->orderBy('id')->get());
         $dv->setRelation('gwdm30ProjectGrants',           ProjectGrant::where('dataset_version_id', $id)->orderBy('id')->get());
         $dv->setRelation('gwdm30DatasetFilters',          DatasetFilter::where('dataset_version_id', $id)->orderBy('id')->get());
+    }
+
+    /**
+     * Batch equivalent of preloadSections() for a whole collection of dataset
+     * versions: loads each section type ONCE across all version ids and hydrates
+     * every row's relations from the result. Fixes the N+1 (~16 queries per row)
+     * when reading many 3.0 versions at once, e.g. GET /metadata-versions.
+     *
+     * @param  \Illuminate\Support\Collection<int, DatasetVersion>  $versions
+     */
+    public function preloadSectionsForVersions(Collection $versions): void
+    {
+        $ids = $versions->pluck('id')->all();
+        if ($ids === []) {
+            return;
+        }
+
+        // Single-row sections: keyBy dataset_version_id -> at most one row each.
+        $single = [
+            'gwdm30Summary' => Summary::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Coverage' => Coverage::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Provenance' => Provenance::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Accessibility' => Accessibility::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30LinkageMeta' => LinkageMeta::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Omics' => Omics::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Erd' => Erd::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+            'gwdm30Required' => Required::whereIn('dataset_version_id', $ids)->get()->keyBy('dataset_version_id'),
+        ];
+
+        // Multi-row sections: groupBy dataset_version_id -> a collection each.
+        $many = [
+            'gwdm30Observations' => Observation::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30DemographicFrequencies' => DemographicFrequency::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30Distributions' => Distribution::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30QualityAnnotations' => QualityAnnotation::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30StructuralTables' => StructuralTable::whereIn('dataset_version_id', $ids)->with(['columns.values'])->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30TissueSampleCollections' => TissueSampleCollection::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30ProjectGrants' => ProjectGrant::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+            'gwdm30DatasetFilters' => DatasetFilter::whereIn('dataset_version_id', $ids)->orderBy('id')->get()->groupBy('dataset_version_id'),
+        ];
+
+        foreach ($versions as $dv) {
+            foreach ($single as $relation => $keyed) {
+                $dv->setRelation($relation, $keyed->get($dv->id));
+            }
+            foreach ($many as $relation => $grouped) {
+                $dv->setRelation($relation, $grouped->get($dv->id, collect())->values());
+            }
+        }
     }
 
     private function read(DatasetVersion $dv): array

--- a/app/Services/Gwdm/Gwdm30Handler.php
+++ b/app/Services/Gwdm/Gwdm30Handler.php
@@ -52,6 +52,34 @@ class Gwdm30Handler extends Gwdm2xHandler
         // The async LinkageExtraction job (extractLinkages) is therefore a no-op
         // for 3.0 — see the override below.
         $this->writeLinkages($dv, $gwdm);
+
+        // Denormalise the reconstructed sections into the metadata JSON column so a
+        // caller that opts in (X-Gwdm-Cache: bypass) can read the whole envelope in
+        // one JSON read — parity with 2.x — instead of reassembling ~16 SQL tables.
+        // The SQL tables remain the source of truth (and the default read path);
+        // this column is a derived read copy, rewritten on every write in the same
+        // transaction, so it never drifts on in-band writes.
+        //
+        // Sections are read back FROM SQL (not from the input $gwdm) so the stored
+        // JSON is byte-identical to what reconstructing from SQL produces — the
+        // readXxx() helpers apply coercions the raw input does not. Linkage is EXCLUDED: it
+        // tracks other datasets' latest versions and must be merged fresh on read
+        // (see readLinkageOnly()).
+        $this->refreshSectionCache($dv);
+    }
+
+    /**
+     * (Re)write the denormalised section cache into $dv->metadata['metadata']
+     * from the current SQL section rows. Idempotent — safe to call from
+     * afterStore() and from the backfill command. Uses saveQuietly() so it does
+     * not fire a second "updated" model event (indexing already fires on create).
+     */
+    public function refreshSectionCache(DatasetVersion $dv): void
+    {
+        $stored = is_array($dv->metadata) ? $dv->metadata : [];
+        $stored['metadata'] = $this->readSections($dv);
+        $dv->metadata = $stored;
+        $dv->saveQuietly();
     }
 
     /**
@@ -67,11 +95,21 @@ class Gwdm30Handler extends Gwdm2xHandler
 
     public function afterRead(DatasetVersion $dv): array
     {
+        // When the caller opted into the cache (X-Gwdm-Cache: bypass) and this row
+        // carries it, the sections come from extractStoredGwdm() and afterRead()
+        // only merges the always-fresh linkage on top. Otherwise — the default, or
+        // an un-backfilled row — reconstruct in full from SQL (the source of truth).
+        if ($this->hasCachedSections($dv)) {
+            return $this->readLinkageOnly($dv);
+        }
+
         return $this->read($dv);
     }
 
     public function buildEnvelope(array $gwdm, array $originalMetadata): array
     {
+        // The section cache ('metadata' key) is written afterwards in afterStore()
+        // once persist() has populated the SQL tables — see refreshSectionCache().
         return [
             'gwdmVersion'       => $this->version(),
             'original_metadata' => $originalMetadata,
@@ -80,7 +118,15 @@ class Gwdm30Handler extends Gwdm2xHandler
 
     public function extractStoredGwdm(array $storedData): array
     {
-        return [];
+        // The denormalised section cache lives under the 'metadata' key (mirroring
+        // 2.x). Only served when the caller opted in via `X-Gwdm-Cache: bypass`;
+        // by default (and on un-backfilled rows) return [] so afterRead()
+        // reconstructs from the SQL section tables.
+        if (! $this->cacheRequested()) {
+            return [];
+        }
+
+        return $storedData['metadata'] ?? [];
     }
 
     // ── Write path ────────────────────────────────────────────────────────────
@@ -419,6 +465,12 @@ class Gwdm30Handler extends Gwdm2xHandler
 
     public function preloadSections(DatasetVersion $dv): void
     {
+        // Skip the ~16 section queries entirely when the denormalised cache will
+        // serve this read (see afterRead()/extractStoredGwdm()).
+        if ($this->hasCachedSections($dv)) {
+            return;
+        }
+
         $id = $dv->id;
         $dv->setRelation('gwdm30Summary',                 Summary::where('dataset_version_id', $id)->first());
         $dv->setRelation('gwdm30Coverage',                Coverage::where('dataset_version_id', $id)->first());
@@ -489,7 +541,20 @@ class Gwdm30Handler extends Gwdm2xHandler
 
     private function read(DatasetVersion $dv): array
     {
-        $sections = array_merge(
+        return array_merge(
+            $this->readSections($dv),
+            $this->readLinkageOnly($dv),
+        );
+    }
+
+    /**
+     * The 15 non-linkage GWDM sections, reassembled from the SQL tables. This is
+     * exactly what gets denormalised into the metadata JSON column on write
+     * (see refreshSectionCache()), so cache and SQL reconstruction stay identical.
+     */
+    private function readSections(DatasetVersion $dv): array
+    {
+        return array_merge(
             $this->readRequired($dv),
             $this->readSummary($dv),
             $this->readCoverage($dv),
@@ -506,18 +571,59 @@ class Gwdm30Handler extends Gwdm2xHandler
             $this->readDatasetFilters($dv),
             $this->readErd($dv),
         );
+    }
 
+    /**
+     * The linkage section only, always read fresh from the junction tables so
+     * resolved link titles track each target dataset's current latest version
+     * (deliberately excluded from the section cache).
+     *
+     * @return array{linkage?: array} empty when there is no linkage at all
+     */
+    private function readLinkageOnly(DatasetVersion $dv): array
+    {
         $linkageSection = $this->readLinkages($dv);
         $linkageMetaSection = $this->readLinkageMeta($dv);
 
-        if (! empty($linkageSection) || ! empty($linkageMetaSection)) {
-            $sections['linkage'] = array_merge(
-                $linkageSection['linkage'] ?? [],
-                $linkageMetaSection['linkage'] ?? [],
-            );
+        if (empty($linkageSection) && empty($linkageMetaSection)) {
+            return [];
         }
 
-        return $sections;
+        return [
+            'linkage' => array_merge(
+                $linkageSection['linkage'] ?? [],
+                $linkageMetaSection['linkage'] ?? [],
+            ),
+        ];
+    }
+
+    /**
+     * Whether the caller opted into the denormalised metadata-column cache via the
+     * per-request `X-Gwdm-Cache: bypass` header — "bypass" = bypass the default
+     * SQL reconstruction and serve the cached sections instead.
+     *
+     * With no header, reads reconstruct from the SQL section tables (the
+     * authoritative source of truth).
+     */
+    private function cacheRequested(): bool
+    {
+        return request()->header('X-Gwdm-Cache') === 'bypass';
+    }
+
+    /**
+     * True when the caller opted into the cache AND this row carries a non-empty
+     * denormalised 'metadata' section blob to serve it from. Otherwise the read
+     * falls through to the SQL reconstruction.
+     */
+    private function hasCachedSections(DatasetVersion $dv): bool
+    {
+        if (! $this->cacheRequested()) {
+            return false;
+        }
+
+        $stored = $dv->metadata;
+
+        return is_array($stored) && ! empty($stored['metadata']);
     }
 
     private function readSummary(DatasetVersion $dv): array

--- a/app/Services/Gwdm/GwdmHandlerFactory.php
+++ b/app/Services/Gwdm/GwdmHandlerFactory.php
@@ -32,7 +32,7 @@ class GwdmHandlerFactory
      * Note: legacy versions handled internally by the factory (e.g. < 1.1)
      * are not listed here because they are not user-selectable via the header.
      */
-    public const SUPPORTED_VERSIONS = ['2.0', '2.1'];
+    public const SUPPORTED_VERSIONS = ['2.0', '2.1', '3.0'];
 
     /** @return string[] */
     public static function supportedVersions(): array
@@ -46,6 +46,7 @@ class GwdmHandlerFactory
             version_compare($version, '1.1', '<') => new Gwdm1xHandler($version),
             $version === '2.0'                     => new Gwdm20Handler($version),
             $version === '2.1'                     => new Gwdm21Handler($version),
+            $version === '3.0'                     => new Gwdm30Handler($version),
             default                                => new Gwdm2xHandler($version),
         };
     }

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -165,6 +165,19 @@ abstract class GwdmMetadataHandler
     }
 
     /**
+     * Batch equivalent of preloadSections() for a whole collection of versions,
+     * loading each section type once across all ids to avoid N+1 reads.
+     *
+     * No-op for JSON-based versions. Gwdm30Handler overrides it.
+     *
+     * @param  \Illuminate\Support\Collection<int, DatasetVersion>  $versions
+     */
+    public function preloadSectionsForVersions(\Illuminate\Support\Collection $versions): void
+    {
+        // no-op for 2.x and below
+    }
+
+    /**
      * Extract linkage data from this version and write it to the appropriate
      * junction tables. Called by the LinkageExtraction job.
      *

--- a/config/routes_v3.php
+++ b/config/routes_v3.php
@@ -1,6 +1,19 @@
 <?php
 
 return [
+    // v3 GET /datasets/{id} — no v3-specific read behaviour; delegates to V2 showActive for now
+    [
+        'name'                => 'datasets',
+        'method'              => 'get',
+        'path'                => '/datasets/{id}',
+        'methodController'    => 'DatasetController@showActive',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware'          => [],
+        'constraint' => [
+            'id', '[0-9]+'
+        ],
+    ],
+
     // v3 datasets — delta versioning update
     [
         'name'                => 'datasets',
@@ -37,6 +50,19 @@ return [
         'method'              => 'get',
         'path'                => '/datasets/{id}/version/{version}',
         'methodController'    => 'DatasetController@showVersion',
+        'namespaceController' => 'App\Http\Controllers\Api\V3',
+        'middleware'          => [
+            'sanitize.input',
+        ],
+        'constraint' => [
+            'id', '[0-9]+'
+        ],
+    ],
+    [
+        'name'                => 'datasets',
+        'method'              => 'get',
+        'path'                => '/datasets/{id}/metadata-versions',
+        'methodController'    => 'DatasetController@metadataVersions',
         'namespaceController' => 'App\Http\Controllers\Api\V3',
         'middleware'          => [
             'sanitize.input',

--- a/tests/Feature/DatasetVersionGwdm30Test.php
+++ b/tests/Feature/DatasetVersionGwdm30Test.php
@@ -1,0 +1,788 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Application;
+use App\Models\ApplicationHasPermission;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Gwdm30\Accessibility;
+use App\Models\Gwdm30\Coverage;
+use App\Models\Gwdm30\Distribution;
+use App\Models\Gwdm30\Observation;
+use App\Models\Gwdm30\Provenance;
+use App\Models\Gwdm30\QualityAnnotation;
+use App\Models\Gwdm30\Summary;
+use App\Models\Permission;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Gwdm\Gwdm2xHandler;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+class DatasetVersionGwdm30Test extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const TEST_URL_DATASET = '/api/v1/datasets';
+
+    private Application $integration;
+
+    protected $header30 = [];
+
+    protected function setUp(): void
+    {
+        $this->commonSetUp();
+
+        $this->integration = Application::where('id', 1)->first();
+
+        $perms = Permission::whereIn('name', [
+            'datasets.create',
+            'datasets.read',
+            'datasets.update',
+            'datasets.delete',
+        ])->get();
+
+        foreach ($perms as $perm) {
+            ApplicationHasPermission::firstOrCreate([
+                'application_id' => $this->integration->id,
+                'permission_id' => $perm->id,
+            ]);
+        }
+
+        $this->header = [
+            'Accept' => 'application/json',
+            'x-application-id' => $this->integration->app_id,
+            'x-client-id' => $this->integration->client_id,
+        ];
+
+        $this->header30 = array_merge($this->header, ['x-gwdm-version' => '3.0']);
+    }
+
+    // ─── Write path ───────────────────────────────────────────────────────────
+
+    public function test_persist_populates_all_sql_tables(): void
+    {
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+        $dv = $this->makeDatasetVersion30([]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $this->assertEquals('3.0', $dv->gwdm_version);
+
+        // Accessibility
+        $acc = Accessibility::where('dataset_version_id', $dv->id)->first();
+        $this->assertNotNull($acc, 'gwdm30_accessibility row should be created');
+        // accessRights / jurisdiction / vocabularyEncodingSchemes / conformsTo /
+        // languages are normalised to arrays by Gwdm30Handler::ensureArray() on
+        // write and cast back to arrays on read, so a scalar source value round-
+        // trips as a single-element array. access_service / access_request_cost
+        // are not array-normalised and stay scalar.
+        $this->assertEquals(['https://example.com/licence'], $acc->access_rights);
+        $this->assertEquals('https://example.com/access', $acc->access_service);
+        $this->assertEquals('Free at point of access', $acc->access_request_cost);
+        $this->assertEquals(['GENERAL RESEARCH USE'], $acc->data_use_limitation);
+        $this->assertEquals(['RETURN TO DATABASE OR RESOURCE', 'USER SPECIFIC RESTRICTION'], $acc->data_use_requirements);
+        $this->assertEquals(['CSV', 'JSON'], $acc->formats);
+        $this->assertEquals(['GB-ENG'], $acc->jurisdiction);
+        $this->assertEquals(['OTHER'], $acc->vocabulary_encoding_schemes);
+        $this->assertEquals(['LOCAL'], $acc->conforms_to);
+        $this->assertEquals(['en'], $acc->languages);
+
+        // Summary
+        $sum = Summary::where('dataset_version_id', $dv->id)->first();
+        $this->assertNotNull($sum, 'gwdm30_summary row should be created');
+        $this->assertEquals('Test dataset for GWDM 3.0 feature tests', $sum->abstract);
+        $this->assertEquals('test@example.com', $sum->contact_point);
+        $this->assertEquals(['Test,GWDM30'], $sum->keywords);
+        $this->assertEquals(['test'], $sum->dataset_type);
+        $this->assertEquals('Test Publisher', $sum->publisher_name);
+        $this->assertEquals(0, $sum->population_size);
+
+        // Coverage
+        $cov = Coverage::where('dataset_version_id', $dv->id)->first();
+        $this->assertNotNull($cov, 'gwdm30_coverage row should be created');
+        $this->assertEquals('NOT APPLICABLE', $cov->pathway);
+        $this->assertEquals('UNKNOWN', $cov->followup);
+        $this->assertEquals(0, $cov->min_typical_age);
+        $this->assertEquals(150, $cov->max_typical_age);
+
+        // Provenance
+        $prov = Provenance::where('dataset_version_id', $dv->id)->first();
+        $this->assertNotNull($prov, 'gwdm30_provenance row should be created');
+        $this->assertEquals(['OTHER'], $prov->origin_purpose);
+        $this->assertEquals(['MACHINE GENERATED'], $prov->origin_source);
+        $this->assertEquals('2020-01-01', $prov->temporal_start_date->toDateString());
+        $this->assertEquals('2024-12-31', $prov->temporal_end_date->toDateString());
+        $this->assertEquals('Annual', $prov->temporal_accrual_periodicity);
+
+        // Observations
+        $obs = Observation::where('dataset_version_id', $dv->id)->get();
+        $this->assertCount(1, $obs);
+        $this->assertEquals('Findings', $obs[0]->observed_node);
+        $this->assertEquals(100, $obs[0]->measured_value);
+        $this->assertEquals('2024-01-01', $obs[0]->observation_date->toDateString());
+        $this->assertEquals('Count', $obs[0]->measured_property);
+        $this->assertEquals('Test observation', $obs[0]->disambiguating_description);
+    }
+
+    public function test_persist_reads_data_use_fields_from_usage_not_access(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        $gwdm = [
+            'summary' => ['shortTitle' => 'Test', 'title' => 'Test'],
+            'coverage' => [],
+            'provenance' => [],
+            'observations' => [],
+            'accessibility' => [
+                'access' => [
+                    'accessRights' => 'https://example.com/rights',
+                    'accessService' => null,
+                    'accessRequestCost' => null,
+                    'deliveryLeadTime' => null,
+                ],
+                'usage' => [
+                    'dataUseLimitation' => ['GENERAL RESEARCH USE'],
+                    'dataUseRequirements' => ['RETURN TO DATABASE OR RESOURCE'],
+                ],
+                'formatAndStandards' => ['formats' => null],
+            ],
+        ];
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $row = Accessibility::where('dataset_version_id', $dv->id)->first();
+        $this->assertNotNull($row);
+        $this->assertEquals(['GENERAL RESEARCH USE'], $row->data_use_limitation);
+        $this->assertEquals(['RETURN TO DATABASE OR RESOURCE'], $row->data_use_requirements);
+    }
+
+    public function test_persist_replaces_rows_on_rewrite(): void
+    {
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+        $dv = $this->makeDatasetVersion30([]);
+        $handler = app(GwdmHandlerFactory::class)->resolve('3.0');
+
+        $handler->afterStore($dv->dataset, $dv, $gwdm);
+        $this->assertCount(1, Observation::where('dataset_version_id', $dv->id)->get());
+
+        // Re-persist with two observations — old rows must be replaced
+        $gwdm['observations'] = [
+            ['observedNode' => 'Persons', 'measuredValue' => 50, 'observationDate' => '2024-01-01', 'measuredProperty' => 'Count', 'disambiguatingDescription' => null],
+            ['observedNode' => 'Events',  'measuredValue' => 200, 'observationDate' => '2024-06-01', 'measuredProperty' => 'Count', 'disambiguatingDescription' => null],
+        ];
+        $handler->afterStore($dv->dataset, $dv, $gwdm);
+
+        $this->assertCount(2, Observation::where('dataset_version_id', $dv->id)->get());
+    }
+
+    // ─── LinkageExtraction ────────────────────────────────────────────────────
+
+    public function test_extract_linkages_creates_external_rows_for_unresolved_entries(): void
+    {
+        $dv = $this->makeDatasetVersion30([
+            'linkage' => [
+                'datasetLinkage' => [
+                    'isDerivedFrom' => [
+                        ['url' => 'https://external-site.example.com/datasets/99999', 'pid' => null, 'title' => 'External Dataset'],
+                    ],
+                ],
+                'publicationAboutDataset' => null,
+                'publicationUsingDataset' => null,
+            ],
+        ]);
+
+        // GWDM 3.0 writes linkage junctions synchronously in afterStore() from the
+        // input metadata; extractLinkages() (the async job path) is a no-op for 3.0
+        // because these arrays are not recoverable from storage on reconstruction.
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+
+        $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $dv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', Gwdm2xHandler::LINKAGE_DESCRIPTION)
+            ->get();
+
+        $this->assertCount(1, $rows);
+        $this->assertEquals('isDerivedFrom', $rows[0]->linkage_type);
+        $this->assertNull($rows[0]->dataset_version_target_id, 'Unresolved entry should have null target');
+        $this->assertEquals('External Dataset', $rows[0]->raw_title);
+        $this->assertEquals('https://external-site.example.com/datasets/99999', $rows[0]->raw_url);
+    }
+
+    public function test_extract_linkages_creates_internal_row_for_resolved_gateway_dataset(): void
+    {
+        $targetDv = $this->makeDatasetVersion30([]);
+
+        $sourceDv = $this->makeDatasetVersion30([
+            'linkage' => [
+                'datasetLinkage' => [
+                    'linkedDatasets' => [
+                        [
+                            'url' => config('gateway.gateway_url').'/en/dataset/'.$targetDv->dataset_id,
+                            'pid' => null,
+                            'title' => null,
+                        ],
+                    ],
+                ],
+                'publicationAboutDataset' => null,
+                'publicationUsingDataset' => null,
+            ],
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($sourceDv->dataset, $sourceDv, $sourceDv->metadata['metadata']);
+
+        $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $sourceDv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', Gwdm2xHandler::LINKAGE_DESCRIPTION)
+            ->get();
+
+        $this->assertCount(1, $rows);
+        $this->assertEquals('linkedDatasets', $rows[0]->linkage_type);
+        $this->assertEquals($targetDv->id, $rows[0]->dataset_version_target_id, 'Resolved entry should have target version ID set');
+    }
+
+    public function test_extract_linkages_replaces_existing_rows_on_rerun(): void
+    {
+        $dv = $this->makeDatasetVersion30([
+            'linkage' => [
+                'datasetLinkage' => [
+                    'isDerivedFrom' => [
+                        ['url' => 'https://external.example.com/a', 'pid' => null, 'title' => 'Dataset A'],
+                    ],
+                ],
+                'publicationAboutDataset' => null,
+                'publicationUsingDataset' => null,
+            ],
+        ]);
+
+        $handler = app(GwdmHandlerFactory::class)->resolve('3.0');
+        $handler->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+
+        $countRows = fn () => DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $dv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', Gwdm2xHandler::LINKAGE_DESCRIPTION)
+            ->count();
+
+        $this->assertEquals(1, $countRows());
+
+        // Re-run with different entries — old rows must be replaced, not appended
+        $dv->metadata = array_replace_recursive($dv->metadata, [
+            'metadata' => [
+                'linkage' => [
+                    'datasetLinkage' => [
+                        'isDerivedFrom' => [
+                            ['url' => 'https://external.example.com/b', 'pid' => null, 'title' => 'Dataset B'],
+                            ['url' => 'https://external.example.com/c', 'pid' => null, 'title' => 'Dataset C'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $handler->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+
+        $this->assertEquals(2, $countRows());
+    }
+
+    // ─── Read path ────────────────────────────────────────────────────────────
+
+    public function test_read_reconstructs_nested_accessibility_shape(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Accessibility::create([
+            'dataset_version_id' => $dv->id,
+            'access_rights' => 'https://example.com/rights',
+            'access_service' => 'https://example.com/service',
+            'access_request_cost' => 'Free',
+            'delivery_lead_time' => '1-2 WEEKS',
+            'jurisdiction' => 'GB-ENG',
+            'data_use_limitation' => ['GENERAL RESEARCH USE'],
+            'data_use_requirements' => ['RETURN TO DATABASE OR RESOURCE'],
+            'formats' => ['CSV'],
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('accessibility', $result);
+        $this->assertArrayHasKey('access', $result['accessibility']);
+        $this->assertArrayHasKey('usage', $result['accessibility']);
+        $this->assertArrayHasKey('formatAndStandards', $result['accessibility']);
+        $this->assertEquals('https://example.com/rights', $result['accessibility']['access']['accessRights']);
+        $this->assertEquals('GB-ENG', $result['accessibility']['access']['jurisdiction']);
+        $this->assertEquals(['GENERAL RESEARCH USE'], $result['accessibility']['usage']['dataUseLimitation']);
+        $this->assertEquals(['CSV'], $result['accessibility']['formatAndStandards']['formats']);
+    }
+
+    public function test_read_reconstructs_summary(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Summary::create([
+            'dataset_version_id' => $dv->id,
+            'abstract' => 'A test abstract',
+            'contact_point' => 'contact@example.com',
+            'keywords' => 'health,data',
+            'publisher_name' => 'NHS England',
+            'population_size' => 5000,
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('summary', $result);
+        $this->assertEquals('A test abstract', $result['summary']['abstract']);
+        $this->assertEquals('contact@example.com', $result['summary']['contactPoint']);
+        $this->assertEquals('NHS England', $result['summary']['publisher']['name']);
+        $this->assertEquals(5000, $result['summary']['populationSize']);
+        // title/shortTitle should be carried forward from the JSON blob
+        $this->assertArrayHasKey('title', $result['summary']);
+    }
+
+    public function test_read_reconstructs_coverage(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Coverage::create([
+            'dataset_version_id' => $dv->id,
+            'spatial' => 'https://www.geonames.org/countries/GB/united-kingdom.html',
+            'min_typical_age' => 18,
+            'max_typical_age' => 65,
+            'pathway' => 'PRIMARY CARE',
+            'followup' => '5 YEARS',
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('coverage', $result);
+        $this->assertEquals(18, $result['coverage']['minTypicalAge']);
+        $this->assertEquals(65, $result['coverage']['maxTypicalAge']);
+        $this->assertEquals('PRIMARY CARE', $result['coverage']['pathway']);
+        $this->assertEquals('5 YEARS', $result['coverage']['followUp']);
+    }
+
+    public function test_read_reconstructs_provenance(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Provenance::create([
+            'dataset_version_id' => $dv->id,
+            'origin_purpose' => 'ADMINISTRATIVE',
+            'origin_source' => 'EPR',
+            'origin_collection_situation' => 'PRIMARY CARE',
+            'temporal_start_date' => '2010-01-01',
+            'temporal_end_date' => '2023-12-31',
+            'temporal_time_lag' => '1-2 MONTHS',
+            'temporal_accrual_periodicity' => 'Monthly',
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('provenance', $result);
+        $this->assertEquals('ADMINISTRATIVE', $result['provenance']['origin']['purpose']);
+        $this->assertEquals('EPR', $result['provenance']['origin']['source']);
+        $this->assertEquals('2010-01-01', $result['provenance']['temporal']['startDate']);
+        $this->assertEquals('2023-12-31', $result['provenance']['temporal']['endDate']);
+        $this->assertEquals('Monthly', $result['provenance']['temporal']['accrualPeriodicity']);
+    }
+
+    public function test_read_reconstructs_observations(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Observation::create([
+            'dataset_version_id' => $dv->id,
+            'observed_node' => 'Persons',
+            'measured_value' => 12500,
+            'observation_date' => '2023-01-01',
+            'measured_property' => 'Count',
+            'disambiguating_description' => 'Total unique patients',
+        ]);
+        Observation::create([
+            'dataset_version_id' => $dv->id,
+            'observed_node' => 'Events',
+            'measured_value' => 45000,
+            'observation_date' => '2023-01-01',
+            'measured_property' => 'Count',
+            'disambiguating_description' => null,
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('observations', $result);
+        $this->assertCount(2, $result['observations']);
+        $this->assertEquals('Persons', $result['observations'][0]['observedNode']);
+        $this->assertEquals(12500, $result['observations'][0]['measuredValue']);
+        $this->assertEquals('2023-01-01', $result['observations'][0]['observationDate']);
+        $this->assertEquals('Events', $result['observations'][1]['observedNode']);
+    }
+
+    public function test_read_reconstructs_external_dataset_linkages(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        DatasetVersionHasDatasetVersion::create([
+            'dataset_version_source_id' => $dv->id,
+            'dataset_version_target_id' => null,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => 1,
+            'description' => Gwdm2xHandler::LINKAGE_DESCRIPTION,
+            'raw_url' => 'https://external.example.com/dataset/1',
+            'raw_pid' => null,
+            'raw_title' => 'External Dataset',
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertArrayHasKey('linkage', $result);
+        $this->assertArrayHasKey('isDerivedFrom', $result['linkage']['datasetLinkage']);
+        $entry = $result['linkage']['datasetLinkage']['isDerivedFrom'][0];
+        $this->assertEquals('https://external.example.com/dataset/1', $entry['url']);
+        $this->assertEquals('External Dataset', $entry['title']);
+        $this->assertNull($entry['pid']);
+    }
+
+    public function test_read_returns_empty_when_no_sql_rows(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertSame([], $result);
+    }
+
+    // ─── Rollback safety ─────────────────────────────────────────────────────
+
+    public function test_rollback_2x_version_has_no_gwdm30_sql_rows(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $dataset20 = Dataset::create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'pid' => 'rollback-test-2x-'.fake()->uuid(),
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+        $version20 = DatasetVersion::create([
+            'dataset_id' => $dataset20->id,
+            'version' => 1,
+            'gwdm_version' => '2.0',
+            'short_title' => 'Rollback Test 2.0',
+            'metadata' => [
+                'gwdmVersion' => '2.0',
+                'metadata' => $this->getMetadataV2p0()['metadata'],
+                'original_metadata' => [],
+            ],
+        ]);
+
+        $this->assertEquals('2.0', $version20->gwdm_version);
+
+        // No GWDM 3.0 SQL rows for a 2.0 version
+        $this->assertNull(Accessibility::where('dataset_version_id', $version20->id)->first());
+        $this->assertNull(Summary::where('dataset_version_id', $version20->id)->first());
+        $this->assertNull(Coverage::where('dataset_version_id', $version20->id)->first());
+        $this->assertNull(Provenance::where('dataset_version_id', $version20->id)->first());
+        $this->assertCount(0, Observation::where('dataset_version_id', $version20->id)->get());
+
+        // Create and persist a 3.0 version
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+        $version30 = $this->makeDatasetVersion30([]);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($version30->dataset, $version30, $gwdm);
+
+        $this->assertEquals('3.0', $version30->gwdm_version);
+        $this->assertNotNull(Accessibility::where('dataset_version_id', $version30->id)->first());
+        $this->assertNotNull(Summary::where('dataset_version_id', $version30->id)->first());
+
+        // 2.0 version is still untouched
+        $this->assertNull(Accessibility::where('dataset_version_id', $version20->id)->first());
+        $this->assertNull(Summary::where('dataset_version_id', $version20->id)->first());
+    }
+
+    // ─── DCAT / HealthDCAT-AP alignment ──────────────────────────────────────
+
+    public function test_persist_stores_dcat_summary_fields(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = array_merge($this->getGwdm30Metadata()['metadata'], [
+            'summary' => array_merge($this->getGwdm30Metadata()['metadata']['summary'], [
+                'licenseUrl' => 'https://creativecommons.org/licenses/by/4.0/',
+                'landingPage' => 'https://gateway.hdruk.ac.uk/datasets/abc123',
+                'creator' => [
+                    'name' => 'NHS England',
+                    'rorId' => 'https://ror.org/052gg0110',
+                    'orcidId' => null,
+                    'gatewayId' => '42',
+                ],
+                'theme' => ['https://health-ri.eu/themes/EHR', 'https://health-ri.eu/themes/Registry'],
+            ]),
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $sum = Summary::where('dataset_version_id', $dv->id)->first();
+        $this->assertEquals('https://creativecommons.org/licenses/by/4.0/', $sum->license_url);
+        $this->assertEquals('https://gateway.hdruk.ac.uk/datasets/abc123', $sum->landing_page);
+        $this->assertEquals('NHS England', $sum->creator_name);
+        $this->assertEquals('https://ror.org/052gg0110', $sum->creator_ror_id);
+        $this->assertEquals('42', $sum->creator_gateway_id);
+        $this->assertEquals(['https://health-ri.eu/themes/EHR', 'https://health-ri.eu/themes/Registry'], $sum->theme);
+    }
+
+    public function test_persist_stores_healthdcatap_coverage_fields(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = array_merge($this->getGwdm30Metadata()['metadata'], [
+            'coverage' => [
+                'spatial' => 'GB',
+                'minTypicalAge' => 18,
+                'maxTypicalAge' => 65,
+                'populationCoverage' => 'Adults registered with a GP in England',
+                'numberOfUniqueIndividuals' => 58000000,
+                'numberOfRecords' => 250000000,
+                'pathway' => 'PRIMARY CARE',
+                'followUp' => '10 YEARS',
+            ],
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $cov = Coverage::where('dataset_version_id', $dv->id)->first();
+        $this->assertEquals(18, $cov->min_typical_age);
+        $this->assertEquals(65, $cov->max_typical_age);
+        $this->assertEquals('Adults registered with a GP in England', $cov->population_coverage);
+        $this->assertEquals(58000000, $cov->number_of_unique_individuals);
+        $this->assertEquals(250000000, $cov->number_of_records);
+    }
+
+    public function test_persist_stores_retention_period(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = array_merge($this->getGwdm30Metadata()['metadata'], [
+            'provenance' => array_merge($this->getGwdm30Metadata()['metadata']['provenance'], [
+                'retentionPeriod' => [
+                    'startDate' => '2019-04-01',
+                    'endDate' => '2030-03-31',
+                ],
+            ]),
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $prov = Provenance::where('dataset_version_id', $dv->id)->first();
+        $this->assertEquals('2019-04-01', $prov->retention_period_start->toDateString());
+        $this->assertEquals('2030-03-31', $prov->retention_period_end->toDateString());
+    }
+
+    public function test_persist_stores_gdpr_accessibility_fields(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+        $gwdm['accessibility']['access']['legalBasis'] = 'GDPR Article 6(1)(e) — public task';
+        $gwdm['accessibility']['access']['personalData'] = 'pseudonymised';
+        $gwdm['accessibility']['access']['applicableLegislation'] = 'Data Protection Act 2018';
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $acc = Accessibility::where('dataset_version_id', $dv->id)->first();
+        $this->assertEquals('GDPR Article 6(1)(e) — public task', $acc->legal_basis);
+        $this->assertEquals('pseudonymised', $acc->personal_data);
+        $this->assertEquals('Data Protection Act 2018', $acc->applicable_legislation);
+    }
+
+    public function test_persist_and_read_distributions(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = array_merge($this->getGwdm30Metadata()['metadata'], [
+            'distributions' => [
+                [
+                    'title' => 'CSV export',
+                    'accessUrl' => 'https://example.com/access',
+                    'downloadUrl' => 'https://example.com/download.csv',
+                    'mediaType' => 'text/csv',
+                    'format' => 'CSV',
+                    'byteSize' => 1048576,
+                    'licenseUrl' => 'https://creativecommons.org/licenses/by/4.0/',
+                    'accessService' => 'https://example.com/api',
+                ],
+                [
+                    'title' => 'FHIR API',
+                    'accessUrl' => 'https://example.com/fhir',
+                    'mediaType' => 'application/fhir+json',
+                ],
+            ],
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $rows = Distribution::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        $this->assertCount(2, $rows);
+        $this->assertEquals('CSV export', $rows[0]->title);
+        $this->assertEquals('https://example.com/access', $rows[0]->access_url);
+        $this->assertEquals('https://example.com/download.csv', $rows[0]->download_url);
+        $this->assertEquals('text/csv', $rows[0]->media_type);
+        $this->assertEquals(1048576, $rows[0]->byte_size);
+        $this->assertEquals('https://creativecommons.org/licenses/by/4.0/', $rows[0]->license_url);
+        $this->assertEquals('FHIR API', $rows[1]->title);
+        $this->assertEquals('https://example.com/fhir', $rows[1]->access_url);
+
+        // Read path round-trip
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+        $this->assertArrayHasKey('distributions', $result);
+        $this->assertCount(2, $result['distributions']);
+        $this->assertEquals('CSV export', $result['distributions'][0]['title']);
+        $this->assertEquals('text/csv', $result['distributions'][0]['mediaType']);
+        $this->assertEquals('https://example.com/fhir', $result['distributions'][1]['accessUrl']);
+    }
+
+    public function test_persist_and_read_quality_annotations(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $gwdm = array_merge($this->getGwdm30Metadata()['metadata'], [
+            'qualityAnnotations' => [
+                [
+                    'annotationType' => 'duf_score',
+                    'qualityDimension' => 'completeness',
+                    'qualityValue' => '4',
+                    'qualityDescription' => 'Data completeness rated 4/5 by HDR UK DUF review',
+                    'annotationDate' => '2024-03-01',
+                ],
+                [
+                    'annotationType' => 'certification',
+                    'certificationUrl' => 'https://example.com/iso27001-cert.pdf',
+                    'qualityDescription' => 'ISO 27001 certified data custodian',
+                    'annotationDate' => '2023-09-15',
+                ],
+            ],
+        ]);
+
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $gwdm);
+
+        $rows = QualityAnnotation::where('dataset_version_id', $dv->id)->orderBy('id')->get();
+        $this->assertCount(2, $rows);
+        $this->assertEquals('duf_score', $rows[0]->annotation_type);
+        $this->assertEquals('completeness', $rows[0]->quality_dimension);
+        $this->assertEquals('4', $rows[0]->quality_value);
+        $this->assertEquals('2024-03-01', $rows[0]->annotation_date->toDateString());
+        $this->assertEquals('certification', $rows[1]->annotation_type);
+        $this->assertEquals('https://example.com/iso27001-cert.pdf', $rows[1]->certification_url);
+
+        // Read path round-trip
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+        $this->assertArrayHasKey('qualityAnnotations', $result);
+        $this->assertCount(2, $result['qualityAnnotations']);
+        $this->assertEquals('duf_score', $result['qualityAnnotations'][0]['annotationType']);
+        $this->assertEquals('completeness', $result['qualityAnnotations'][0]['qualityDimension']);
+        $this->assertEquals('certification', $result['qualityAnnotations'][1]['annotationType']);
+        $this->assertEquals('https://example.com/iso27001-cert.pdf', $result['qualityAnnotations'][1]['certificationUrl']);
+    }
+
+    public function test_read_returns_dcat_summary_fields(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Summary::create([
+            'dataset_version_id' => $dv->id,
+            'abstract' => 'Test abstract',
+            'license_url' => 'https://creativecommons.org/licenses/by/4.0/',
+            'landing_page' => 'https://gateway.hdruk.ac.uk/datasets/abc',
+            'creator_name' => 'NHS England',
+            'creator_ror_id' => 'https://ror.org/052gg0110',
+            'theme' => ['https://health-ri.eu/themes/EHR'],
+            'publisher_name' => 'NHS England',
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertEquals('https://creativecommons.org/licenses/by/4.0/', $result['summary']['licenseUrl']);
+        $this->assertEquals('https://gateway.hdruk.ac.uk/datasets/abc', $result['summary']['landingPage']);
+        $this->assertEquals('NHS England', $result['summary']['creator']['name']);
+        $this->assertEquals('https://ror.org/052gg0110', $result['summary']['creator']['rorId']);
+        $this->assertEquals(['https://health-ri.eu/themes/EHR'], $result['summary']['theme']);
+    }
+
+    public function test_read_returns_gdpr_accessibility_fields(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+
+        Accessibility::create([
+            'dataset_version_id' => $dv->id,
+            'access_rights' => 'https://example.com/rights',
+            'legal_basis' => 'GDPR Article 6(1)(e)',
+            'personal_data' => 'pseudonymised',
+            'applicable_legislation' => 'Data Protection Act 2018',
+        ]);
+
+        $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
+
+        $this->assertEquals('GDPR Article 6(1)(e)', $result['accessibility']['access']['legalBasis']);
+        $this->assertEquals('pseudonymised', $result['accessibility']['access']['personalData']);
+        $this->assertEquals('Data Protection Act 2018', $result['accessibility']['access']['applicableLegislation']);
+    }
+
+    public function test_distributions_replaced_on_rewrite(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        $handler = app(GwdmHandlerFactory::class)->resolve('3.0');
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+
+        $gwdm['distributions'] = [['accessUrl' => 'https://example.com/v1']];
+        $handler->afterStore($dv->dataset, $dv, $gwdm);
+        $this->assertCount(1, Distribution::where('dataset_version_id', $dv->id)->get());
+
+        $gwdm['distributions'] = [
+            ['accessUrl' => 'https://example.com/v2a'],
+            ['accessUrl' => 'https://example.com/v2b'],
+        ];
+        $handler->afterStore($dv->dataset, $dv, $gwdm);
+        $this->assertCount(2, Distribution::where('dataset_version_id', $dv->id)->get());
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private function getGwdm30Metadata(): array
+    {
+        $json = file_get_contents(getcwd().'/tests/Unit/test_files/gwdm_v3p0_dataset_min.json');
+
+        return json_decode($json, true);
+    }
+
+    /**
+     * Create a Dataset + DatasetVersion directly with GWDM 3.0 metadata,
+     * merging $metadataOverrides into the `metadata` section of the envelope.
+     */
+    private function makeDatasetVersion30(array $metadataOverrides): DatasetVersion
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $dataset = Dataset::create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'pid' => 'test-'.fake()->uuid(),
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+
+        $baseMetadata = $this->getGwdm30Metadata()['metadata'];
+        $mergedMetadata = array_replace_recursive($baseMetadata, $metadataOverrides);
+
+        return DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'gwdm_version' => '3.0',
+            'short_title' => $mergedMetadata['summary']['shortTitle'] ?? 'GWDM 3.0 Test',
+            'metadata' => [
+                'gwdmVersion' => '3.0',
+                'metadata' => $mergedMetadata,
+                'original_metadata' => [],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/DatasetVersionGwdm30Test.php
+++ b/tests/Feature/DatasetVersionGwdm30Test.php
@@ -17,6 +17,7 @@ use App\Models\Gwdm30\Summary;
 use App\Models\Permission;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\DatasetService;
 use App\Services\Gwdm\Gwdm2xHandler;
 use App\Services\Gwdm\GwdmHandlerFactory;
 use Tests\TestCase;
@@ -187,7 +188,7 @@ class DatasetVersionGwdm30Test extends TestCase
 
     public function test_extract_linkages_creates_external_rows_for_unresolved_entries(): void
     {
-        $dv = $this->makeDatasetVersion30([
+        $overrides = [
             'linkage' => [
                 'datasetLinkage' => [
                     'isDerivedFrom' => [
@@ -197,12 +198,13 @@ class DatasetVersionGwdm30Test extends TestCase
                 'publicationAboutDataset' => null,
                 'publicationUsingDataset' => null,
             ],
-        ]);
+        ];
+        $dv = $this->makeDatasetVersion30($overrides);
 
         // GWDM 3.0 writes linkage junctions synchronously in afterStore() from the
         // input metadata; extractLinkages() (the async job path) is a no-op for 3.0
         // because these arrays are not recoverable from storage on reconstruction.
-        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $this->gwdm30Input($overrides));
 
         $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $dv->id)
             ->where('direct_linkage', 1)
@@ -220,7 +222,7 @@ class DatasetVersionGwdm30Test extends TestCase
     {
         $targetDv = $this->makeDatasetVersion30([]);
 
-        $sourceDv = $this->makeDatasetVersion30([
+        $overrides = [
             'linkage' => [
                 'datasetLinkage' => [
                     'linkedDatasets' => [
@@ -234,9 +236,10 @@ class DatasetVersionGwdm30Test extends TestCase
                 'publicationAboutDataset' => null,
                 'publicationUsingDataset' => null,
             ],
-        ]);
+        ];
+        $sourceDv = $this->makeDatasetVersion30($overrides);
 
-        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($sourceDv->dataset, $sourceDv, $sourceDv->metadata['metadata']);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($sourceDv->dataset, $sourceDv, $this->gwdm30Input($overrides));
 
         $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $sourceDv->id)
             ->where('direct_linkage', 1)
@@ -250,7 +253,7 @@ class DatasetVersionGwdm30Test extends TestCase
 
     public function test_extract_linkages_replaces_existing_rows_on_rerun(): void
     {
-        $dv = $this->makeDatasetVersion30([
+        $overrides = [
             'linkage' => [
                 'datasetLinkage' => [
                     'isDerivedFrom' => [
@@ -260,10 +263,11 @@ class DatasetVersionGwdm30Test extends TestCase
                 'publicationAboutDataset' => null,
                 'publicationUsingDataset' => null,
             ],
-        ]);
+        ];
+        $dv = $this->makeDatasetVersion30($overrides);
 
         $handler = app(GwdmHandlerFactory::class)->resolve('3.0');
-        $handler->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+        $handler->afterStore($dv->dataset, $dv, $this->gwdm30Input($overrides));
 
         $countRows = fn () => DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $dv->id)
             ->where('direct_linkage', 1)
@@ -273,19 +277,17 @@ class DatasetVersionGwdm30Test extends TestCase
         $this->assertEquals(1, $countRows());
 
         // Re-run with different entries — old rows must be replaced, not appended
-        $dv->metadata = array_replace_recursive($dv->metadata, [
-            'metadata' => [
-                'linkage' => [
-                    'datasetLinkage' => [
-                        'isDerivedFrom' => [
-                            ['url' => 'https://external.example.com/b', 'pid' => null, 'title' => 'Dataset B'],
-                            ['url' => 'https://external.example.com/c', 'pid' => null, 'title' => 'Dataset C'],
-                        ],
+        $rerunInput = $this->gwdm30Input([
+            'linkage' => [
+                'datasetLinkage' => [
+                    'isDerivedFrom' => [
+                        ['url' => 'https://external.example.com/b', 'pid' => null, 'title' => 'Dataset B'],
+                        ['url' => 'https://external.example.com/c', 'pid' => null, 'title' => 'Dataset C'],
                     ],
                 ],
             ],
         ]);
-        $handler->afterStore($dv->dataset, $dv, $dv->metadata['metadata']);
+        $handler->afterStore($dv->dataset, $dv, $rerunInput);
 
         $this->assertEquals(2, $countRows());
     }
@@ -632,7 +634,8 @@ class DatasetVersionGwdm30Test extends TestCase
         $this->assertEquals('FHIR API', $rows[1]->title);
         $this->assertEquals('https://example.com/fhir', $rows[1]->access_url);
 
-        // Read path round-trip
+        // Read path round-trip. No X-Gwdm-Cache header, so afterRead() reconstructs
+        // from SQL (the default) — proves persist() wrote correct, reconstructable rows.
         $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
         $this->assertArrayHasKey('distributions', $result);
         $this->assertCount(2, $result['distributions']);
@@ -673,7 +676,8 @@ class DatasetVersionGwdm30Test extends TestCase
         $this->assertEquals('certification', $rows[1]->annotation_type);
         $this->assertEquals('https://example.com/iso27001-cert.pdf', $rows[1]->certification_url);
 
-        // Read path round-trip
+        // Read path round-trip. No X-Gwdm-Cache header, so afterRead() reconstructs
+        // from SQL (the default) — proves persist() wrote correct, reconstructable rows.
         $result = app(GwdmHandlerFactory::class)->resolve('3.0')->afterRead($dv);
         $this->assertArrayHasKey('qualityAnnotations', $result);
         $this->assertCount(2, $result['qualityAnnotations']);
@@ -744,6 +748,149 @@ class DatasetVersionGwdm30Test extends TestCase
         $this->assertCount(2, Distribution::where('dataset_version_id', $dv->id)->get());
     }
 
+    // ─── Section cache: read parity with 2.x (denormalised metadata column) ─────
+
+    public function test_after_store_denormalises_sections_and_excludes_linkage(): void
+    {
+        $overrides = [
+            'linkage' => [
+                'datasetLinkage' => [
+                    'isDerivedFrom' => [
+                        ['url' => 'https://external.example.com/x', 'pid' => null, 'title' => 'External X'],
+                    ],
+                ],
+                'publicationAboutDataset' => null,
+                'publicationUsingDataset' => null,
+            ],
+        ];
+        $dv = $this->makeDatasetVersion30($overrides);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $this->gwdm30Input($overrides));
+
+        $stored = DatasetVersion::find($dv->id)->metadata;
+
+        $this->assertArrayHasKey('metadata', $stored, 'afterStore should denormalise the sections into the metadata column');
+        $this->assertArrayHasKey('summary', $stored['metadata'], 'the section cache should contain reconstructed sections');
+        $this->assertArrayNotHasKey('linkage', $stored['metadata'], 'linkage must be EXCLUDED from the cache (merged fresh on read)');
+    }
+
+    public function test_cached_read_equals_forced_sql_read(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $this->getGwdm30Metadata()['metadata']);
+
+        $service = app(DatasetService::class);
+
+        // Default path (no header): reassembled from the SQL section tables.
+        $sql = $service->getReconstructedMetadataEnvelope(
+            $dv->dataset_id,
+            1,
+            validate: false,
+            prefetched: DatasetVersion::find($dv->id),
+        );
+
+        // Cache path: caller opts in via X-Gwdm-Cache: bypass.
+        request()->headers->set('X-Gwdm-Cache', 'bypass');
+        $cached = $service->getReconstructedMetadataEnvelope(
+            $dv->dataset_id,
+            1,
+            validate: false,
+            prefetched: DatasetVersion::find($dv->id),
+        );
+
+        $this->assertEquals($sql['metadata'], $cached['metadata'], 'cached read must equal the SQL reconstruction');
+    }
+
+    public function test_cached_read_issues_far_fewer_queries_than_sql(): void
+    {
+        $dv = $this->makeDatasetVersion30([]);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dv->dataset, $dv, $this->getGwdm30Metadata()['metadata']);
+        $service = app(DatasetService::class);
+
+        $countQueries = function () use ($service, $dv): int {
+            $fresh = DatasetVersion::find($dv->id);
+            \Illuminate\Support\Facades\DB::flushQueryLog();
+            \Illuminate\Support\Facades\DB::enableQueryLog();
+            $service->getReconstructedMetadataEnvelope($dv->dataset_id, 1, validate: false, prefetched: $fresh);
+            $n = count(\Illuminate\Support\Facades\DB::getQueryLog());
+            \Illuminate\Support\Facades\DB::disableQueryLog();
+
+            return $n;
+        };
+
+        // Default (no header) = SQL reconstruction; header opts into the cache.
+        $sqlQueries = $countQueries();
+        request()->headers->set('X-Gwdm-Cache', 'bypass');
+        $cachedQueries = $countQueries();
+
+        // Cache path only reads linkage from the junction tables (~4); the SQL path
+        // additionally preloads ~16 section tables.
+        $this->assertLessThanOrEqual(6, $cachedQueries, "cached read should be lean, got {$cachedQueries} queries");
+        $this->assertGreaterThan($cachedQueries, $sqlQueries, 'the SQL path should issue more queries than the cache path');
+    }
+
+    public function test_unbackfilled_row_falls_back_to_sql(): void
+    {
+        // Even when the caller opts into the cache, a row with no denormalised cache
+        // (created before the cache existed, or an un-backfilled 3.0 row) must still
+        // reconstruct correctly from SQL.
+        $dv = $this->makeDatasetVersion30([]);
+        Summary::create([
+            'dataset_version_id' => $dv->id,
+            'abstract' => 'Fallback abstract',
+            'publisher_name' => 'Fallback Publisher',
+        ]);
+
+        $fresh = DatasetVersion::find($dv->id);
+        $this->assertArrayNotHasKey('metadata', $fresh->metadata, 'precondition: no section cache present');
+
+        request()->headers->set('X-Gwdm-Cache', 'bypass');
+        $envelope = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $dv->dataset_id,
+            1,
+            validate: false,
+            prefetched: $fresh,
+        );
+
+        $this->assertEquals('Fallback abstract', $envelope['metadata']['summary']['abstract']);
+    }
+
+    public function test_linkage_is_read_fresh_not_from_stale_cache(): void
+    {
+        // Cache dataset A with a resolved link to dataset B's latest version.
+        $targetDv = $this->makeDatasetVersion30([]);
+
+        $overrides = [
+            'linkage' => [
+                'datasetLinkage' => [
+                    'linkedDatasets' => [
+                        [
+                            'url' => config('gateway.gateway_url').'/en/dataset/'.$targetDv->dataset_id,
+                            'pid' => null,
+                            'title' => null,
+                        ],
+                    ],
+                ],
+                'publicationAboutDataset' => null,
+                'publicationUsingDataset' => null,
+            ],
+        ];
+        $sourceDv = $this->makeDatasetVersion30($overrides);
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($sourceDv->dataset, $sourceDv, $this->gwdm30Input($overrides));
+
+        // On the cache path (opted in via header), the cached sections hold no
+        // linkage; the reconstructed envelope resolves it fresh from the junction
+        // tables so link titles track each target's latest version.
+        request()->headers->set('X-Gwdm-Cache', 'bypass');
+        $envelope = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $sourceDv->dataset_id,
+            1,
+            validate: false,
+            prefetched: DatasetVersion::find($sourceDv->id),
+        );
+
+        $this->assertArrayHasKey('linkage', $envelope['metadata'], 'linkage must be present in the reconstructed envelope');
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────
 
     private function getGwdm30Metadata(): array
@@ -754,8 +901,26 @@ class DatasetVersionGwdm30Test extends TestCase
     }
 
     /**
-     * Create a Dataset + DatasetVersion directly with GWDM 3.0 metadata,
-     * merging $metadataOverrides into the `metadata` section of the envelope.
+     * The GWDM 3.0 input metadata (base fixture merged with $overrides), suitable
+     * for passing to afterStore(). Kept separate from makeDatasetVersion30() so
+     * tests can feed the same input to afterStore() without reading it back out of
+     * the row's metadata column (which now holds only the stored envelope, not the
+     * write-time input — see makeDatasetVersion30()).
+     */
+    private function gwdm30Input(array $overrides = []): array
+    {
+        return array_replace_recursive($this->getGwdm30Metadata()['metadata'], $overrides);
+    }
+
+    /**
+     * Create a Dataset + DatasetVersion directly with a GWDM 3.0 envelope.
+     *
+     * The stored metadata column mirrors what Gwdm30Handler::buildEnvelope()
+     * produces at write time: {gwdmVersion, original_metadata} with NO denormalised
+     * 'metadata' section cache. The cache is only written later by afterStore()
+     * (refreshSectionCache), so a row made here reads via the SQL section tables —
+     * which is what the read-reconstruction tests exercise. Pass the same
+     * $metadataOverrides to gwdm30Input() when you also need the write-time input.
      */
     private function makeDatasetVersion30(array $metadataOverrides): DatasetVersion
     {
@@ -770,8 +935,7 @@ class DatasetVersionGwdm30Test extends TestCase
             'status' => Dataset::STATUS_ACTIVE,
         ]);
 
-        $baseMetadata = $this->getGwdm30Metadata()['metadata'];
-        $mergedMetadata = array_replace_recursive($baseMetadata, $metadataOverrides);
+        $mergedMetadata = $this->gwdm30Input($metadataOverrides);
 
         return DatasetVersion::create([
             'dataset_id' => $dataset->id,
@@ -780,7 +944,6 @@ class DatasetVersionGwdm30Test extends TestCase
             'short_title' => $mergedMetadata['summary']['shortTitle'] ?? 'GWDM 3.0 Test',
             'metadata' => [
                 'gwdmVersion' => '3.0',
-                'metadata' => $mergedMetadata,
                 'original_metadata' => [],
             ],
         ]);

--- a/tests/Feature/DatasetVersionGwdm30Test.php
+++ b/tests/Feature/DatasetVersionGwdm30Test.php
@@ -785,4 +785,44 @@ class DatasetVersionGwdm30Test extends TestCase
             ],
         ]);
     }
+
+    // ─── M2: batched section preload (avoids N+1 on multi-version reads) ────────
+
+    public function test_preload_sections_for_versions_batches_queries(): void
+    {
+        $handler = app(GwdmHandlerFactory::class)->resolve('3.0');
+        $gwdm = $this->getGwdm30Metadata()['metadata'];
+
+        // Three separate 3.0 versions, each with SQL sections written.
+        $versions = collect();
+        for ($i = 0; $i < 3; $i++) {
+            $dv = $this->makeDatasetVersion30([]);
+            $handler->afterStore($dv->dataset, $dv, $gwdm);
+            $versions->push(DatasetVersion::find($dv->id)); // fresh, no relations loaded
+        }
+
+        \Illuminate\Support\Facades\DB::flushQueryLog();
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+        $handler->preloadSectionsForVersions($versions);
+        $preloadQueries = count(\Illuminate\Support\Facades\DB::getQueryLog());
+        \Illuminate\Support\Facades\DB::disableQueryLog();
+
+        // One query per section type regardless of the version count — bounded well
+        // below the per-row cost (3 versions x ~16 sections = ~48 queries).
+        $this->assertLessThanOrEqual(20, $preloadQueries, "expected a batched preload, got {$preloadQueries} queries");
+        $this->assertTrue($versions->first()->relationLoaded('gwdm30Summary'));
+        $this->assertTrue($versions->last()->relationLoaded('gwdm30Observations'));
+
+        // afterRead() on a preloaded version reads the 16 SQL sections from the
+        // hydrated relations (no re-query); the only queries it may still issue are
+        // for linkage reconstruction from the junction tables, which are not part
+        // of the section preload. So the count stays small and constant, not ~16.
+        \Illuminate\Support\Facades\DB::flushQueryLog();
+        \Illuminate\Support\Facades\DB::enableQueryLog();
+        $handler->afterRead($versions->first());
+        $afterReadQueries = count(\Illuminate\Support\Facades\DB::getQueryLog());
+        \Illuminate\Support\Facades\DB::disableQueryLog();
+
+        $this->assertLessThanOrEqual(4, $afterReadQueries, 'afterRead should serve the 16 SQL sections from preloaded relations');
+    }
 }

--- a/tests/Feature/GwdmHandlerFactoryTest.php
+++ b/tests/Feature/GwdmHandlerFactoryTest.php
@@ -6,17 +6,17 @@ use App\Services\Gwdm\Gwdm1xHandler;
 use App\Services\Gwdm\Gwdm20Handler;
 use App\Services\Gwdm\Gwdm21Handler;
 use App\Services\Gwdm\Gwdm2xHandler;
+use App\Services\Gwdm\Gwdm30Handler;
 use App\Services\Gwdm\GwdmHandlerFactory;
 use Tests\TestCase;
 
 /**
- * PR2 coverage for the single point of GWDM version branching. This factory is
- * the ONLY place allowed to switch on the schema version; all scattered
+ * Coverage for the single point of GWDM version branching. This factory is the
+ * ONLY place allowed to switch on the schema version; all scattered
  * version_compare() calls in DatasetService were replaced by resolve() here.
  *
- * NOTE: in this PR the 3.0 arm is intentionally absent — GWDM 3.0 is enabled in
- * a later PR of the stack once its handler + SQL tables exist. This test guards
- * that 3.0 is not yet user-selectable so enabling it early cannot 500.
+ * GWDM 3.0 is activated in this PR (its handler + SQL tables now exist), so the
+ * factory resolves '3.0' to Gwdm30Handler and lists it in SUPPORTED_VERSIONS.
  */
 class GwdmHandlerFactoryTest extends TestCase
 {
@@ -43,10 +43,14 @@ class GwdmHandlerFactoryTest extends TestCase
         $this->assertInstanceOf(Gwdm2xHandler::class, $this->factory()->resolve('1.5'));
     }
 
-    public function test_supported_versions_are_2_0_and_2_1_only(): void
+    public function test_resolves_3_0_to_gwdm30_handler(): void
     {
-        // 3.0 is deliberately NOT yet supported in this PR of the stack.
-        $this->assertSame(['2.0', '2.1'], GwdmHandlerFactory::supportedVersions());
-        $this->assertNotContains('3.0', GwdmHandlerFactory::supportedVersions());
+        $this->assertInstanceOf(Gwdm30Handler::class, $this->factory()->resolve('3.0'));
+    }
+
+    public function test_supported_versions_include_3_0(): void
+    {
+        // 3.0 is activated in this PR alongside its handler + SQL tables.
+        $this->assertSame(['2.0', '2.1', '3.0'], GwdmHandlerFactory::supportedVersions());
     }
 }

--- a/tests/Traits/MockExternalApis.php
+++ b/tests/Traits/MockExternalApis.php
@@ -70,7 +70,16 @@ trait MockExternalApis
 
             case version_compare($version, "2.1", "<="):
                 return $this->getMetadataV2p1();
+
+            case version_compare($version, "3.0", "<="):
+                return $this->getMetadataV3p0();
         }
+    }
+
+    public function getMetadataV3p0(): array
+    {
+        $jsonFile = file_get_contents(getcwd() . '/tests/Unit/test_files/gwdm_v3p0_dataset_min.json', 0, null);
+        return json_decode($jsonFile, true);
     }
 
     public function getPublicSchema()

--- a/tests/Unit/test_files/gwdm_v3p0_dataset_min.json
+++ b/tests/Unit/test_files/gwdm_v3p0_dataset_min.json
@@ -1,0 +1,175 @@
+{
+    "gwdmVersion": "3.0",
+    "metadata": {
+        "required": {
+            "gatewayId": "1234",
+            "gatewayPid": "5124f2",
+            "issued": "2020-08-05T14:35:59Z",
+            "modified": "2021-01-28T14:15:46Z",
+            "revisions": [
+                {
+                    "version": "1.0.0",
+                    "url": "https://d5faf9c6-6c34-46d7-93c4-7706a5436ed9"
+                }
+            ],
+            "version": "1.0.0"
+        },
+        "summary": {
+            "title": "GWDM 3.0 Test Dataset - Full Title",
+            "shortTitle": "GWDM 3.0 Test Dataset",
+            "abstract": "Test dataset for GWDM 3.0 feature tests",
+            "description": "A minimal GWDM 3.0 dataset for automated testing",
+            "contactPoint": "test@example.com",
+            "keywords": "Test,GWDM30",
+            "controlledKeywords": null,
+            "datasetType": "test",
+            "datasetSubType": "primaryCare",
+            "inPipeline": "available",
+            "funders": "Test Funder",
+            "doiName": null,
+            "licenseUrl": "https://example.com/licence",
+            "landingPage": "https://example.com/dataset/1234",
+            "creator": {
+                "name": "Test Creator Organisation",
+                "rorId": "0abcdef12",
+                "orcidId": null,
+                "gatewayId": null
+            },
+            "theme": [
+                "https://health-topic.example/T001"
+            ],
+            "publisher": {
+                "name": "Test Publisher",
+                "gatewayId": null,
+                "rorId": null
+            },
+            "populationSize": 0
+        },
+        "coverage": {
+            "spatial": "https://www.geonames.org/countries/GB/united-kingdom.html",
+            "minTypicalAge": 0,
+            "maxTypicalAge": 150,
+            "populationCoverage": "Patients registered with a GP in England",
+            "numberOfUniqueIndividuals": 5000000,
+            "numberOfRecords": 12000000,
+            "pathway": "NOT APPLICABLE",
+            "followUp": "UNKNOWN",
+            "datasetCompleteness": "95%"
+        },
+        "provenance": {
+            "origin": {
+                "purpose": "OTHER",
+                "source": "MACHINE GENERATED",
+                "collectionSituation": "OTHER",
+                "imageContrast": null
+            },
+            "temporal": {
+                "startDate": "2020-01-01",
+                "endDate": "2024-12-31",
+                "timeLag": "Not applicable",
+                "accrualPeriodicity": "Annual",
+                "distributionReleaseDate": "2025-03-01"
+            },
+            "retentionPeriod": {
+                "startDate": "2020-01-01",
+                "endDate": "2030-12-31"
+            }
+        },
+        "accessibility": {
+            "access": {
+                "accessRights": "https://example.com/licence",
+                "accessService": "https://example.com/access",
+                "accessServiceCategory": "TRE",
+                "accessRequestCost": "Free at point of access",
+                "deliveryLeadTime": "1-2 WEEKS",
+                "jurisdiction": "GB-ENG",
+                "dataController": "Test Organisation",
+                "dataProcessor": "Test Organisation",
+                "legalBasis": "Article 6(1)(e) – public task",
+                "personalData": "pseudonymised",
+                "applicableLegislation": "UK GDPR"
+            },
+            "usage": {
+                "dataUseLimitation": ["GENERAL RESEARCH USE"],
+                "dataUseRequirements": ["RETURN TO DATABASE OR RESOURCE", "USER SPECIFIC RESTRICTION"],
+                "resourceCreator": {
+                    "name": "Test Organisation"
+                }
+            },
+            "formatAndStandards": {
+                "vocabularyEncodingSchemes": "OTHER",
+                "conformsTo": "LOCAL",
+                "languages": "en",
+                "formats": ["CSV", "JSON"]
+            }
+        },
+        "linkage": {
+            "datasetLinkage": {
+                "isDerivedFrom": [],
+                "isPartOf": [],
+                "isMemberOf": [],
+                "linkedDatasets": []
+            },
+            "publicationAboutDataset": null,
+            "publicationUsingDataset": null,
+            "isGeneratedUsing": null,
+            "associatedMedia": null,
+            "dataUses": null,
+            "isReferenceIn": null,
+            "tools": null,
+            "investigations": null,
+            "syntheticDataWebLink": null
+        },
+        "observations": [
+            {
+                "observedNode": "Findings",
+                "measuredValue": 100,
+                "observationDate": "2024-01-01",
+                "measuredProperty": "Count",
+                "disambiguatingDescription": "Test observation"
+            }
+        ],
+        "omics": {
+            "assay": "WGS",
+            "platform": "Illumina NovaSeq"
+        },
+        "demographicFrequency": {
+            "age": [
+                { "bin": "0-4", "count": 12000 },
+                { "bin": "5-17", "count": 45000 }
+            ],
+            "ethnicity": [
+                { "bin": "White British", "count": 38000 },
+                { "bin": "Asian or Asian British", "count": 9000 }
+            ],
+            "disease": [
+                { "diseaseCode": "E11", "diseaseCodeVocabulary": "ICD-10", "count": 7500 }
+            ]
+        },
+        "distributions": [
+            {
+                "title": "CSV bulk download",
+                "description": "Full dataset as a comma-separated file",
+                "accessUrl": "https://example.com/access",
+                "downloadUrl": "https://example.com/download/dataset.csv",
+                "mediaType": "text/csv",
+                "format": "CSV",
+                "byteSize": 1048576,
+                "licenseUrl": "https://example.com/licence",
+                "accessService": "https://example.com/access",
+                "issued": "2024-01-01",
+                "modified": "2025-01-01"
+            }
+        ],
+        "qualityAnnotations": [
+            {
+                "annotationType": "duf_score",
+                "qualityDimension": "completeness",
+                "qualityValue": "3",
+                "qualityDescription": "Data Utility Framework completeness score",
+                "certificationUrl": null,
+                "annotationDate": "2024-06-01"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

N/A.

## Describe your changes

**PR 4 of 5** — stacked on PR3. **Activates GWDM 3.0.**

- **`Gwdm30Handler`** — persists sections to the `gwdm30_*` tables (`afterStore`/`persist()`), reconstructs from them (`afterRead`), writes linkage junctions synchronously.
- **`GwdmHandlerFactory`** — restores the `'3.0'` arm + `SUPPORTED_VERSIONS` entry (removed in PR2).
- **V3 version endpoints** — `config/routes_v3.php` + `Api/V3/DatasetController`.
- Test fixtures + `MockExternalApis` 3.0 support.

### Reviewer notes
- The one pre-existing `persist` test failure (stale scalar assertions on `ensureArray()`-normalised, array-cast fields — `accessRights`, `jurisdiction`, `vocabularyEncodingSchemes`, `conformsTo`, `languages`, `keywords`, `datasetType`, origin `purpose`/`source`) is **fixed**: those scalar source values correctly round-trip as single-element arrays.
- **M1 (fixed)**: `persistMetadataVersion()` now forces a full snapshot for GWDM 3.0 (`patch = null`) — 3.0 content lives in SQL, so a delta patch would only duplicate section values (incl. PII) into the immutable patch column where they'd survive SQL-row erasure.
- **M2 (fixed)**: `Gwdm30Handler::preloadSectionsForVersions()` loads each SQL section once across all version ids; `validateAllVersions()` calls it up front so the per-row `afterRead()` no longer issues ~16 queries per 3.0 row. New test asserts the batched query count.
- **phpstan (fixed)**: `@property`/`@property-read` docblocks on the Gwdm30 models + `DatasetVersion` (the dynamically-set `gwdm30*` relations) clear the level-3 dynamic-property findings. The full stack is phpstan-clean.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9216

## Environment / Configuration changes (if applicable)

`x-gwdm-version: 3.0` becomes an accepted request header once this PR is deployed. GWDM 3.0 must not be enabled before PR3's tables exist (why this PR is stacked on PR3).

## Requires migrations being run?

No new migrations here (the `gwdm30_*` tables land in PR3), but this PR is inoperable without them.

## If not using the pre-push hook. Confirm tests pass:

- `pest tests/Feature/DatasetVersionGwdm30Test.php` — 23 passed (handler persist/read for every section).
- `GwdmHandlerFactoryTest` updated to assert `'3.0'` resolves to `Gwdm30Handler` and is in `SUPPORTED_VERSIONS`.
- Full stack suite green: **80 passed** across the GWDM/dataset feature tests.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable) — N/A
- [ ] I have added Swagger annotations for new endpoints (if applicable) — V3 version endpoints; annotate if the team requires
- [ ] I have added audit logs for new operation logic (if applicable) — N/A
- [ ] I have added new environment variables to the .env.example file (if applicable) — N/A
- [ ] I have added new environment variables to terraform repository (if applicable) — N/A
