### PR TITLE
feat(GAT-9217):  [POC] add app:backfill-gwdm30 command to migrate 2.x datasets to 3.0

### DIFF
--- a/app/Console/Commands/BackfillGwdm30.php
+++ b/app/Console/Commands/BackfillGwdm30.php
@@ -16,6 +16,7 @@ class BackfillGwdm30 extends Command
         {--dry-run : Preview without writing}
         {--dataset-id= : Limit migration to a single dataset ID}
         {--force : Re-persist rows already at GWDM 3.0 (re-runs prepareMetadata + afterStore, skips TRASER)}
+        {--rebuild-json : Only (re)populate the denormalised metadata section cache for existing GWDM 3.0 rows from their SQL tables — no TRASER, no re-persist, no SQL/linkage writes}
         {--min-dataset-id= : Resume from this datasets.id (inclusive)}
         {--max-dataset-id= : Stop after this datasets.id (inclusive)}';
 
@@ -33,6 +34,7 @@ class BackfillGwdm30 extends Command
         $dryRun      = $this->option('dry-run');
         $datasetId   = $this->option('dataset-id');
         $force       = $this->option('force');
+        $rebuildJson = $this->option('rebuild-json');
         $minDatasetId = $this->option('min-dataset-id');
         $maxDatasetId = $this->option('max-dataset-id');
 
@@ -45,6 +47,7 @@ class BackfillGwdm30 extends Command
         $flags = implode(' ', array_filter([
             $dryRun       ? '--dry-run'                        : null,
             $force        ? '--force'                          : null,
+            $rebuildJson  ? '--rebuild-json'                   : null,
             $datasetId    ? "--dataset-id={$datasetId}"        : null,
             $minDatasetId ? "--min-dataset-id={$minDatasetId}" : null,
             $maxDatasetId ? "--max-dataset-id={$maxDatasetId}" : null,
@@ -61,8 +64,13 @@ class BackfillGwdm30 extends Command
         $query = Dataset::query()
             ->where('status', 'ACTIVE')
             ->whereNull('deleted_at')
-            ->unless($force, fn ($q) =>
-                $q->whereDoesntHave('versions', fn ($q) => $q->where('gwdm_version', '3.0'))
+            ->when(
+                $rebuildJson,
+                // rebuild-json only touches datasets that already have a 3.0 row.
+                fn ($q) => $q->whereHas('versions', fn ($q) => $q->where('gwdm_version', '3.0')),
+                fn ($q) => $q->unless($force, fn ($q) =>
+                    $q->whereDoesntHave('versions', fn ($q) => $q->where('gwdm_version', '3.0'))
+                )
             )
             ->when($datasetId, fn ($q) => $q->where('id', $datasetId))
             ->when($minDatasetId, fn ($q) => $q->where('id', '>=', $minDatasetId))
@@ -74,7 +82,7 @@ class BackfillGwdm30 extends Command
         if ($total === 0) {
             $this->info('No ACTIVE datasets require migration. Nothing to do.');
 
-            if (!$force) {
+            if (!$force && !$rebuildJson) {
                 $already30 = Dataset::query()
                     ->where('status', 'ACTIVE')
                     ->whereNull('deleted_at')
@@ -90,9 +98,11 @@ class BackfillGwdm30 extends Command
             return self::SUCCESS;
         }
 
-        $label = $force
-            ? "Found {$total} ACTIVE dataset(s) to process (including those already at GWDM 3.0)."
-            : "Found {$total} ACTIVE dataset(s) without a GWDM 3.0 version to migrate.";
+        $label = match (true) {
+            $rebuildJson => "Found {$total} ACTIVE dataset(s) with a GWDM 3.0 version to rebuild the section cache for.",
+            $force       => "Found {$total} ACTIVE dataset(s) to process (including those already at GWDM 3.0).",
+            default      => "Found {$total} ACTIVE dataset(s) without a GWDM 3.0 version to migrate.",
+        };
         $this->info($label);
 
         $bar = $this->output->createProgressBar($total);
@@ -123,11 +133,15 @@ class BackfillGwdm30 extends Command
         });
 
         $query->with('team')
-            ->chunkById(50, function ($datasets) use ($dryRun, $force, $handler, $bar, $write, &$migrated, &$failed, &$currentDataset, &$lastDataset) {
+            ->chunkById(50, function ($datasets) use ($dryRun, $force, $rebuildJson, $handler, $bar, $write, &$migrated, &$failed, &$currentDataset, &$lastDataset) {
                 foreach ($datasets as $dataset) {
                     $currentDataset = $dataset;
                     try {
-                        $this->migrateDataset($dataset, $handler, $dryRun, $force);
+                        if ($rebuildJson) {
+                            $this->rebuildJsonForDataset($dataset, $handler, $dryRun);
+                        } else {
+                            $this->migrateDataset($dataset, $handler, $dryRun, $force);
+                        }
                         $migrated++;
                     } catch (\Throwable $e) {
                         $failed++;
@@ -156,6 +170,32 @@ class BackfillGwdm30 extends Command
         $write($summary . '  finished ' . date('Y-m-d H:i:s'));
 
         return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * --rebuild-json path: (re)populate the denormalised section cache in the
+     * metadata column for every existing GWDM 3.0 version of a dataset, straight
+     * from the SQL section tables. No TRASER, no prepareMetadata, no SQL/linkage
+     * writes — just the derived read cache. Idempotent.
+     */
+    private function rebuildJsonForDataset(Dataset $dataset, $handler, bool $dryRun): void
+    {
+        $rows = DatasetVersion::where('dataset_id', $dataset->id)
+            ->where('gwdm_version', '3.0')
+            ->orderBy('version')
+            ->get();
+
+        if ($rows->isEmpty()) {
+            throw new \RuntimeException('No GWDM 3.0 version rows found to rebuild.');
+        }
+
+        if ($dryRun) {
+            return;
+        }
+
+        foreach ($rows as $row) {
+            $handler->refreshSectionCache($row);
+        }
     }
 
     private function migrateDataset(Dataset $dataset, $handler, bool $dryRun, bool $force = false): void

--- a/app/Console/Commands/BackfillGwdm30.php
+++ b/app/Console/Commands/BackfillGwdm30.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use MetadataManagementController as MMC;
+
+class BackfillGwdm30 extends Command
+{
+    protected $signature = 'app:backfill-gwdm30
+        {--dry-run : Preview without writing}
+        {--dataset-id= : Limit migration to a single dataset ID}
+        {--force : Re-persist rows already at GWDM 3.0 (re-runs prepareMetadata + afterStore, skips TRASER)}
+        {--min-dataset-id= : Resume from this datasets.id (inclusive)}
+        {--max-dataset-id= : Stop after this datasets.id (inclusive)}';
+
+    protected $description = 'Translate GWDM 2.x dataset versions to 3.0 and persist as new dataset_version rows';
+
+    public function __construct(
+        private readonly DatasetService $datasetService,
+        private readonly GwdmHandlerFactory $handlerFactory,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun      = $this->option('dry-run');
+        $datasetId   = $this->option('dataset-id');
+        $force       = $this->option('force');
+        $minDatasetId = $this->option('min-dataset-id');
+        $maxDatasetId = $this->option('max-dataset-id');
+
+        $logPath = storage_path('logs/backfill-gwdm30-' . date('Y-m-d_H-i-s') . '.log');
+        $log     = fopen($logPath, 'w');
+        $write   = function (string $line) use ($log): void {
+            fwrite($log, $line . PHP_EOL);
+        };
+
+        $flags = implode(' ', array_filter([
+            $dryRun       ? '--dry-run'                        : null,
+            $force        ? '--force'                          : null,
+            $datasetId    ? "--dataset-id={$datasetId}"        : null,
+            $minDatasetId ? "--min-dataset-id={$minDatasetId}" : null,
+            $maxDatasetId ? "--max-dataset-id={$maxDatasetId}" : null,
+        ]));
+        $write("backfill-gwdm30 {$flags}  started " . date('Y-m-d H:i:s'));
+        $write(str_repeat('-', 80));
+
+        $this->info("Log: {$logPath}");
+
+        if ($dryRun) {
+            $this->info('[dry-run] No changes will be written.');
+        }
+
+        $query = Dataset::query()
+            ->where('status', 'ACTIVE')
+            ->whereNull('deleted_at')
+            ->unless($force, fn ($q) =>
+                $q->whereDoesntHave('versions', fn ($q) => $q->where('gwdm_version', '3.0'))
+            )
+            ->when($datasetId, fn ($q) => $q->where('id', $datasetId))
+            ->when($minDatasetId, fn ($q) => $q->where('id', '>=', $minDatasetId))
+            ->when($maxDatasetId, fn ($q) => $q->where('id', '<=', $maxDatasetId))
+            ->orderBy('id');
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No ACTIVE datasets require migration. Nothing to do.');
+
+            if (!$force) {
+                $already30 = Dataset::query()
+                    ->where('status', 'ACTIVE')
+                    ->whereNull('deleted_at')
+                    ->when($datasetId, fn ($q) => $q->where('id', $datasetId))
+                    ->whereHas('versions', fn ($q) => $q->where('gwdm_version', '3.0'))
+                    ->count();
+
+                if ($already30 > 0) {
+                    $this->info("{$already30} dataset(s) already have a GWDM 3.0 version and were skipped. Use --force to re-persist them.");
+                }
+            }
+
+            return self::SUCCESS;
+        }
+
+        $label = $force
+            ? "Found {$total} ACTIVE dataset(s) to process (including those already at GWDM 3.0)."
+            : "Found {$total} ACTIVE dataset(s) without a GWDM 3.0 version to migrate.";
+        $this->info($label);
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $migrated       = 0;
+        $failed         = 0;
+        $handler        = $this->handlerFactory->resolve('3.0');
+        $currentDataset = null;
+        $lastDataset    = null;
+
+        register_shutdown_function(function () use (&$currentDataset, &$lastDataset, $write, $log) {
+            $error = error_get_last();
+            if ($error !== null && ($error['type'] & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR)) !== 0) {
+                $context = $currentDataset
+                    ? "during dataset_id={$currentDataset->id}"
+                    : ($lastDataset
+                        ? "between datasets — last completed: dataset_id={$lastDataset->id}; resume with --min-dataset-id=" . ($lastDataset->id + 1)
+                        : 'before any dataset was processed');
+                $msg = "FATAL {$context}";
+                fwrite(STDERR, PHP_EOL . "  {$msg}" . PHP_EOL);
+                $write("[FATAL] {$msg}");
+                $write("  {$error['message']} in {$error['file']}:{$error['line']}");
+            }
+            if (is_resource($log)) {
+                fclose($log);
+            }
+        });
+
+        $query->with('team')
+            ->chunkById(50, function ($datasets) use ($dryRun, $force, $handler, $bar, $write, &$migrated, &$failed, &$currentDataset, &$lastDataset) {
+                foreach ($datasets as $dataset) {
+                    $currentDataset = $dataset;
+                    try {
+                        $this->migrateDataset($dataset, $handler, $dryRun, $force);
+                        $migrated++;
+                    } catch (\Throwable $e) {
+                        $failed++;
+                        $msg = "FAILED dataset_id={$dataset->id}: {$e->getMessage()}";
+                        $this->newLine();
+                        $this->warn("  {$msg}");
+                        $write("[FAIL]  {$msg}");
+                        $write($e->getTraceAsString());
+                        $write('');
+                    }
+                    $lastDataset    = $dataset;
+                    $currentDataset = null;
+                    $bar->advance();
+                }
+
+                gc_collect_cycles();
+            }, 'datasets.id', 'id');
+
+        $bar->finish();
+        $this->newLine();
+
+        $action  = $dryRun ? 'would be migrated' : 'migrated';
+        $summary = "Done. {$migrated} {$action}, {$failed} failed.";
+        $this->info($summary);
+        $write(str_repeat('-', 80));
+        $write($summary . '  finished ' . date('Y-m-d H:i:s'));
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function migrateDataset(Dataset $dataset, $handler, bool $dryRun, bool $force = false): void
+    {
+        $team = $dataset->team;
+
+        if ($team === null) {
+            throw new \RuntimeException('Dataset has no team — ACTIVE dataset should always have a team.');
+        }
+
+        // --force path: re-populate SQL tables for an existing 3.0 row (no TRASER, no new row).
+        if ($force) {
+            $existing30 = DatasetVersion::where('dataset_id', $dataset->id)
+                ->where('gwdm_version', '3.0')
+                ->orderBy('version', 'desc')
+                ->first();
+
+            if ($existing30) {
+                $envelope = $this->datasetService->getReconstructedMetadataEnvelope(
+                    $dataset->id,
+                    $existing30->version,
+                );
+
+                $gwdm30 = $handler->prepareMetadata(
+                    $envelope['metadata'],
+                    $dataset,
+                    $team,
+                    $existing30->version,
+                );
+
+                // TRASER can lose summary.title; fall back to the best 2.x source version.
+                if (empty($gwdm30['summary']['title'])) {
+                    $source2x = DatasetVersion::where('dataset_id', $dataset->id)
+                        ->where('gwdm_version', '2.1')
+                        ->orderBy('version', 'desc')
+                        ->first()
+                        ?? DatasetVersion::where('dataset_id', $dataset->id)
+                            ->where('gwdm_version', '2.0')
+                            ->orderBy('version', 'desc')
+                            ->first();
+
+                    if ($source2x) {
+                        $env2x = $this->datasetService->getReconstructedMetadataEnvelope($dataset->id, $source2x->version);
+                        $gwdm30['summary']['title']     = $env2x['metadata']['summary']['title'] ?? null;
+                        $gwdm30['summary']['shortTitle'] = $env2x['metadata']['summary']['shortTitle'] ?? null;
+                    }
+                }
+
+                if ($dryRun) {
+                    return;
+                }
+
+                DB::transaction(function () use ($existing30, $handler, $gwdm30, $dataset, $envelope) {
+                    [$title, $shortTitle] = $handler->extractTitleFields($gwdm30);
+                    $envelope30 = $handler->buildEnvelope($gwdm30, $envelope['original_metadata'] ?? []);
+                    $existing30->title       = $title;
+                    $existing30->short_title = $shortTitle;
+                    $existing30->metadata    = json_encode($envelope30);
+                    $existing30->save();
+                    $handler->afterStore($dataset, $existing30, $gwdm30);
+                });
+
+                return;
+            }
+            // No 3.0 row yet — fall through to the standard insert path below.
+        }
+
+        // Standard path: find the best 2.x source, translate, create a new 3.0 row.
+
+        // Step A — source version selection: prefer 2.1, fall back to 2.0.
+        $sourceRow = DatasetVersion::where('dataset_id', $dataset->id)
+            ->where('gwdm_version', '2.1')
+            ->orderBy('version', 'desc')
+            ->first()
+            ?? DatasetVersion::where('dataset_id', $dataset->id)
+                ->where('gwdm_version', '2.0')
+                ->orderBy('version', 'desc')
+                ->first();
+
+        if ($sourceRow === null) {
+            throw new \RuntimeException('No GWDM 2.x source version found for this dataset.');
+        }
+
+        // Step B — reconstruct full envelope and translate to GWDM 3.0 via TRASER.
+        $envelope2x = $this->datasetService->getReconstructedMetadataEnvelope(
+            $dataset->id,
+            $sourceRow->version,
+        );
+
+        $translated = MMC::translateDataModelType(
+            json_encode($envelope2x),
+            'GWDM',
+            '3.0',
+            'GWDM',
+            $sourceRow->gwdm_version,
+            true,   // validateInput
+            false,  // validateOutput — allow minor schema drift carried through by TRASER
+        );
+
+        if (!$translated['wasTranslated']) {
+            throw new \RuntimeException(
+                'TRASER translation failed (HTTP ' . $translated['statusCode'] . '): '
+                . json_encode($translated['traser_message'])
+            );
+        }
+
+        // Step C — apply version-specific mutations.
+        $newVersionNumber = DatasetVersion::where('dataset_id', $dataset->id)->max('version') + 1;
+
+        $gwdm30 = $handler->prepareMetadata(
+            $translated['metadata'],
+            $dataset,
+            $team,
+            $newVersionNumber,
+        );
+
+        // TRASER can lose summary.title during 2.x→3.0 translation; fall back to the 2.x source.
+        if (empty($gwdm30['summary']['title'])) {
+            $gwdm30['summary']['title'] = $envelope2x['metadata']['summary']['title'] ?? null;
+        }
+        if (empty($gwdm30['summary']['shortTitle'])) {
+            $gwdm30['summary']['shortTitle'] = $envelope2x['metadata']['summary']['shortTitle'] ?? null;
+        }
+
+        // Step D — dry-run early exit.
+        if ($dryRun) {
+            return;
+        }
+
+        // Step E — insert the new 3.0 row and populate structured SQL tables.
+        DB::transaction(function () use ($dataset, $handler, $gwdm30, $envelope2x, $newVersionNumber) {
+            [$title, $shortTitle] = $handler->extractTitleFields($gwdm30);
+            $envelope30 = $handler->buildEnvelope($gwdm30, $envelope2x['original_metadata']);
+
+            $newDv = DatasetVersion::create([
+                'dataset_id'   => $dataset->id,
+                'metadata'     => json_encode($envelope30),
+                'patch'        => null,   // always a full snapshot — schema-lineage break
+                'version'      => $newVersionNumber,
+                'title'        => $title,
+                'short_title'  => $shortTitle,
+                'gwdm_version' => '3.0',
+            ]);
+
+            $handler->afterStore($dataset, $newDv, $gwdm30);
+        });
+    }
+}

--- a/app/Console/Commands/BackfillGwdm30.php
+++ b/app/Console/Commands/BackfillGwdm30.php
@@ -213,7 +213,9 @@ class BackfillGwdm30 extends Command
                     $envelope30 = $handler->buildEnvelope($gwdm30, $envelope['original_metadata'] ?? []);
                     $existing30->title       = $title;
                     $existing30->short_title = $shortTitle;
-                    $existing30->metadata    = json_encode($envelope30);
+                    // Assign the array (the metadata Attribute json-encodes it). Passing
+                    // a pre-encoded string trips phpstan on the array-cast column.
+                    $existing30->metadata    = $envelope30;
                     $existing30->save();
                     $handler->afterStore($dataset, $existing30, $gwdm30);
                 });

--- a/tests/Feature/BackfillGwdm30CommandTest.php
+++ b/tests/Feature/BackfillGwdm30CommandTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * PR5 coverage — the app:backfill-gwdm30 command's selection + guard behaviour.
+ *
+ * Scoped to a single dataset via --dataset-id so seeded fixtures don't skew the
+ * assertions. Observers disabled (the command's writes would otherwise dispatch
+ * Elasticsearch jobs unrelated to the backfill).
+ *
+ * The translate -> prepareMetadata -> afterStore persist path itself is covered by
+ * DatasetVersionGwdm30Test (PR4); a live 2.x->3.0 TRASER translation is not
+ * reproducible through the shared test mock, so this suite exercises the parts
+ * that do not depend on it: the dry-run guard and the "already at 3.0" skip
+ * (idempotency) selection.
+ */
+class BackfillGwdm30CommandTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+        $this->disableObservers();
+    }
+
+    private function gwdm30Metadata(): array
+    {
+        return json_decode(
+            file_get_contents(getcwd().'/tests/Unit/test_files/gwdm_v3p0_dataset_min.json'),
+            true,
+        )['metadata'];
+    }
+
+    /** Create an ACTIVE 2.0 dataset (single v1 snapshot) via the service. */
+    private function createActive2xDataset(): int
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        request()->headers->set('x-gwdm-version', '2.0');
+
+        $created = app(DatasetService::class)->create(
+            [
+                'metadata' => $this->getMetadataV2p0(),
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+
+        return $created['dataset_id'];
+    }
+
+    /** Create an ACTIVE dataset that already has a GWDM 3.0 version row. */
+    private function createDatasetWith30Version(): int
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $dataset = Dataset::create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'pid' => 'bf-'.fake()->uuid(),
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+
+        DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'gwdm_version' => '3.0',
+            'short_title' => 'Already 3.0',
+            'metadata' => [
+                'gwdmVersion' => '3.0',
+                'metadata' => $this->gwdm30Metadata(),
+                'original_metadata' => [],
+            ],
+        ]);
+
+        return $dataset->id;
+    }
+
+    private function count30(int $datasetId): int
+    {
+        return DatasetVersion::where('dataset_id', $datasetId)
+            ->where('gwdm_version', '3.0')
+            ->count();
+    }
+
+    public function test_dry_run_creates_no_gwdm30_version(): void
+    {
+        $datasetId = $this->createActive2xDataset();
+        $this->assertSame(0, $this->count30($datasetId));
+
+        Artisan::call('app:backfill-gwdm30', ['--dataset-id' => $datasetId, '--dry-run' => true]);
+
+        $this->assertSame(0, $this->count30($datasetId), 'dry-run must not create a 3.0 version');
+    }
+
+    public function test_dataset_already_at_gwdm30_is_skipped_without_force(): void
+    {
+        $datasetId = $this->createDatasetWith30Version();
+        $this->assertSame(1, $this->count30($datasetId));
+
+        Artisan::call('app:backfill-gwdm30', ['--dataset-id' => $datasetId]);
+        $output = Artisan::output();
+
+        // Idempotency: a dataset that already has a 3.0 version is not re-migrated.
+        $this->assertSame(1, $this->count30($datasetId), 'must not add a second 3.0 version');
+        $this->assertStringContainsString('already', strtolower($output));
+    }
+
+    public function test_no_active_datasets_in_range_is_a_noop(): void
+    {
+        // An id-range that matches nothing exits cleanly without writing.
+        Artisan::call('app:backfill-gwdm30', [
+            '--min-dataset-id' => 999999,
+            '--max-dataset-id' => 999999,
+        ]);
+
+        $this->assertStringContainsString(
+            'Nothing to do',
+            Artisan::output(),
+        );
+    }
+}

--- a/tests/Feature/BackfillGwdm30CommandTest.php
+++ b/tests/Feature/BackfillGwdm30CommandTest.php
@@ -7,6 +7,7 @@ use App\Models\DatasetVersion;
 use App\Models\Team;
 use App\Models\User;
 use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 use Tests\Traits\Authorization;
@@ -105,6 +106,93 @@ class BackfillGwdm30CommandTest extends TestCase
         return DatasetVersion::where('dataset_id', $datasetId)
             ->where('gwdm_version', '3.0')
             ->count();
+    }
+
+    /**
+     * An ACTIVE 3.0 dataset with SQL section rows populated but NO denormalised
+     * section cache in the metadata column — i.e. a row written before the cache
+     * existed. This is what --rebuild-json targets.
+     */
+    private function createUnbackfilled30Dataset(): int
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $dataset = Dataset::create([
+            'user_id' => $user->id,
+            'team_id' => $team->id,
+            'pid' => 'bf-'.fake()->uuid(),
+            'create_origin' => Dataset::ORIGIN_MANUAL,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+
+        $dv = DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'gwdm_version' => '3.0',
+            'short_title' => 'Unbackfilled 3.0',
+            'metadata' => ['gwdmVersion' => '3.0', 'original_metadata' => []],
+        ]);
+
+        // Write the SQL section tables (afterStore also refreshes the cache), then
+        // strip the cache back out to simulate a pre-cache row.
+        app(GwdmHandlerFactory::class)->resolve('3.0')->afterStore($dataset, $dv, $this->gwdm30Metadata());
+        $dv->metadata = ['gwdmVersion' => '3.0', 'original_metadata' => []];
+        $dv->saveQuietly();
+
+        return $dataset->id;
+    }
+
+    public function test_rebuild_json_populates_section_cache_from_sql(): void
+    {
+        $datasetId = $this->createUnbackfilled30Dataset();
+
+        $dv = DatasetVersion::where('dataset_id', $datasetId)->where('gwdm_version', '3.0')->first();
+        $this->assertArrayNotHasKey('metadata', $dv->metadata, 'precondition: no section cache present');
+
+        Artisan::call('app:backfill-gwdm30', ['--dataset-id' => $datasetId, '--rebuild-json' => true]);
+
+        $dv->refresh();
+        $this->assertArrayHasKey('metadata', $dv->metadata, 'rebuild-json should populate the section cache');
+        $this->assertArrayHasKey('summary', $dv->metadata['metadata']);
+        $this->assertArrayNotHasKey('linkage', $dv->metadata['metadata'], 'linkage stays out of the cache');
+
+        // The cache equals the SQL reconstruction of the sections (no X-Gwdm-Cache
+        // header, so the reconstruction reads from SQL — the default).
+        $sql = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $datasetId,
+            $dv->version,
+            validate: false,
+            prefetched: DatasetVersion::find($dv->id),
+        );
+        $this->assertEquals($sql['metadata']['summary'], $dv->metadata['metadata']['summary']);
+    }
+
+    public function test_rebuild_json_dry_run_writes_nothing(): void
+    {
+        $datasetId = $this->createUnbackfilled30Dataset();
+
+        Artisan::call('app:backfill-gwdm30', [
+            '--dataset-id' => $datasetId,
+            '--rebuild-json' => true,
+            '--dry-run' => true,
+        ]);
+
+        $dv = DatasetVersion::where('dataset_id', $datasetId)->where('gwdm_version', '3.0')->first();
+        $this->assertArrayNotHasKey('metadata', $dv->metadata, 'dry-run must not write the cache');
+    }
+
+    public function test_rebuild_json_is_idempotent(): void
+    {
+        $datasetId = $this->createUnbackfilled30Dataset();
+
+        Artisan::call('app:backfill-gwdm30', ['--dataset-id' => $datasetId, '--rebuild-json' => true]);
+        $first = DatasetVersion::where('dataset_id', $datasetId)->where('gwdm_version', '3.0')->first()->metadata;
+
+        Artisan::call('app:backfill-gwdm30', ['--dataset-id' => $datasetId, '--rebuild-json' => true]);
+        $second = DatasetVersion::where('dataset_id', $datasetId)->where('gwdm_version', '3.0')->first()->metadata;
+
+        $this->assertEquals($first, $second, 'a second rebuild-json must produce identical output');
     }
 
     public function test_dry_run_creates_no_gwdm30_version(): void


### PR DESCRIPTION
## Screenshots (if relevant)

N/A.

## Describe your changes

**PR 5 of 5** — stacked on PR4. Final PR.

Adds `app:backfill-gwdm30` — migrates ACTIVE GWDM 2.x datasets to 3.0 (reconstruct latest 2.x → translate via TRASER → persist a new 3.0 `dataset_version` row). Flags: `--dry-run`, `--force` (re-persist existing 3.0 rows in place), `--dataset-id`, `--min/--max-dataset-id`, with resumable logging.

**Run manually** — heavy, platform-wide, hard to reverse. Dry-run first, inspect, then run for real.

### Reviewer notes
- This is a **manual** command by design — no deployment step auto-runs it. The gwdm30 distributions back-fill migration was **removed in PR3** as unneeded (`persist()` writes distributions from metadata); this command does not re-introduce it.
- **Safe ordering:** the C1 reconstruction fix lands in PR2, so running this backfill cannot make a 3.0 row the latest version and strip search titles/abstracts.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9217

## Environment / Configuration changes (if applicable)

None (new artisan command only).

## Requires migrations being run?

No (relies on the tables from PR3 already being present).

## If not using the pre-push hook. Confirm tests pass:

- `pest tests/Feature/BackfillGwdm30CommandTest.php` — 3 passed: `--dry-run` creates no 3.0 version; a dataset already at 3.0 is skipped (idempotency); an empty id-range is a clean no-op. (The translate→persist path itself is covered by `DatasetVersionGwdm30Test` in PR4; a live 2.x→3.0 TRASER translation is not reproducible through the shared test mock.)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable) — N/A
- [ ] I have added Swagger annotations for new endpoints (if applicable) — no endpoints (CLI command)
- [ ] I have added audit logs for new operation logic (if applicable) — command writes a per-run log file
- [ ] I have added new environment variables to the .env.example file (if applicable) — N/A
- [ ] I have added new environment variables to terraform repository (if applicable) — N/A
