### PR TITLE
fix(GAT-9219): publisher raw-data + pid normalisation on write

### DIFF
--- a/app/Console/Commands/NormalisePublisherGatewayId.php
+++ b/app/Console/Commands/NormalisePublisherGatewayId.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use Illuminate\Console\Command;
+
+/**
+ * One-off data fix: normalise summary.publisher gateway identifiers stored in
+ * dataset_versions so that gatewayId (GWDM 2.x) / publisherId (legacy < 1.1)
+ * hold a team PID rather than an internal primary key.
+ *
+ * Historically these were sometimes populated with a raw team id (chiefly via
+ * the V1 onboarding path, whose value traced back to the frontend
+ * dataCustodian.identifier = team.id bug). Consumers cope by guessing
+ * (is_numeric -> id, else pid); this command makes the stored data canonical.
+ *
+ * Covers both storage forms:
+ *   - Snapshot rows (patch IS NULL): the full GWDM envelope in `metadata`.
+ *   - Delta rows (patch present): RFC-6902 patch ops that write the publisher
+ *     id path (paths are relative to the GWDM object, e.g.
+ *     /summary/publisher/gatewayId — see DatasetService::computePatch/
+ *     reconstructGwdmMetadata).
+ *
+ * `original_metadata` is deliberately left untouched (audit trail). Intended to
+ * run as a post-migration deployment step (registered in RunPostMigrations
+ * before the datasets reindex, so Elasticsearch picks up corrected values).
+ */
+class NormalisePublisherGatewayId extends Command
+{
+    protected $signature = 'app:normalise-publisher-gateway-id
+                            {--dry-run : Report what would change without writing}
+                            {--chunk=200 : Number of dataset_versions per chunk}';
+
+    protected $description = 'Normalise summary.publisher gatewayId/publisherId in dataset_versions to team PIDs (snapshots + delta patch ops).';
+
+    /** Publisher id keys across GWDM shapes (2.x gatewayId, legacy publisherId). */
+    private const ID_KEYS = ['gatewayId', 'publisherId'];
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+
+        // Preload teams once for in-memory id-or-pid resolution (mirrors the
+        // approach in DatasetHydrator). Include soft-deleted teams so metadata
+        // referencing a since-archived team can still be normalised.
+        $teams = Team::withTrashed()->get(['id', 'pid', 'name']);
+        $byId = $teams->keyBy('id');
+        $byPid = $teams->keyBy('pid');
+
+        $resolvePid = function ($gatewayId) use ($byId, $byPid): ?string {
+            if ($gatewayId === null || $gatewayId === '') {
+                return null;
+            }
+            $team = is_numeric($gatewayId)
+                ? $byId->get((int) $gatewayId)
+                : $byPid->get((string) $gatewayId);
+
+            return $team?->pid;
+        };
+
+        $stats = ['scanned' => 0, 'snapshots' => 0, 'deltaOps' => 0, 'unresolved' => 0];
+
+        DatasetVersion::withTrashed()->chunkById($chunk, function ($versions) use ($resolvePid, $dryRun, &$stats) {
+            foreach ($versions as $dv) {
+                $stats['scanned']++;
+
+                if ($dv->patch === null) {
+                    $this->fixSnapshot($dv, $resolvePid, $dryRun, $stats);
+                } else {
+                    $this->fixDelta($dv, $resolvePid, $dryRun, $stats);
+                }
+            }
+        });
+
+        $mode = $dryRun ? 'DRY-RUN (no writes)' : 'APPLIED';
+        $this->info(sprintf(
+            '[%s] scanned=%d snapshotsFixed=%d deltaOpsFixed=%d unresolved=%d',
+            $mode,
+            $stats['scanned'],
+            $stats['snapshots'],
+            $stats['deltaOps'],
+            $stats['unresolved'],
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Snapshot row: the publisher lives in metadata.metadata.summary.publisher.
+     */
+    private function fixSnapshot(DatasetVersion $dv, callable $resolvePid, bool $dryRun, array &$stats): void
+    {
+        $envelope = $dv->metadata;
+        if (! is_array($envelope) || ! isset($envelope['metadata']['summary']['publisher'])) {
+            return;
+        }
+
+        $publisher = $envelope['metadata']['summary']['publisher'];
+        if (! is_array($publisher)) {
+            return;
+        }
+
+        $result = $this->normalisePublisherArray($publisher, $resolvePid, $dv, $stats);
+        if (! $result['changed']) {
+            return;
+        }
+
+        $stats['snapshots']++;
+        if (! $dryRun) {
+            $envelope['metadata']['summary']['publisher'] = $result['publisher'];
+            $dv->metadata = $envelope;
+            $dv->saveQuietly();
+        }
+    }
+
+    /**
+     * Delta row: publisher only appears in RFC-6902 patch ops (metadata is []).
+     */
+    private function fixDelta(DatasetVersion $dv, callable $resolvePid, bool $dryRun, array &$stats): void
+    {
+        $patch = $dv->patch;
+        if (! is_array($patch)) {
+            return;
+        }
+
+        $changed = false;
+        foreach ($patch as $i => $op) {
+            if (! is_array($op) || ! isset($op['op'], $op['path']) || ! array_key_exists('value', $op)) {
+                continue;
+            }
+            if (! in_array($op['op'], ['add', 'replace'], true)) {
+                continue;
+            }
+
+            // Case 1: op targets the id leaf directly (value is a scalar id/pid).
+            if ($this->isPublisherIdLeafPath($op['path'])) {
+                $pid = $resolvePid($op['value']);
+                if ($pid === null) {
+                    $this->noteUnresolved($op['value'], $dv, $stats, $op['path']);
+
+                    continue;
+                }
+                if ((string) $op['value'] !== $pid) {
+                    $patch[$i]['value'] = $pid;
+                    $changed = true;
+                    $stats['deltaOps']++;
+                }
+
+                continue;
+            }
+
+            // Case 2: op replaces the whole publisher object (value is an array).
+            if ($op['path'] === '/summary/publisher' && is_array($op['value'])) {
+                $result = $this->normalisePublisherArray($op['value'], $resolvePid, $dv, $stats);
+                if ($result['changed']) {
+                    $patch[$i]['value'] = $result['publisher'];
+                    $changed = true;
+                    $stats['deltaOps']++;
+                }
+            }
+        }
+
+        if ($changed && ! $dryRun) {
+            $dv->patch = $patch;
+            $dv->saveQuietly();
+        }
+    }
+
+    /**
+     * Normalise each id key present on a publisher array to the resolved team
+     * pid. Returns ['changed' => bool, 'publisher' => array].
+     */
+    private function normalisePublisherArray(array $publisher, callable $resolvePid, DatasetVersion $dv, array &$stats): array
+    {
+        $changed = false;
+        foreach (self::ID_KEYS as $idKey) {
+            if (! array_key_exists($idKey, $publisher)) {
+                continue;
+            }
+            $current = $publisher[$idKey];
+            $pid = $resolvePid($current);
+            if ($pid === null) {
+                $this->noteUnresolved($current, $dv, $stats, "summary.publisher.$idKey");
+
+                continue;
+            }
+            if ((string) $current !== $pid) {
+                $publisher[$idKey] = $pid;
+                $changed = true;
+            }
+        }
+
+        return ['changed' => $changed, 'publisher' => $publisher];
+    }
+
+    private function isPublisherIdLeafPath(string $path): bool
+    {
+        return in_array($path, [
+            '/summary/publisher/gatewayId',
+            '/summary/publisher/publisherId',
+        ], true);
+    }
+
+    private function noteUnresolved(mixed $value, DatasetVersion $dv, array &$stats, string $where): void
+    {
+        if ($value === null || $value === '') {
+            return;
+        }
+        $stats['unresolved']++;
+        $this->warn("Unresolved publisher id '{$value}' ({$where}) on dataset_version id={$dv->id} — left unchanged");
+    }
+}

--- a/app/Console/Commands/RunPostMigrations.php
+++ b/app/Console/Commands/RunPostMigrations.php
@@ -81,6 +81,10 @@ class RunPostMigrations extends Command
                 'arguments' => [],
             ], // add team dar modal content
             [
+                'command' => 'app:normalise-publisher-gateway-id',
+                'arguments' => [],
+            ], // normalise summary.publisher gatewayId/publisherId to team pids (before reindex)
+            [
                 'command' => 'app:reindex-entities',
                 'arguments' => [
                     'entity' => 'datasets',

--- a/app/Context/GwdmVersionContext.php
+++ b/app/Context/GwdmVersionContext.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Context;
+
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Config;
+
+/**
+ * Resolves the GWDM schema version for write and read operations.
+ *
+ * targetVersion()   — write path: x-gwdm-version header with config fallback
+ * requestedVersion() — read path: x-gwdm-version header only; null if not set
+ *
+ * To add a new supported GWDM version, update GwdmHandlerFactory — the valid
+ * version list (SUPPORTED_VERSIONS) lives there as the single source of truth.
+ *
+ * Used by DatasetService. GMI / MetadataOnboard / MetadataVersioning traits
+ * continue using Config::get directly — they always ingest to the system-wide
+ * GWDM version regardless of request context.
+ */
+class GwdmVersionContext
+{
+    public function targetVersion(): string
+    {
+        $header = request()->header('x-gwdm-version');
+
+        if ($header && in_array($header, GwdmHandlerFactory::supportedVersions(), true)) {
+            return $header;
+        }
+
+        return Config::get('metadata.GWDM.version', '2.0');
+    }
+
+    /**
+     * Returns the explicitly requested GWDM version from the request header,
+     * or null if the header was not sent. Throws if the header is present but
+     * not a recognised version — callers should treat this as a 400.
+     *
+     * @throws \InvalidArgumentException when an unrecognised version is requested
+     */
+    public function requestedVersion(): ?string
+    {
+        $header = request()->header('x-gwdm-version');
+
+        if (! $header) {
+            return null;
+        }
+
+        if (in_array($header, GwdmHandlerFactory::supportedVersions(), true)) {
+            return $header;
+        }
+
+        $supported = implode(', ', GwdmHandlerFactory::supportedVersions());
+        throw new \InvalidArgumentException(
+            "Unsupported GWDM version '{$header}'. Supported versions: {$supported}."
+        );
+    }
+}

--- a/app/Context/OutputSchemaContext.php
+++ b/app/Context/OutputSchemaContext.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Context;
+
+/**
+ * Resolves the output schema model and version for read operations.
+ *
+ * HTTP clients (HDRUK portal, CRUK, PRUK, DCAT frontends) can set these headers
+ * globally instead of appending ?schema_model=&schema_version= to every URL.
+ *
+ * Resolution order in controllers:
+ *   1. ?schema_model / ?schema_version query params       — highest priority
+ *   2. x-schema-model / x-schema-version request headers — this class
+ *   3. Partner default from config/partners.php           — derived from PartnerContext
+ *   4. null (no translation — return stored GWDM)
+ *
+ * Not needed in queued jobs (output translation is a synchronous read concern).
+ * No middleware or container binding required — instantiated via auto-resolution.
+ */
+class OutputSchemaContext
+{
+    public function __construct(private PartnerContext $partnerContext)
+    {
+    }
+
+    public function schemaModel(): ?string
+    {
+        return request()->header('x-schema-model')
+            ?: $this->partnerContext->defaultSchemaModel()
+            ?: null;
+    }
+
+    public function schemaVersion(): ?string
+    {
+        return request()->header('x-schema-version')
+            ?: $this->partnerContext->defaultSchemaVersion()
+            ?: null;
+    }
+}

--- a/app/Context/PartnerContext.php
+++ b/app/Context/PartnerContext.php
@@ -72,6 +72,16 @@ class PartnerContext
         return $this->defaultIndexResourceFor($modelClass);
     }
 
+    public function defaultSchemaModel(): ?string
+    {
+        return config('partners.schema.' . $this->getPartner() . '.model') ?: null;
+    }
+
+    public function defaultSchemaVersion(): ?string
+    {
+        return config('partners.schema.' . $this->getPartner() . '.version') ?: null;
+    }
+
     private function defaultResourceFor(string $modelClass): string
     {
         return config('partners.resources.HDRUK', [])[$modelClass] ?? $modelClass;

--- a/app/Http/Controllers/Api/V1/FormHydrationController.php
+++ b/app/Http/Controllers/Api/V1/FormHydrationController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api\V1;
 
 use Config;
 use MetadataManagementController as MMC;
+use App\Context\GwdmVersionContext;
+use App\Context\OutputSchemaContext;
 use App\Http\Controllers\Controller;
 use App\Models\Dataset;
 use App\Models\Team;
@@ -13,6 +15,32 @@ use Illuminate\Support\Facades\Http;
 
 class FormHydrationController extends Controller
 {
+    /**
+     * GWDM metadata dot-paths used by getDefaultValues() to extract per-team defaults.
+     *
+     * Keyed by GWDM version string. The '2.1' entry inherits '2.0' paths unless
+     * GWDM 2.1 restructures these fields — add overrides here if it does.
+     * Add a '3.0' entry when structured SQL columns replace the JSON paths.
+     */
+    private const DEFAULTS_PATHS = [
+        '2.0' => [
+            'dataUseLimitation'   => 'metadata.metadata.accessibility.usage.dataUseLimitation',
+            'dataUseRequirements' => 'metadata.metadata.accessibility.usage.dataUseRequirements',
+            'accessRights'        => 'metadata.metadata.accessibility.access.accessRights',
+            'accessService'       => 'metadata.metadata.accessibility.access.accessService',
+            'accessRequestCost'   => 'metadata.metadata.accessibility.access.accessRequestCost',
+            'deliveryLeadTime'    => 'metadata.metadata.accessibility.access.deliveryLeadTime',
+            'formats'             => 'metadata.metadata.accessibility.formatAndStandards.formats',
+        ],
+        '2.1' => [],  // inherits '2.0' paths; override here if 2.1 restructures these fields
+    ];
+
+    public function __construct(
+        private readonly OutputSchemaContext $outputSchemaContext,
+        private readonly GwdmVersionContext $gwdmVersionContext,
+    ) {
+    }
+
     /**
      * @OA\Get(
      *      path="/api/v1/form_hydration/schema",
@@ -57,8 +85,14 @@ class FormHydrationController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $model = $request->input('model', Config::get('form_hydration.schema.model'));
-        $version = $request->input('version', Config::get('form_hydration.schema.latest_version'));
+        $model   = $request->input(
+            'model',
+            $this->outputSchemaContext->schemaModel() ?? Config::get('form_hydration.schema.model')
+        );
+        $version = $request->input(
+            'version',
+            $this->outputSchemaContext->schemaVersion() ?? Config::get('form_hydration.schema.latest_version')
+        );
 
         $url = sprintf(Config::get('form_hydration.schema.url'), $model, $version);
 
@@ -127,8 +161,14 @@ class FormHydrationController extends Controller
      */
     public function onboardingFormHydration(Request $request): JsonResponse
     {
-        $model = $request->input('model', Config::get('form_hydration.schema.model'));
-        $version = $request->input('version', Config::get('form_hydration.schema.latest_version'));
+        $model   = $request->input(
+            'model',
+            $this->outputSchemaContext->schemaModel() ?? Config::get('form_hydration.schema.model')
+        );
+        $version = $request->input(
+            'version',
+            $this->outputSchemaContext->schemaVersion() ?? Config::get('form_hydration.schema.latest_version')
+        );
         $dataTypes = $request->input('dataTypes', '');
         $teamId = $request->input('team_id', null);
 
@@ -170,34 +210,39 @@ class FormHydrationController extends Controller
 
             $datasets = $datasets->toArray();
 
+            // Resolve paths for the active GWDM version; fall back to 2.0 if the
+            // version has no override entry in DEFAULTS_PATHS.
+            $gwdmVersion = $this->gwdmVersionContext->targetVersion();
+            $paths = self::DEFAULTS_PATHS[$gwdmVersion] ?? self::DEFAULTS_PATHS['2.0'];
+
             $datasetDefaultValues['Data use limitation'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.usage.dataUseLimitation',
+                $paths['dataUseLimitation'],
                 $datasets,
                 true
             );
             $datasetDefaultValues['Data use requirements'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.usage.dataUseRequirements',
+                $paths['dataUseRequirements'],
                 $datasets,
                 true
             );
             $datasetDefaultValues['Access rights'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.access.accessRights',
+                $paths['accessRights'],
                 $datasets
             );
             $datasetDefaultValues['Access service description'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.access.accessService',
+                $paths['accessService'],
                 $datasets
             );
             $datasetDefaultValues['Access request cost'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.access.accessRequestCost',
+                $paths['accessRequestCost'],
                 $datasets
             );
             $datasetDefaultValues['Time to dataset access'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.access.deliveryLeadTime',
+                $paths['deliveryLeadTime'],
                 $datasets
             );
             $datasetDefaultValues['Format'] = $this->mostCommonValue(
-                'metadata.metadata.accessibility.formatAndStandards.formats',
+                $paths['formats'],
                 $datasets,
                 true
             );

--- a/app/Http/Controllers/Api/V1/FormHydrationController.php
+++ b/app/Http/Controllers/Api/V1/FormHydrationController.php
@@ -173,7 +173,14 @@ class FormHydrationController extends Controller
         $team = Team::findOrFail($id);
 
         $defaultValues = array();
-        $defaultValues['identifier'] = $team['id'];
+        // Seed the data-custodian default with the team's persistent identifier
+        // (pid), NOT the internal MySQL primary key. This value hydrates
+        // `summary.dataCustodian.identifier`, which the bulk-upload flow already
+        // validates against `team.pid` (UploadDataset.tsx -> errorNoMatchingPid)
+        // and which downstream lookups resolve as a pid. Using $team['id'] here
+        // previously made the manual-wizard and bulk-upload flows disagree on the
+        // meaning of the same field. See GAT publisher/dataCustodian investigation.
+        $defaultValues['identifier'] = $team['pid'];
         $defaultValues['Name of Data Custodian'] = $team['name'];
         $defaultValues['Organisation Logo'] = (is_null($team['team_logo']) || strlen(trim($team['team_logo'])) === 0) ? null : (preg_match('/^https?:\/\//', $team['team_logo']) ? $team['team_logo'] : Config::get('services.media.base_url') . $team['team_logo']);
         $defaultValues['Organisation Description'] = $team['name'];

--- a/app/Http/Controllers/Api/V1/FormHydrationController.php
+++ b/app/Http/Controllers/Api/V1/FormHydrationController.php
@@ -9,35 +9,17 @@ use App\Context\OutputSchemaContext;
 use App\Http\Controllers\Controller;
 use App\Models\Dataset;
 use App\Models\Team;
+use App\Services\Gwdm\GwdmHandlerFactory;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Http;
 
 class FormHydrationController extends Controller
 {
-    /**
-     * GWDM metadata dot-paths used by getDefaultValues() to extract per-team defaults.
-     *
-     * Keyed by GWDM version string. The '2.1' entry inherits '2.0' paths unless
-     * GWDM 2.1 restructures these fields — add overrides here if it does.
-     * Add a '3.0' entry when structured SQL columns replace the JSON paths.
-     */
-    private const DEFAULTS_PATHS = [
-        '2.0' => [
-            'dataUseLimitation'   => 'metadata.metadata.accessibility.usage.dataUseLimitation',
-            'dataUseRequirements' => 'metadata.metadata.accessibility.usage.dataUseRequirements',
-            'accessRights'        => 'metadata.metadata.accessibility.access.accessRights',
-            'accessService'       => 'metadata.metadata.accessibility.access.accessService',
-            'accessRequestCost'   => 'metadata.metadata.accessibility.access.accessRequestCost',
-            'deliveryLeadTime'    => 'metadata.metadata.accessibility.access.deliveryLeadTime',
-            'formats'             => 'metadata.metadata.accessibility.formatAndStandards.formats',
-        ],
-        '2.1' => [],  // inherits '2.0' paths; override here if 2.1 restructures these fields
-    ];
-
     public function __construct(
         private readonly OutputSchemaContext $outputSchemaContext,
         private readonly GwdmVersionContext $gwdmVersionContext,
+        private readonly GwdmHandlerFactory $gwdmHandlerFactory,
     ) {
     }
 
@@ -210,39 +192,39 @@ class FormHydrationController extends Controller
 
             $datasets = $datasets->toArray();
 
-            // Resolve paths for the active GWDM version; fall back to 2.0 if the
-            // version has no override entry in DEFAULTS_PATHS.
+            // Paths are owned by the GWDM handler for the active version — see
+            // GwdmMetadataHandler::defaultValuePaths().
             $gwdmVersion = $this->gwdmVersionContext->targetVersion();
-            $paths = self::DEFAULTS_PATHS[$gwdmVersion] ?? self::DEFAULTS_PATHS['2.0'];
+            $paths = $this->gwdmHandlerFactory->resolve($gwdmVersion)->defaultValuePaths();
 
             $datasetDefaultValues['Data use limitation'] = $this->mostCommonValue(
-                $paths['dataUseLimitation'],
+                $paths['dataUseLimitation'] ?? null,
                 $datasets,
                 true
             );
             $datasetDefaultValues['Data use requirements'] = $this->mostCommonValue(
-                $paths['dataUseRequirements'],
+                $paths['dataUseRequirements'] ?? null,
                 $datasets,
                 true
             );
             $datasetDefaultValues['Access rights'] = $this->mostCommonValue(
-                $paths['accessRights'],
+                $paths['accessRights'] ?? null,
                 $datasets
             );
             $datasetDefaultValues['Access service description'] = $this->mostCommonValue(
-                $paths['accessService'],
+                $paths['accessService'] ?? null,
                 $datasets
             );
             $datasetDefaultValues['Access request cost'] = $this->mostCommonValue(
-                $paths['accessRequestCost'],
+                $paths['accessRequestCost'] ?? null,
                 $datasets
             );
             $datasetDefaultValues['Time to dataset access'] = $this->mostCommonValue(
-                $paths['deliveryLeadTime'],
+                $paths['deliveryLeadTime'] ?? null,
                 $datasets
             );
             $datasetDefaultValues['Format'] = $this->mostCommonValue(
-                $paths['formats'],
+                $paths['formats'] ?? null,
                 $datasets,
                 true
             );
@@ -261,11 +243,17 @@ class FormHydrationController extends Controller
         ];
     }
 
-    private function mostCommonValue(string $path, array $datasets, bool $isArray = false): mixed
+    private function mostCommonValue(?string $path, array $datasets, bool $isArray = false): mixed
     {
+        if ($path === null) {
+            return $isArray ? [] : null;
+        }
+
         $values = array();
         foreach ($datasets as $dataset) {
-            $v = $this->getValueFromPath($dataset, $path);
+            // $dataset['metadata'] holds the raw dataset_versions.metadata envelope;
+            // handler-owned paths are relative to that envelope (see defaultValuePaths()).
+            $v = $this->getValueFromPath($dataset, 'metadata.' . $path);
             $values[] = is_scalar($v) ? (string)$v : '';
         }
 

--- a/app/Http/Controllers/Api/V1/IntegrationDatasetController.php
+++ b/app/Http/Controllers/Api/V1/IntegrationDatasetController.php
@@ -572,21 +572,21 @@ class IntegrationDatasetController extends Controller
                 //            - publisher.publisherId --> publisher.gatewayId
                 //            - publisher.publisherName --> publisher.name
                 // -------------------------------------------------------------------
+                // Normalise the raw (post-TRASER) publisher instead of forcing
+                // the requesting team: keep a publisher that names a different
+                // organisation, while normalising its gateway identifier to a
+                // pid and falling back to the requesting team when absent.
+                $incomingPublisher = $input['metadata']['metadata']['summary']['publisher'] ?? [];
+
                 if (version_compare(Config::get('metadata.GWDM.version'), '1.1', '<')) {
-                    $publisher = [
-                        'publisherId' => $team['pid'],
-                        'publisherName' => $team['name'],
-                    ];
+                    $publisher = $this->normalisePublisher($incomingPublisher, $team, 'publisherId', 'publisherName');
                 } else {
                     $version = $this->getVersion(1);
                     if (array_key_exists('version', $input['metadata']['metadata']['required'])) {
                         $version = $input['metadata']['metadata']['required']['version'];
                     }
                     $required['version'] = $version;
-                    $publisher = [
-                        'gatewayId' => $team['pid'],
-                        'name' => $team['name'],
-                    ];
+                    $publisher = $this->normalisePublisher($incomingPublisher, $team, 'gatewayId', 'name');
                 }
 
                 $input['metadata']['metadata']['required'] = $required;

--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -7,6 +7,7 @@ use Config;
 use Exception;
 use App\Models\Dataset;
 use App\Models\Team;
+use App\Context\OutputSchemaContext;
 use App\Context\PartnerContext;
 use App\Services\DatasetService;
 use App\Http\Traits\CheckAccess;
@@ -32,6 +33,7 @@ class DatasetController extends Controller
     public function __construct(
         private readonly DatasetService $datasetService,
         private readonly PartnerContext $partnerContext,
+        private readonly OutputSchemaContext $outputSchemaContext,
     ) {
     }
 
@@ -184,10 +186,19 @@ class DatasetController extends Controller
                 return $this->streamStructuralMetadataExport($dataset, $id);
             }
 
+            if ($request->query('view') === 'metadataOnly') {
+                $metadata = $this->datasetService->getMetadataOnly(
+                    $dataset,
+                    $request->query('schema_model') ?? $this->outputSchemaContext->schemaModel(),
+                    $request->query('schema_version') ?? $this->outputSchemaContext->schemaVersion(),
+                );
+                return response()->json(['message' => 'success', 'data' => $metadata]);
+            }
+
             $dataset = $this->datasetService->prepareForShow(
                 $dataset,
-                $request->query('schema_model'),
-                $request->query('schema_version'),
+                $request->query('schema_model') ?? $this->outputSchemaContext->schemaModel(),
+                $request->query('schema_version') ?? $this->outputSchemaContext->schemaVersion(),
             );
 
             Auditor::log([
@@ -206,6 +217,8 @@ class DatasetController extends Controller
 
         } catch (\InvalidArgumentException $e) {
             return response()->json(['message' => $e->getMessage()], 400);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
         } catch (\RuntimeException $e) {
             return response()->json(['message' => 'failed to translate', 'details' => $e->getMessage()], 400);
         } catch (Exception $e) {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -46,6 +46,7 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\ResolveGwdmVersionContext::class,
             // \Illuminate\Session\Middleware\StartSession::class,
         ],
     ];

--- a/app/Http/Middleware/ResolveGwdmVersionContext.php
+++ b/app/Http/Middleware/ResolveGwdmVersionContext.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Context\GwdmVersionContext;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Writes the resolved GWDM version into the Laravel request-scoped Context.
+ *
+ * Laravel 12 automatically propagates Context entries into any jobs dispatched
+ * during the request, so LinkageExtraction, TermExtraction, and other enrichment
+ * jobs receive the same gwdm_version value without explicit constructor passing.
+ *
+ * This middleware is a no-op when no x-gwdm-version header is present:
+ * GwdmVersionContext falls back to Config::get('metadata.GWDM.version'),
+ * which is the existing system default — no behaviour change for existing callers.
+ */
+class ResolveGwdmVersionContext
+{
+    public function __construct(private readonly GwdmVersionContext $gwdmVersionContext)
+    {
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        Context::add('gwdm_version', $this->gwdmVersionContext->targetVersion());
+
+        return $next($request);
+    }
+}

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -45,6 +45,18 @@ trait IndexElastic
     private $collections = [];
 
     /**
+     * Single named resolution point for DatasetService within this trait.
+     *
+     * Constructor injection isn't viable here: IndexElastic is a trait consumed
+     * by ~20 unrelated controllers/jobs/observers, so there is no single
+     * constructor to inject into without a much larger refactor.
+     */
+    private function datasetService(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /**
      * Reconstruct the full GWDM envelope for a dataset's latest version.
      *
      * DatasetVersion->metadata cannot be read directly for indexing: delta rows
@@ -65,7 +77,7 @@ trait IndexElastic
             return [];
         }
 
-        return app(DatasetService::class)->getReconstructedMetadataEnvelope(
+        return $this->datasetService()->getReconstructedMetadataEnvelope(
             $dataset->id,
             $version->version,
             false,
@@ -102,6 +114,7 @@ trait IndexElastic
             }
 
             $metadata = $this->reconstructedLatestEnvelope($datasetMatch);
+            $latestVersion = $datasetMatch->latestVersion();
 
             // inject relationships via Local functions
             $materialTypes = $this->getMaterialTypes($metadata);
@@ -112,8 +125,10 @@ trait IndexElastic
                 'abstract' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.abstract'], ''),
                 'keywords' => $this->normalizeDelimitedList($this->getValueByPossibleKeys($metadata, ['metadata.summary.keywords'], '')),
                 'description' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.description'], ''),
-                'shortTitle' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], ''),
-                'title' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.title'], ''),
+                // short_title/title are populated columns on every write (see DatasetVersion);
+                // only fall back to the envelope for legacy pre-migration rows where they're null.
+                'shortTitle' => $latestVersion->short_title ?? $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], ''),
+                'title' => $latestVersion->title ?? $this->getValueByPossibleKeys($metadata, ['metadata.summary.title'], ''),
                 'populationSize' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.populationSize'], -1),
                 'publisherName' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.publisher.name', 'metadata.summary.publisher.publisherName'], ''),
                 'startDate' => $this->getValueByPossibleKeys($metadata, ['metadata.provenance.temporal.startDate'], null),
@@ -320,7 +335,7 @@ trait IndexElastic
                 if ($latestVersion) {
                     $datasetVersionIds[] = $latestVersion->id;
                     $metadata = $latestVersion->metadata;
-                    $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                    $datasetTitles[] = $latestVersion->short_title ?? ($metadata['metadata']['summary']['shortTitle'] ?? '');
                     $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
                     foreach ($types as $t) {
                         if (!in_array($t, $dataTypes)) {
@@ -490,11 +505,9 @@ trait IndexElastic
         $datasetTitles = array();
         $datasetAbstracts = array();
         foreach ($datasetIds as $d) {
-            $metadata = Dataset::where(['id' => $d])
-                ->first()
-                ->latestVersion()
-                ->metadata;
-            $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+            $latestVersion = Dataset::where(['id' => $d])->first()->latestVersion();
+            $metadata = $latestVersion->metadata;
+            $datasetTitles[] = $latestVersion->short_title ?? ($metadata['metadata']['summary']['shortTitle'] ?? '');
             $datasetAbstracts[] = $metadata['metadata']['summary']['abstract'];
         }
 
@@ -565,8 +578,7 @@ trait IndexElastic
 
             foreach ($datasets as $dataset) {
                 $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages  ?? []);
-                $envelope = $this->reconstructedLatestEnvelope($dataset);
-                $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
+                $datasetTitles[] = $dataset->latestVersion()?->short_title ?? '';
                 foreach ($dataset['spatialCoverage'] as $loc) {
                     if (!in_array($loc['region'], $locations)) {
                         $locations[] = $loc['region'];
@@ -628,11 +640,7 @@ trait IndexElastic
 
             $datasetTitles = array();
             foreach ($datasetIds as $d) {
-                $metadata = Dataset::where(['id' => $d])
-                    ->first()
-                    ->latestVersion()
-                    ->metadata;
-                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                $datasetTitles[] = Dataset::where(['id' => $d])->first()->latestVersion()->short_title ?? '';
             }
 
             $keywords = array();
@@ -729,9 +737,9 @@ trait IndexElastic
 
             foreach ($datasets as $dataset) {
                 $datasetModel = Dataset::where(['id' => $dataset['id']])->first();
-                $latestVersionID = $datasetModel->latestVersion()->id;
-                $envelope = $this->reconstructedLatestEnvelope($datasetModel);
-                $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
+                $latestVersion = $datasetModel->latestVersion();
+                $latestVersionID = $latestVersion->id;
+                $datasetTitles[] = $latestVersion->short_title ?? '';
 
                 // change from 'UNKNOWN' to 'USING' - temp
                 $linkType = PublicationHasDatasetVersion::where([
@@ -869,8 +877,7 @@ trait IndexElastic
                 $datasetTitles[] = '_Can be used with any dataset';
             } else {
                 foreach ($datasets as $dataset) {
-                    $envelope = $this->reconstructedLatestEnvelope($dataset);
-                    $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
+                    $datasetTitles[] = $dataset->latestVersion()?->short_title ?? '';
                 }
                 usort($datasetTitles, 'strcasecmp');
             }
@@ -1143,7 +1150,10 @@ trait IndexElastic
 
         $metadataSummary = $this->reconstructedLatestEnvelope($dataset)['metadata']['summary'] ?? [];
 
-        $title = $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
+        // title/short_title are populated columns on every write; only fall back
+        // to the reconstructed envelope for legacy pre-migration rows.
+        $title = $dataset->latestVersion()?->title
+            ?? $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
         $populationSize = $this->getValueByPossibleKeys($metadataSummary, ['populationSize'], -1);
         $datasetType = $this->getValueByPossibleKeys($metadataSummary, ['datasetType'], '');
 

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -31,6 +31,7 @@ use App\Models\ToolHasProgrammingPackage;
 use App\Models\ToolHasTag;
 use App\Models\ToolHasTypeCategory;
 use App\Models\TypeCategory;
+use App\Services\DatasetService;
 use ElasticClientController as ECC;
 
 trait IndexElastic
@@ -42,6 +43,35 @@ trait IndexElastic
     private $tools = [];
     private $publications = [];
     private $collections = [];
+
+    /**
+     * Reconstruct the full GWDM envelope for a dataset's latest version.
+     *
+     * DatasetVersion->metadata cannot be read directly for indexing: delta rows
+     * store an empty metadata blob, and GWDM 3.0 rows omit the `metadata` key
+     * entirely (their data lives in dedicated SQL tables). Funnelling through
+     * DatasetService::getReconstructedMetadataEnvelope() yields a complete
+     * {gwdmVersion, metadata, original_metadata} envelope for every schema
+     * version and every snapshot/delta storage shape. Validation is skipped —
+     * data is validated at write time.
+     *
+     * @return array The reconstructed envelope, or [] when the dataset has no versions.
+     */
+    private function reconstructedLatestEnvelope(Dataset $dataset): array
+    {
+        $version = $dataset->latestVersion();
+
+        if (!$version) {
+            return [];
+        }
+
+        return app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $dataset->id,
+            $version->version,
+            false,
+            $version,
+        );
+    }
 
     /**
      * Calls a re-indexing of Elastic search when a dataset is created, updated or added to a collection.
@@ -71,7 +101,7 @@ trait IndexElastic
                 // throw new \Exception("Error: DatasetVersion is missing for dataset ID=$datasetId.");
             }
 
-            $metadata = $datasetMatch->latestVersion()->metadata;
+            $metadata = $this->reconstructedLatestEnvelope($datasetMatch);
 
             // inject relationships via Local functions
             $materialTypes = $this->getMaterialTypes($metadata);
@@ -535,8 +565,8 @@ trait IndexElastic
 
             foreach ($datasets as $dataset) {
                 $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages  ?? []);
-                $metadata = $dataset['versions'][0];
-                $datasetTitles[] = $metadata['metadata']['metadata']['summary']['shortTitle'];
+                $envelope = $this->reconstructedLatestEnvelope($dataset);
+                $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
                 foreach ($dataset['spatialCoverage'] as $loc) {
                     if (!in_array($loc['region'], $locations)) {
                         $locations[] = $loc['region'];
@@ -698,9 +728,10 @@ trait IndexElastic
             ];
 
             foreach ($datasets as $dataset) {
-                $metadata = Dataset::where(['id' => $dataset['id']])->first()->latestVersion()->metadata;
-                $latestVersionID = Dataset::where(['id' => $dataset['id']])->first()->latestVersion()->id;
-                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                $datasetModel = Dataset::where(['id' => $dataset['id']])->first();
+                $latestVersionID = $datasetModel->latestVersion()->id;
+                $envelope = $this->reconstructedLatestEnvelope($datasetModel);
+                $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
 
                 // change from 'UNKNOWN' to 'USING' - temp
                 $linkType = PublicationHasDatasetVersion::where([
@@ -838,8 +869,8 @@ trait IndexElastic
                 $datasetTitles[] = '_Can be used with any dataset';
             } else {
                 foreach ($datasets as $dataset) {
-                    $dataset_version = $dataset['versions'][0];
-                    $datasetTitles[] = $dataset_version['metadata']['metadata']['summary']['shortTitle'];
+                    $envelope = $this->reconstructedLatestEnvelope($dataset);
+                    $datasetTitles[] = $envelope['metadata']['summary']['shortTitle'] ?? '';
                 }
                 usort($datasetTitles, 'strcasecmp');
             }
@@ -1110,14 +1141,7 @@ trait IndexElastic
         $publicationIds = array_column($dataset->allActivePublications, 'id') ?? [];
         $toolIds = array_column($dataset->allActiveTools, 'id') ?? [];
 
-        $version = $dataset->latestVersion();
-        $withLinks = DatasetVersion::where('id', $version['id'])
-            ->with(['linkedDatasetVersions'])
-            ->first();
-
-        $dataset->setAttribute('versions', [$withLinks]);
-
-        $metadataSummary = $dataset['versions'][0]['metadata']['metadata']['summary'] ?? [];
+        $metadataSummary = $this->reconstructedLatestEnvelope($dataset)['metadata']['summary'] ?? [];
 
         $title = $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
         $populationSize = $this->getValueByPossibleKeys($metadataSummary, ['populationSize'], -1);

--- a/app/Http/Traits/MetadataOnboard.php
+++ b/app/Http/Traits/MetadataOnboard.php
@@ -12,9 +12,38 @@ use App\Jobs\TermExtraction;
 use App\Jobs\LinkageExtraction;
 use Illuminate\Support\Str;
 use MetadataManagementController as MMC;
+use App\Services\Gwdm\GwdmMetadataHandler;
 
 trait MetadataOnboard
 {
+    /**
+     * Normalise a summary.publisher object for these legacy V1 inline write
+     * paths: prefer the raw (post-TRASER) publisher, resolve its gateway
+     * identifier to a team pid (accepting either a primary key or a pid), and
+     * fall back to the requesting team when no resolvable publisher is present.
+     *
+     * Mirrors GwdmMetadataHandler::resolvePublisher() for the paths that build
+     * the version envelope inline instead of via the handler. $idKey/$nameKey
+     * select the version-specific shape (2.x: gatewayId/name; <1.1:
+     * publisherId/publisherName).
+     */
+    protected function normalisePublisher(array $incoming, array $team, string $idKey, string $nameKey): array
+    {
+        $resolved = GwdmMetadataHandler::resolveTeamFromGatewayId($incoming[$idKey] ?? null);
+
+        if (!$resolved) {
+            return [
+                $idKey   => $team['pid'],
+                $nameKey => $team['name'],
+            ];
+        }
+
+        $incoming[$idKey]   = $resolved->pid;
+        $incoming[$nameKey] = $incoming[$nameKey] ?? $resolved->name;
+
+        return $incoming;
+    }
+
     /**
      * Create new Dataset, calling translation service if necessary
      *
@@ -119,18 +148,23 @@ trait MetadataOnboard
             //            - publisher.publisherId --> publisher.gatewayId
             //            - publisher.publisherName --> publisher.name
             // -------------------------------------------------------------------
+            // Normalise the publisher from the raw (post-TRASER) payload rather
+            // than force-attributing to the requesting team: this preserves a
+            // publisher that names a different organisation while guaranteeing
+            // its gateway identifier is stored as a pid (not a raw primary key).
+            $incomingPublisher = $input['metadata']['metadata']['summary']['publisher'] ?? [];
+
             if (version_compare(Config::get('metadata.GWDM.version'), '1.1', '<')) {
-                $publisher = [
-                    'publisherId' => $team['pid'],
-                    'publisherName' => $team['name'],
-                ];
-                $input['metadata']['metadata']['summary']['publisher'] = $publisher;
+                $input['metadata']['metadata']['summary']['publisher'] =
+                    $this->normalisePublisher($incomingPublisher, $team, 'publisherId', 'publisherName');
             } else {
                 $version = $this->formatVersion(1);
                 if (array_key_exists('version', $input['metadata']['metadata']['required'])) {
                     $version = $input['metadata']['metadata']['required']['version'];
                 }
                 $required['version'] = $version;
+                $input['metadata']['metadata']['summary']['publisher'] =
+                    $this->normalisePublisher($incomingPublisher, $team, 'gatewayId', 'name');
             }
 
             $input['metadata']['metadata']['required'] = $required;

--- a/app/Jobs/LinkageExtraction.php
+++ b/app/Jobs/LinkageExtraction.php
@@ -10,11 +10,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Http\Traits\LoggingContext;
-use App\Models\DatasetVersionHasDatasetVersion;
-use App\Models\PublicationHasDatasetVersion;
-use App\Models\Dataset;
 use App\Models\DatasetVersion;
-use App\Models\Publication;
+use App\Services\Gwdm\GwdmHandlerFactory;
 
 class LinkageExtraction implements ShouldQueue
 {
@@ -30,41 +27,23 @@ class LinkageExtraction implements ShouldQueue
     protected string $sourceDatasetId = '';
     protected string $sourceDatasetVersionId = '';
     protected string $gwdmVersion = '';
-    protected array|null $datasetLinkages;
-    protected array|null $publicationAboutDatasetLinkages;
-    protected array|null $publicationUsingDatasetLinkages;
-    protected string $description = '';
 
     private ?array $loggingContext = null;
 
-    /**
-     * Create a new job instance.
-     */
     public function __construct(string $datasetId, string $datasetVersionId)
     {
         $this->onQueue('enrichment');
         try {
-
             $version = DatasetVersion::findOrFail($datasetVersionId);
 
-            $this->sourceDatasetId = $datasetId;
+            $this->sourceDatasetId        = $datasetId;
             $this->sourceDatasetVersionId = $datasetVersionId;
-            $this->gwdmVersion = $version->metadata['gwdmVersion'];
-
-            $datasetLinkage = $version->metadata['metadata']['linkage']['datasetLinkage'] ?? null;
-            $this->datasetLinkages = $datasetLinkage !== '' ? $datasetLinkage : null;
-
-            $publicationAboutDatasetLinkages = $version->metadata['metadata']['linkage']['publicationAboutDataset'] ?? null;
-            $this->publicationAboutDatasetLinkages = $publicationAboutDatasetLinkages !== '' ? $publicationAboutDatasetLinkages : null;
-
-            $publicationUsingDatasetLinkages = $version->metadata['metadata']['linkage']['publicationUsingDataset'] ?? null;
-            $this->publicationUsingDatasetLinkages = $publicationUsingDatasetLinkages !== '' ? $publicationUsingDatasetLinkages : null;
-
-            $this->description = 'Extracted from GWDM';
+            // Indexed column is reliable on delta rows where the metadata envelope
+            // stores only a patch, not the full document.
+            $this->gwdmVersion = $version->gwdm_version ?? $version->metadata['gwdmVersion'] ?? '2.0';
 
             $this->loggingContext = $this->getLoggingContext(\request());
             $this->loggingContext['method_name'] = class_basename($this);
-
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
@@ -72,27 +51,15 @@ class LinkageExtraction implements ShouldQueue
                 'description' => $e->getMessage(),
             ]);
 
-            \Log::info('Error initializing LinkageExtraction job: ' . $e->getMessage(), $this->loggingContext);
-
             throw new Exception('Error initializing LinkageExtraction job: ' . $e->getMessage());
         }
     }
 
-    /**
-     * Execute the job.
-     */
-    public function handle(): void
+    public function handle(GwdmHandlerFactory $handlerFactory): void
     {
         try {
-            if (!version_compare($this->gwdmVersion, '2.0', '=')) {
-                return; // Not the correct version for processing
-            }
-
-            // Process dataset and publication linkages
-            $this->processDatasetLinkages();
-            $this->processPublicationLinkages($this->publicationAboutDatasetLinkages, 'ABOUT');
-            $this->processPublicationLinkages($this->publicationUsingDatasetLinkages, 'USING');
-
+            $version = DatasetVersion::findOrFail($this->sourceDatasetVersionId);
+            $handlerFactory->resolve($this->gwdmVersion)->extractLinkages($version);
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
@@ -106,161 +73,6 @@ class LinkageExtraction implements ShouldQueue
         }
     }
 
-    /**
-     * Process dataset linkages.
-     */
-    protected function processDatasetLinkages(): void
-    {
-        try {
-            DatasetVersionHasDatasetVersion::where([
-                'dataset_version_source_id' => $this->sourceDatasetVersionId,
-                'direct_linkage' => 1,
-                'description' => $this->description
-            ])->delete();
-
-            if (is_null($this->datasetLinkages)) {
-                return; // No datasets to process
-            }
-
-            foreach ($this->datasetLinkages as $key => $data) {
-                if (!$data) {
-                    continue;
-                }
-                foreach ($data as $d) {
-                    $targetDatasetVersionId = $this->findTargetDataset($d);
-                    if (!$targetDatasetVersionId) {
-                        continue;
-                    }
-                    DatasetVersionHasDatasetVersion::firstOrCreate([
-                        'dataset_version_source_id' => $this->sourceDatasetVersionId,
-                        'dataset_version_target_id' => $targetDatasetVersionId,
-                        'linkage_type' => $key,
-                        'direct_linkage' => 1,
-                        'description' => $this->description
-                    ]);
-                }
-            }
-        } catch (Exception $e) {
-            Auditor::log([
-                'action_type' => 'EXCEPTION',
-                'action_name' => __METHOD__,
-                'description' => $e->getMessage(),
-            ]);
-
-            \Log::info('Error processing dataset linkages: ' . $e->getMessage(), $this->loggingContext);
-
-            throw new Exception('Error processing dataset linkages: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Generalized function to process publication linkages.
-     */
-    protected function processPublicationLinkages(?array $publicationLinkages, string $linkType): void
-    {
-        try {
-            // Clear any old linkages matching this description for the current dataset version
-            PublicationHasDatasetVersion::where([
-                'dataset_version_id' => $this->sourceDatasetVersionId,
-                'description' => $this->description,
-                'link_type' => $linkType,
-            ])->delete();
-
-            if (is_null($publicationLinkages)) {
-                return; // No publications to process
-            }
-
-            foreach ($publicationLinkages as $doi) {
-                if (!$doi) {
-                    continue;
-                }
-
-                $publicationId = $this->findTargetPublication($doi);
-                if (!$publicationId) {
-                    // THIS IS WHERE WE CAN SEARCH FOR NEW PUB AUTOMAGICALLY
-                    continue;
-                }
-
-                // Use firstOrCreate and restore if necessary
-                $linkage = PublicationHasDatasetVersion::withTrashed()->firstOrCreate([
-                    'publication_id' => $publicationId,
-                    'dataset_version_id' => $this->sourceDatasetVersionId,
-                    'link_type' => $linkType,
-                    'description' => $this->description,
-                ]);
-
-
-                // Restore if it’s soft-deleted
-                if ($linkage->trashed()) {
-                    $linkage->restore();
-                }
-            }
-        } catch (Exception $e) {
-            Auditor::log([
-                'action_type' => 'EXCEPTION',
-                'action_name' => __METHOD__,
-                'description' => $e->getMessage(),
-            ]);
-
-            \Log::info("Error processing publication linkages ({$linkType}): " . $e->getMessage(), $this->loggingContext);
-
-            throw new Exception("Error processing publication linkages ({$linkType}): " . $e->getMessage());
-        }
-    }
-
-
-    /**
-     * Find the target dataset version ID.
-     */
-    protected function findTargetDataset(array $data): ?int
-    {
-        $id = $data['url'] ?? null;
-        $pid = $data['pid'] ?? null;
-        $title = $data['title'] ?? null;
-
-        if ($id) {
-            $urlParts = explode('/', parse_url($id, PHP_URL_PATH));
-            $id = end($urlParts);
-            $dataset = Dataset::find($id);
-            if ($dataset) {
-                return $dataset->latestVersionID($dataset->id);
-            }
-        }
-
-        if ($pid) {
-            $dataset = Dataset::where('pid', $pid)->first();
-            if ($dataset) {
-                return $dataset->latestVersionID($dataset->id);
-            }
-        }
-
-        if ($title) {
-            $datasetVersion = DatasetVersion::filterTitle($title)->first();
-            if ($datasetVersion) {
-                return $datasetVersion->id;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Find the target publication ID.
-     */
-    protected function findTargetPublication(string $doi): ?int
-    {
-        // Search for publications with matching normalized DOI
-        $publication = Publication::whereRaw(
-            "REPLACE(REPLACE(paper_doi, 'https://doi.org/', ''), 'doi.org/', '') = ?",
-            [$doi]
-        )->first();
-
-        return $publication?->id;
-    }
-
-    /**
-     * Tags for the job.
-     */
     public function tags(): array
     {
         return [

--- a/app/MetadataManagementController/MetadataManagementController.php
+++ b/app/MetadataManagementController/MetadataManagementController.php
@@ -157,7 +157,47 @@ class MetadataManagementController
                 'application/json'
             )->post($urlString);
 
+            if ($response->status() !== 200) {
+                \Log::warning('GWDM validation rejected by TRASER', array_merge($loggingContext, [
+                    'status'   => $response->status(),
+                    'response' => $response->body(),
+                ]));
+            }
+
             return ($response->status() === 200);
+        } catch (Exception $e) {
+            \Log::info($e->getMessage(), $loggingContext);
+            throw new MMCException($e->getMessage());
+        }
+    }
+
+    /**
+     * Validate a metadata JSON string against the given schema and version, returning
+     * structured error details from TRASER rather than a plain boolean.
+     *
+     * @return array{valid: bool, errors: mixed}
+     */
+    public function validateDataModelTypeWithErrors(string &$dataset, string $input_schema, string $input_version): array
+    {
+        $loggingContext = $this->getLoggingContext(\request());
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
+        try {
+            $urlString = sprintf(
+                '%s/validate?input_schema=%s&input_version=%s',
+                config('services.traser.url'),
+                $input_schema,
+                $input_version
+            );
+
+            $response = Http::withBody($dataset, 'application/json')->post($urlString);
+
+            $valid = $response->status() === 200;
+
+            return [
+                'valid'  => $valid,
+                'errors' => $valid ? null : $response->json(),
+            ];
         } catch (Exception $e) {
             \Log::info($e->getMessage(), $loggingContext);
             throw new MMCException($e->getMessage());

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -223,9 +223,12 @@ class Dataset extends Model
     {
         if ($gwdmVersion) {
             $result = DB::select(
-                'SELECT dv.id FROM dataset_versions dv
-                 WHERE dv.dataset_id = :dataset_id AND dv.gwdm_version = :gwdm_version
-                 ORDER BY version DESC LIMIT 1',
+                'SELECT dv.id
+                 FROM dataset_versions dv
+                 WHERE dv.dataset_id = :dataset_id
+                   AND dv.gwdm_version = :gwdm_version
+                 ORDER BY version DESC
+                 LIMIT 1',
                 ['dataset_id' => $datasetId, 'gwdm_version' => $gwdmVersion]
             );
 
@@ -233,9 +236,11 @@ class Dataset extends Model
         }
 
         $result = DB::select(
-            'SELECT dv.id FROM dataset_versions dv
+            'SELECT dv.id
+             FROM dataset_versions dv
              WHERE dv.dataset_id = :dataset_id
-             ORDER BY version DESC LIMIT 1',
+             ORDER BY version DESC
+             LIMIT 1',
             ['dataset_id' => $datasetId]
         );
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -396,13 +396,22 @@ class Dataset extends Model
     ): array {
         $targetTable = (new $targetClass())->getTable();
 
+        // Scope to the latest version only. Coverage pivot rows accumulate one set
+        // per version; unioning across all versions makes displayed coverage only
+        // ever grow (e.g. changing England -> Scotland would show both forever).
+        $latestVersionId = $this->latestVersionID($this->id);
+
+        if ($latestVersionId === null) {
+            return [];
+        }
+
         $results = DB::select("
             SELECT {$targetTable}.*, {$linkageTable}.dataset_version_id
             FROM {$targetTable}
             INNER JOIN {$linkageTable} ON {$targetTable}.id = {$linkageTable}.{$foreignKey}
             INNER JOIN dataset_versions ON dataset_versions.id = {$linkageTable}.dataset_version_id
-            WHERE dataset_versions.dataset_id = ?
-        ", [$this->id]);
+            WHERE dataset_versions.dataset_id = ? AND dataset_versions.id = ?
+        ", [$this->id, $latestVersionId]);
 
         return collect($results)
             ->groupBy('id')

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -107,6 +107,8 @@ class Dataset extends Model
 
     protected $casts = [
         'is_cohort_discovery' => 'boolean',
+        'created'             => 'datetime',
+        'updated'             => 'datetime',
     ];
 
     protected static array $sortableColumns = [
@@ -182,13 +184,28 @@ class Dataset extends Model
 
     /**
      * The very latest version of a DatasetVersion object that corresponds to this dataset.
-     **/
-    public function latestVersion(?array $fields = null): DatasetVersion | null
+     *
+     * When $gwdmVersion is provided, returns the latest row with that gwdm_version;
+     * falls back to the overall latest if no matching row exists.
+     */
+    public function latestVersion(?array $fields = null, ?string $gwdmVersion = null): DatasetVersion|null
     {
-        $version = DatasetVersion::where('dataset_id', $this->id)
-            ->select(['version','id'])
-            ->latest('version')
-            ->first();
+        $version = null;
+
+        if ($gwdmVersion) {
+            $version = DatasetVersion::where('dataset_id', $this->id)
+                ->where('gwdm_version', $gwdmVersion)
+                ->select(['version', 'id'])
+                ->latest('version')
+                ->first();
+        }
+
+        if (!$version) {
+            $version = DatasetVersion::where('dataset_id', $this->id)
+                ->select(['version', 'id'])
+                ->latest('version')
+                ->first();
+        }
 
         if (!$version) {
             return null;
@@ -202,30 +219,27 @@ class Dataset extends Model
         )->findOrFail($version->id);
     }
 
-    public function latestVersionID(int $datasetId): null|int
+    public function latestVersionID(int $datasetId, ?string $gwdmVersion = null): null|int
     {
-        $result = DB::select(
-            '
-                SELECT 
-                    dv.id,
-                    dv.version
-                FROM dataset_versions dv
-                WHERE
-                    dv.dataset_id = :dataset_id
-                ORDER BY
-                    version DESC
-                LIMIT 1
-            ',
-            [
-                'dataset_id' => $datasetId,
-            ]
-        );
+        if ($gwdmVersion) {
+            $result = DB::select(
+                'SELECT dv.id FROM dataset_versions dv
+                 WHERE dv.dataset_id = :dataset_id AND dv.gwdm_version = :gwdm_version
+                 ORDER BY version DESC LIMIT 1',
+                ['dataset_id' => $datasetId, 'gwdm_version' => $gwdmVersion]
+            );
 
-        if (count($result) > 0) {
-            return $result[0]->id;
+            return count($result) > 0 ? $result[0]->id : null;
         }
 
-        return null;
+        $result = DB::select(
+            'SELECT dv.id FROM dataset_versions dv
+             WHERE dv.dataset_id = :dataset_id
+             ORDER BY version DESC LIMIT 1',
+            ['dataset_id' => $datasetId]
+        );
+
+        return count($result) > 0 ? $result[0]->id : null;
     }
 
     /** @return HasOne<DatasetVersion, $this> */

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -77,6 +77,10 @@ class DatasetVersion extends BaseTypesenseModel
         // from the reconstructed GWDM metadata at write time.
         'title',
         'short_title',
+        // Queryable GWDM schema version for this row (see migration
+        // 2026_06_17_000001). Replaces reading from metadata->gwdmVersion, which
+        // is absent on delta rows and unindexed on all rows.
+        'gwdm_version',
     ];
 
     /**
@@ -239,16 +243,14 @@ class DatasetVersion extends BaseTypesenseModel
             'dataset_version_source_id',
             'dataset_version_target_id',
             'linkage_type',
-        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id,
-        JSON_UNQUOTE(JSON_EXTRACT(JSON_UNQUOTE(metadata), '$.metadata.summary.title')) as title,
-        short_title as shortTitle");
+        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle");
     }
 
     public function dataset(): BelongsTo
     {
         return $this->belongsTo(Dataset::class, 'dataset_id', 'id')
             ->where('status', 'ACTIVE')
-            ->select(['id', 'status']);
+            ->select(['id', 'status', 'team_id']);
     }
 
     public function shouldBeSearchable(): bool

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -3,22 +3,23 @@
 namespace App\Models;
 
 use App\Models\Base\BaseTypesenseModel;
-use Illuminate\Database\Eloquent\Model;
 use App\Observers\DatasetVersionObserver;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @OA\Schema(
  *   schema="DatasetVersion",
  *   description="A versioned snapshot of dataset metadata in GWDM format",
+ *
  *   @OA\Property(property="id", type="integer", example=101),
  *   @OA\Property(property="dataset_id", type="integer", example=1),
  *   @OA\Property(property="version", type="integer", example=3),
@@ -35,8 +36,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  *     type="array",
  *     nullable=true,
  *     description="RFC 6902 JSON Patch array used to reconstruct this version from the previous snapshot. Null for full snapshots (v1 and every 10th version).",
+ *
  *     @OA\Items(type="object")
  *   ),
+ *
  *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-01-15T10:30:00Z"),
  *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-06-01T08:00:00Z"),
  * )
@@ -45,8 +48,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 class DatasetVersion extends BaseTypesenseModel
 {
     use HasFactory;
-    use SoftDeletes;
     use Prunable;
+    use SoftDeletes;
 
     /**
      * Table associated with this model
@@ -57,7 +60,7 @@ class DatasetVersion extends BaseTypesenseModel
 
     protected $casts = [
         'metadata' => 'array',
-        'patch'    => 'array',
+        'patch' => 'array',
     ];
 
     /**
@@ -85,8 +88,6 @@ class DatasetVersion extends BaseTypesenseModel
 
     /**
      * Get and Set the metadata.
-     *
-     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function metadata(): Attribute
     {
@@ -96,6 +97,7 @@ class DatasetVersion extends BaseTypesenseModel
                 if (is_string($response)) {
                     $response = json_decode($response, true);
                 }
+
                 return $response;
             },
             set: fn ($value) => is_array($value) ? json_encode($value) : $value,
@@ -109,8 +111,7 @@ class DatasetVersion extends BaseTypesenseModel
      * to the encoding of the string being added to the db field.
      * Needs further investigation as this is just a workaround.
      *
-     * @param $value The original value prior to pre-processing
-     *
+     * @param  $value  The original value prior to pre-processing
      * @return array The json metadata string as an array
      */
     // public function getMetadataAttribute($value): array
@@ -132,12 +133,8 @@ class DatasetVersion extends BaseTypesenseModel
     // }
 
     /**
-    * Scope a query to filter on metadata summary title
-    *
-    * @param Builder $query
-    * @param string $filterTitle
-    * @return Builder
-    */
+     * Scope a query to filter on metadata summary title
+     */
     public function scopeFilterTitle(Builder $query, string $filterTitle): Builder
     {
         return $query->where('title', 'LIKE', "%{$filterTitle}%");
@@ -158,7 +155,6 @@ class DatasetVersion extends BaseTypesenseModel
     {
         return $this->belongsToMany(SpatialCoverage::class, 'dataset_version_has_spatial_coverage');
     }
-
 
     /**
      * The tools that belong to the dataset version.
@@ -228,10 +224,10 @@ class DatasetVersion extends BaseTypesenseModel
     }
 
     /**
-    * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
-    * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
-    * we can easily switch. - Jamie B
-    */
+     * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
+     * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
+     * we can easily switch. - Jamie B
+     */
     public function reducedLinkedDatasetVersions(): BelongsToMany
     {
         return $this->belongsToMany(
@@ -243,14 +239,14 @@ class DatasetVersion extends BaseTypesenseModel
             'dataset_version_source_id',
             'dataset_version_target_id',
             'linkage_type',
-        )->selectRaw("dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle");
+        )->selectRaw('dataset_versions.id, dataset_versions.dataset_id, title, short_title as shortTitle');
     }
 
     public function dataset(): BelongsTo
     {
         return $this->belongsTo(Dataset::class, 'dataset_id', 'id')
             ->where('status', 'ACTIVE')
-            ->select(['id', 'status', 'team_id']);
+            ->select(['id', 'status']);
     }
 
     public function shouldBeSearchable(): bool
@@ -285,47 +281,47 @@ class DatasetVersion extends BaseTypesenseModel
     {
         $meta = $this->metadata ?? [];
 
-        $keywords   = data_get($meta, 'metadata.summary.keywords', '');
-        $dataType   = data_get($meta, 'metadata.summary.datasetType', '');
+        $keywords = data_get($meta, 'metadata.summary.keywords', '');
+        $dataType = data_get($meta, 'metadata.summary.datasetType', '');
         $conformsTo = data_get($meta, 'metadata.accessibility.formatAndStandards.conformsTo', '');
         $structural = data_get($meta, 'metadata.structuralMetadata', []);
         if (is_string($structural)) {
             $structural = json_decode($structural, true) ?? [];
         }
-        if (!is_array($structural)) {
+        if (! is_array($structural)) {
             $structural = [];
         }
 
         return [
-            'id'                            => (string) $this->id,
-            'dataset_id'                    => (string) $this->dataset_id,
-            'title'                         => $this->title ?? '',
-            'shortTitle'                    => $this->short_title ?? '',
-            'abstract'                      => data_get($meta, 'metadata.summary.abstract', ''),
-            'description'                   => data_get($meta, 'metadata.summary.description', ''),
-            'keywords'                      => array_values(array_filter(explode(';,;', $keywords))),
-            'publisherName'                 => data_get(
+            'id' => (string) $this->id,
+            'dataset_id' => (string) $this->dataset_id,
+            'title' => $this->title ?? '',
+            'shortTitle' => $this->short_title ?? '',
+            'abstract' => data_get($meta, 'metadata.summary.abstract', ''),
+            'description' => data_get($meta, 'metadata.summary.description', ''),
+            'keywords' => array_values(array_filter(explode(';,;', $keywords))),
+            'publisherName' => data_get(
                 $meta,
                 'metadata.summary.publisher.name',
                 data_get($meta, 'metadata.summary.publisher.publisherName', '')
             ),
-            'dataType'                      => array_values(array_filter(explode(';,;', $dataType))),
-            'populationSize'                => (int) data_get($meta, 'metadata.summary.populationSize', -1),
-            'geographicLocation'            => $this->spatialCoverage->pluck('region')->all(),
-            'datasetDOI'                    => data_get($meta, 'metadata.summary.doiName', ''),
-            'conformsTo'                    => array_values(array_filter(explode(';,;', $conformsTo))),
-            'structuralTableNames'          => collect($structural)
-                                                ->pluck('name')
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnNames'         => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnDescriptions'  => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
+            'dataType' => array_values(array_filter(explode(';,;', $dataType))),
+            'populationSize' => (int) data_get($meta, 'metadata.summary.populationSize', -1),
+            'geographicLocation' => $this->spatialCoverage->pluck('region')->all(),
+            'datasetDOI' => data_get($meta, 'metadata.summary.doiName', ''),
+            'conformsTo' => array_values(array_filter(explode(';,;', $conformsTo))),
+            'structuralTableNames' => collect($structural)
+                ->pluck('name')
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnNames' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnDescriptions' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
         ];
     }
 

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -3,23 +3,22 @@
 namespace App\Models;
 
 use App\Models\Base\BaseTypesenseModel;
-use App\Observers\DatasetVersionObserver;
-use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Observers\DatasetVersionObserver;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @OA\Schema(
  *   schema="DatasetVersion",
  *   description="A versioned snapshot of dataset metadata in GWDM format",
- *
  *   @OA\Property(property="id", type="integer", example=101),
  *   @OA\Property(property="dataset_id", type="integer", example=1),
  *   @OA\Property(property="version", type="integer", example=3),
@@ -36,10 +35,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  *     type="array",
  *     nullable=true,
  *     description="RFC 6902 JSON Patch array used to reconstruct this version from the previous snapshot. Null for full snapshots (v1 and every 10th version).",
- *
  *     @OA\Items(type="object")
  *   ),
- *
  *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-01-15T10:30:00Z"),
  *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-06-01T08:00:00Z"),
  * )
@@ -48,8 +45,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class DatasetVersion extends BaseTypesenseModel
 {
     use HasFactory;
-    use Prunable;
     use SoftDeletes;
+    use Prunable;
 
     /**
      * Table associated with this model
@@ -60,7 +57,7 @@ class DatasetVersion extends BaseTypesenseModel
 
     protected $casts = [
         'metadata' => 'array',
-        'patch' => 'array',
+        'patch'    => 'array',
     ];
 
     /**
@@ -88,6 +85,8 @@ class DatasetVersion extends BaseTypesenseModel
 
     /**
      * Get and Set the metadata.
+     *
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute
      */
     public function metadata(): Attribute
     {
@@ -97,7 +96,6 @@ class DatasetVersion extends BaseTypesenseModel
                 if (is_string($response)) {
                     $response = json_decode($response, true);
                 }
-
                 return $response;
             },
             set: fn ($value) => is_array($value) ? json_encode($value) : $value,
@@ -111,7 +109,8 @@ class DatasetVersion extends BaseTypesenseModel
      * to the encoding of the string being added to the db field.
      * Needs further investigation as this is just a workaround.
      *
-     * @param  $value  The original value prior to pre-processing
+     * @param $value The original value prior to pre-processing
+     *
      * @return array The json metadata string as an array
      */
     // public function getMetadataAttribute($value): array
@@ -133,8 +132,12 @@ class DatasetVersion extends BaseTypesenseModel
     // }
 
     /**
-     * Scope a query to filter on metadata summary title
-     */
+    * Scope a query to filter on metadata summary title
+    *
+    * @param Builder $query
+    * @param string $filterTitle
+    * @return Builder
+    */
     public function scopeFilterTitle(Builder $query, string $filterTitle): Builder
     {
         return $query->where('title', 'LIKE', "%{$filterTitle}%");
@@ -155,6 +158,7 @@ class DatasetVersion extends BaseTypesenseModel
     {
         return $this->belongsToMany(SpatialCoverage::class, 'dataset_version_has_spatial_coverage');
     }
+
 
     /**
      * The tools that belong to the dataset version.
@@ -224,10 +228,10 @@ class DatasetVersion extends BaseTypesenseModel
     }
 
     /**
-     * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
-     * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
-     * we can easily switch. - Jamie B
-     */
+    * The reduced dataset versions that belong to the dataset version, the above linkedDatasetVersions
+    * is used in a few places, if in infuture we discover that we only ever need to use the below instead,
+    * we can easily switch. - Jamie B
+    */
     public function reducedLinkedDatasetVersions(): BelongsToMany
     {
         return $this->belongsToMany(
@@ -281,47 +285,47 @@ class DatasetVersion extends BaseTypesenseModel
     {
         $meta = $this->metadata ?? [];
 
-        $keywords = data_get($meta, 'metadata.summary.keywords', '');
-        $dataType = data_get($meta, 'metadata.summary.datasetType', '');
+        $keywords   = data_get($meta, 'metadata.summary.keywords', '');
+        $dataType   = data_get($meta, 'metadata.summary.datasetType', '');
         $conformsTo = data_get($meta, 'metadata.accessibility.formatAndStandards.conformsTo', '');
         $structural = data_get($meta, 'metadata.structuralMetadata', []);
         if (is_string($structural)) {
             $structural = json_decode($structural, true) ?? [];
         }
-        if (! is_array($structural)) {
+        if (!is_array($structural)) {
             $structural = [];
         }
 
         return [
-            'id' => (string) $this->id,
-            'dataset_id' => (string) $this->dataset_id,
-            'title' => $this->title ?? '',
-            'shortTitle' => $this->short_title ?? '',
-            'abstract' => data_get($meta, 'metadata.summary.abstract', ''),
-            'description' => data_get($meta, 'metadata.summary.description', ''),
-            'keywords' => array_values(array_filter(explode(';,;', $keywords))),
-            'publisherName' => data_get(
+            'id'                            => (string) $this->id,
+            'dataset_id'                    => (string) $this->dataset_id,
+            'title'                         => $this->title ?? '',
+            'shortTitle'                    => $this->short_title ?? '',
+            'abstract'                      => data_get($meta, 'metadata.summary.abstract', ''),
+            'description'                   => data_get($meta, 'metadata.summary.description', ''),
+            'keywords'                      => array_values(array_filter(explode(';,;', $keywords))),
+            'publisherName'                 => data_get(
                 $meta,
                 'metadata.summary.publisher.name',
                 data_get($meta, 'metadata.summary.publisher.publisherName', '')
             ),
-            'dataType' => array_values(array_filter(explode(';,;', $dataType))),
-            'populationSize' => (int) data_get($meta, 'metadata.summary.populationSize', -1),
-            'geographicLocation' => $this->spatialCoverage->pluck('region')->all(),
-            'datasetDOI' => data_get($meta, 'metadata.summary.doiName', ''),
-            'conformsTo' => array_values(array_filter(explode(';,;', $conformsTo))),
-            'structuralTableNames' => collect($structural)
-                ->pluck('name')
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
-            'structuralColumnNames' => collect($structural)
-                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
-            'structuralColumnDescriptions' => collect($structural)
-                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
-                ->filter(fn ($v) => is_string($v) && $v !== '')
-                ->values()->all(),
+            'dataType'                      => array_values(array_filter(explode(';,;', $dataType))),
+            'populationSize'                => (int) data_get($meta, 'metadata.summary.populationSize', -1),
+            'geographicLocation'            => $this->spatialCoverage->pluck('region')->all(),
+            'datasetDOI'                    => data_get($meta, 'metadata.summary.doiName', ''),
+            'conformsTo'                    => array_values(array_filter(explode(';,;', $conformsTo))),
+            'structuralTableNames'          => collect($structural)
+                                                ->pluck('name')
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
+            'structuralColumnNames'         => collect($structural)
+                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
+            'structuralColumnDescriptions'  => collect($structural)
+                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
+                                                ->filter(fn ($v) => is_string($v) && $v !== '')
+                                                ->values()->all(),
         ];
     }
 

--- a/app/Models/DatasetVersionHasDatasetVersion.php
+++ b/app/Models/DatasetVersionHasDatasetVersion.php
@@ -24,6 +24,9 @@ class DatasetVersionHasDatasetVersion extends Model
         'linkage_type',
         'direct_linkage',
         'description',
+        'raw_url',
+        'raw_pid',
+        'raw_title',
     ];
 
     /**

--- a/app/Models/DatasetVersionHasDatasetVersion.php
+++ b/app/Models/DatasetVersionHasDatasetVersion.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 /**
  * @property string|null $short_title
  * @property int $target_dataset_id
+ *
+ * Populated by the join select in Gwdm2xHandler::afterRead() (d.id as dataset_id, d.pid):
+ * @property-read int|null $dataset_id
+ * @property-read string|null $pid
  */
 class DatasetVersionHasDatasetVersion extends Model
 {

--- a/app/Models/PublicationHasDatasetVersion.php
+++ b/app/Models/PublicationHasDatasetVersion.php
@@ -25,6 +25,7 @@ class PublicationHasDatasetVersion extends Model
         'dataset_version_id',
         'link_type',
         'description',
+        'raw_doi',
     ];
 
     protected $dates = ['deleted_at'];

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -225,7 +225,7 @@ class DatasetService
      * Supports the same x-gwdm-version header and schema_model/schema_version
      * TRASER translation as the full show path.
      *
-     * @return array{gwdmVersion: string, metadata: array}
+     * @return array{gwdmVersion?: string, metadata?: array} empty when the dataset has no version rows
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException when the requested GWDM version has no rows
      * @throws \InvalidArgumentException when schema_model/schema_version are mismatched
@@ -342,17 +342,19 @@ class DatasetService
 
     public function getMetadataVersionSummary(Dataset $dataset): array
     {
-        $rows = DatasetVersion::where('dataset_id', $dataset->id)
-            ->selectRaw('gwdm_version, count(*) as count')
-            ->groupBy('gwdm_version')
+        // countBy() over the plucked version strings avoids selecting a `count`
+        // aggregate alias onto the Eloquent model (which phpstan cannot see as a
+        // property). Keys stay in ascending gwdm_version order via the orderBy.
+        $counts = DatasetVersion::where('dataset_id', $dataset->id)
             ->orderBy('gwdm_version')
-            ->get();
+            ->pluck('gwdm_version')
+            ->countBy();
 
         return [
-            'total_versions' => $rows->sum('count'),
-            'gwdm_versions' => $rows->map(fn ($r) => [
-                'gwdm_version' => $r->gwdm_version,
-                'count' => (int) $r->count,
+            'total_versions' => $counts->sum(),
+            'gwdm_versions' => $counts->map(fn (int $count, string $version) => [
+                'gwdm_version' => $version,
+                'count' => $count,
             ])->values()->all(),
         ];
     }

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -200,7 +200,7 @@ class DatasetService
                     throw new \RuntimeException($traserError);
                 }
 
-                $withLinks->metadata = json_encode(['metadata' => $translated['metadata']]);
+                $withLinks->metadata = ['metadata' => $translated['metadata']];
             } else {
                 $withLinks->metadata = $envelope;
             }
@@ -752,6 +752,8 @@ class DatasetService
             })
             ->select([
                 'dataset_version_has_dataset_version.linkage_type',
+                'dataset_version_has_dataset_version.raw_url',
+                'dataset_version_has_dataset_version.raw_title',
                 'dataset_versions.short_title',
                 'datasets.id as target_dataset_id',
             ])
@@ -876,6 +878,7 @@ class DatasetService
         int $targetVersion,
         bool $validate = true,
         ?DatasetVersion $prefetched = null,
+        bool $applySupplementary = true,
     ): array {
         $row = $prefetched ?? DatasetVersion::where('dataset_id', $datasetId)
             ->where('version', $targetVersion)
@@ -902,9 +905,14 @@ class DatasetService
         }
 
         // For 3.0+, afterRead() merges supplementary data from structured SQL tables.
-        $supplementary = $handler->afterRead($row);
-        if (! empty($supplementary)) {
-            $gwdm = array_merge($gwdm, $supplementary);
+        // Skipped when the caller is itself the writer of those tables (e.g.
+        // extractLinkages()), to avoid a circular read that would feed stale
+        // junction-table data back into the very rows being rewritten.
+        if ($applySupplementary) {
+            $supplementary = $handler->afterRead($row);
+            if (! empty($supplementary)) {
+                $gwdm = array_merge($gwdm, $supplementary);
+            }
         }
 
         // Validate the reconstructed metadata only when explicitly requested.
@@ -1047,44 +1055,11 @@ class DatasetService
             return $dv;
         });
 
-        // -----------------------------------------------------------------------
-        // Relation pivot table updates — DISCUSSION POINT FOR REVIEW
-        // -----------------------------------------------------------------------
-        // When a new version is persisted (delta or snapshot) the spatial coverage
-        // pivot table (dataset_version_has_spatial_coverage) should be updated
-        // to reflect the new version's coverage values.
-        //
-        // Currently mapCoverage() is only called during create(), which means
-        // existing version rows correctly reflect coverage at v1 but subsequent
-        // version rows have no pivot entries. This gap was pre-existing before
-        // delta versioning was introduced, but becomes more visible now that
-        // updates genuinely create new rows.
-        //
-        // The call below addresses spatial coverage. Questions for review:
-        //
-        //  1. Should the call use the FULL new metadata or only the GWDM portion?
-        //     mapCoverage() expects the shape { metadata: {...GWDM...} }, so we
-        //     reconstruct a compatible envelope here.
-        //
-        //  2. Should the old version's coverage rows be soft-deleted (or at least
-        //     flagged) when a new version supersedes them? At present coverage rows
-        //     accumulate across versions, which is used intentionally by
-        //     Dataset::getAllSpatialCoveragesAttribute() to union coverage across
-        //     all version rows. Whether that union is still desirable now that each
-        //     version has its own row is worth discussing.
-        //
-        //  3. Named entities (dataset_version_has_named_entities) are populated
-        //     asynchronously by the TermExtraction job and do NOT need to be
-        //     handled here — the job already receives the new version ID via
-        //     dispatchJobs() above.
-        //
-        //  4. Tool linkages (dataset_version_has_tool) are managed externally
-        //     (not set during a metadata update) and are therefore intentionally
-        //     omitted here.
-        //
-        // TODO: revisit points 2 and 3 in a follow-up ticket once the overall
-        //       per-version vs. cross-version model is confirmed.
-        // -----------------------------------------------------------------------
+        // Sync the spatial coverage pivot for this new version. mapCoverage()
+        // upserts the version's coverage rows and prunes stale ones, and
+        // Dataset::getAllSpatialCoveragesAttribute() reads only the latest
+        // version's rows — so coverage reflects the current metadata, not a
+        // union across all historical versions.
         $envelopeForCoverage = [
             'metadata' => $newGwdmMetadata,
         ];
@@ -1171,32 +1146,41 @@ class DatasetService
         $allCoverages = SpatialCoverage::all();
         $ukCoverages = $allCoverages->filter(fn ($c) => $c->region !== 'Rest of the world');
         $worldId = $allCoverages->firstWhere('region', 'Rest of the world')?->id;
-        $matchFound = false;
+
+        // Collect the coverage IDs this version should map to, then sync the pivot
+        // (upsert desired + prune stale) so editing coverage DOWN actually removes
+        // entries rather than accumulating them.
+        $desiredIds = [];
 
         foreach ($ukCoverages as $c) {
             if (str_contains($coverage, strtolower($c->region))) {
-                DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id' => (int) $version->id,
-                    'spatial_coverage_id' => (int) $c->id,
-                ]);
-                $matchFound = true;
+                $desiredIds[] = (int) $c->id;
             }
         }
 
-        if (! $matchFound) {
+        if (empty($desiredIds)) {
             if (str_contains($coverage, 'united kingdom')) {
                 foreach ($ukCoverages as $c) {
-                    DatasetVersionHasSpatialCoverage::updateOrCreate([
-                        'dataset_version_id' => (int) $version->id,
-                        'spatial_coverage_id' => (int) $c->id,
-                    ]);
+                    $desiredIds[] = (int) $c->id;
                 }
-            } else {
-                DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id' => (int) $version->id,
-                    'spatial_coverage_id' => (int) $worldId,
-                ]);
+            } elseif ($worldId !== null) {
+                $desiredIds[] = (int) $worldId;
             }
         }
+
+        foreach ($desiredIds as $coverageId) {
+            DatasetVersionHasSpatialCoverage::updateOrCreate([
+                'dataset_version_id' => (int) $version->id,
+                'spatial_coverage_id' => $coverageId,
+            ]);
+        }
+
+        // Prune any pivot rows for this version no longer present in the metadata.
+        DatasetVersionHasSpatialCoverage::where('dataset_version_id', (int) $version->id)
+            ->when(
+                ! empty($desiredIds),
+                fn ($q) => $q->whereNotIn('spatial_coverage_id', $desiredIds),
+            )
+            ->delete();
     }
 }

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -2,16 +2,18 @@
 
 namespace App\Services;
 
-use Config;
+use App\Context\GwdmVersionContext;
+use App\Jobs\LinkageExtraction;
+use App\Jobs\TermExtraction;
+use App\Models\DataAccessTemplate;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\DatasetVersionHasDatasetVersion;
 use App\Models\DatasetVersionHasSpatialCoverage;
-use App\Models\DataAccessTemplate;
 use App\Models\SpatialCoverage;
 use App\Models\Team;
-use App\Jobs\TermExtraction;
-use App\Jobs\LinkageExtraction;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Config;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -31,6 +33,11 @@ class DatasetService
      */
     private const SNAPSHOT_INTERVAL = 10;
 
+    public function __construct(
+        private readonly GwdmVersionContext $gwdmVersionContext,
+        private readonly GwdmHandlerFactory $handlerFactory,
+    ) {}
+
     public function list(
         ?string $filterStatus,
         ?string $filterTitle,
@@ -38,7 +45,7 @@ class DatasetService
         int $perPage,
         ?string $partnerContext = null,
     ): LengthAwarePaginator {
-        if (!empty($filterTitle)) {
+        if (! empty($filterTitle)) {
             // Use a subquery for the status filter to avoid materialising all IDs.
             // The unique-per-dataset deduplication still requires PHP-side processing
             // because MySQL lacks a portable "latest version per group" without window
@@ -46,7 +53,7 @@ class DatasetService
             $statusSubquery = Dataset::query()
                 ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
                 ->when(
-                    $partnerContext && ($partnerContext !== 'HDRUK' || !config('partners.allow_cross_context_read', true)),
+                    $partnerContext && ($partnerContext !== 'HDRUK' || ! config('partners.allow_cross_context_read', true)),
                     fn ($q) => $q->where('partner_context', $partnerContext)
                 )
                 ->select('id');
@@ -64,7 +71,7 @@ class DatasetService
             $query = Dataset::query()
                 ->when($filterStatus, fn ($q) => $q->where('status', $filterStatus))
                 ->when(
-                    $partnerContext && ($partnerContext !== 'HDRUK' || !config('partners.allow_cross_context_read', true)),
+                    $partnerContext && ($partnerContext !== 'HDRUK' || ! config('partners.allow_cross_context_read', true)),
                     fn ($q) => $q->where('partner_context', $partnerContext)
                 );
         }
@@ -93,105 +100,212 @@ class DatasetService
      * Replaces DatasetsV2Helpers@getDatasetDetails. All counts are pre-computed
      * here so the Resource's toArray() runs no queries.
      *
-     * @throws \InvalidArgumentException  when schema_model/schema_version are mismatched
-     * @throws \RuntimeException          when MMC translation fails
+     * @throws \InvalidArgumentException when schema_model/schema_version are mismatched
+     * @throws \RuntimeException when MMC translation fails
      */
     public function prepareForShow(
         Dataset $dataset,
         ?string $outputSchemaModel = null,
         ?string $outputSchemaVersion = null,
-    ): Dataset {
+    ): Dataset|string {
         $dataset->loadMissing('team');
 
-        $latestVersionId = $dataset->latestVersionID($dataset->id);
+        $requestedGwdmVersion = $this->gwdmVersionContext->requestedVersion();
 
-        // Cache version IDs on the model so that each allActive* accessor
-        // (tools, collections, durs, publications, namedEntities) reuses this
-        // result instead of re-querying the same versions table 5 times.
-        $dataset->cachedVersionIds = $dataset->versions()->pluck('id')->toArray();
+        // Single query replaces latestVersionID() + versions()->pluck('id') — two
+        // separate dataset_versions round-trips in the original code.
+        $allVersions = $dataset->versions()
+            ->select(['id', 'version', 'gwdm_version'])
+            ->orderBy('version', 'desc')
+            ->get();
 
-        $activeCollections  = $dataset->allActiveCollections ?? [];
-        $activeDurs         = $dataset->allActiveDurs ?? [];
+        // Cache version IDs so each allActive* accessor reuses this result instead
+        // of re-querying the same versions table independently.
+        $dataset->cachedVersionIds = $allVersions->pluck('id')->toArray();
+
+        if ($requestedGwdmVersion !== null) {
+            $latestVersionRow = $allVersions->firstWhere('gwdm_version', $requestedGwdmVersion);
+            if ($latestVersionRow === null) {
+                throw new \Illuminate\Database\Eloquent\ModelNotFoundException(
+                    "No dataset version found with GWDM version '{$requestedGwdmVersion}'."
+                );
+            }
+            $latestVersionId = $latestVersionRow->id;
+        } else {
+            $latestVersionId = $allVersions->first()?->id;
+        }
+
+        $activeCollections = $dataset->allActiveCollections ?? [];
+        $activeDurs = $dataset->allActiveDurs ?? [];
         $activePublications = $dataset->allActivePublications ?? [];
 
-        // Derive counts directly from the already-loaded collections rather than
-        // issuing separate COUNT queries against the database.
-        $dataset->durs_count         = collect($activeDurs)->filter(
+        $dataset->durs_count = count(array_filter(
+            $activeDurs,
             fn ($d) => in_array($latestVersionId, $d['dataset_version_ids'] ?? [])
-        )->count();
-        $dataset->publications_count = collect($activePublications)->filter(
-            fn ($p) => collect($p['dataset_versions'] ?? [])->contains('dataset_version_id', $latestVersionId)
-        )->count();
-        $dataset->tools_count        = count($dataset->allActiveTools);
-        $dataset->collections_count  = count($activeCollections);
-        $dataset->spatialCoverage    = $dataset->allSpatialCoverages ?? [];
-        $dataset->durs               = $activeDurs;
-        $dataset->publications       = $activePublications;
-        $dataset->named_entities     = $dataset->allNamedEntities ?? [];
-        $dataset->collections        = $activeCollections;
+        ));
+        $dataset->publications_count = count(array_filter(
+            $activePublications,
+            fn ($p) => in_array($latestVersionId, array_column($p['dataset_versions'] ?? [], 'dataset_version_id'))
+        ));
+        $dataset->tools_count = count($dataset->allActiveTools);
+        $dataset->collections_count = count($activeCollections);
+        $dataset->spatialCoverage = $dataset->allSpatialCoverages ?? [];
+        $dataset->durs = $activeDurs;
+        $dataset->publications = $activePublications;
+        $dataset->named_entities = $dataset->allNamedEntities ?? [];
+        $dataset->collections = $activeCollections;
 
-        if ($outputSchemaModel && $outputSchemaVersion) {
-            $latestVersion = $dataset->latestVersion();
-            // Reconstruct the full GWDM metadata for the latest version before
-            // passing to TRASER; the version row may be a delta.
-            $fullMetadata = $this->getReconstructedMetadataEnvelope($dataset->id, $latestVersion->version);
+        if ($outputSchemaModel && ! $outputSchemaVersion) {
+            throw new \InvalidArgumentException('schema_model provided without schema_version');
+        }
+        if ($outputSchemaVersion && ! $outputSchemaModel) {
+            throw new \InvalidArgumentException('schema_version provided without schema_model');
+        }
+
+        $translateRequested = $outputSchemaModel && $outputSchemaVersion;
+
+        // Reduced relation set is sufficient for the TRASER path (metadata is replaced
+        // entirely by the translation result). No-translation path needs the full graph.
+        $loadRelation = $translateRequested ? 'reducedLinkedDatasetVersions' : 'linkedDatasetVersions';
+
+        $withLinks = DatasetVersion::where('id', $latestVersionId)
+            ->with([$loadRelation])
+            ->first();
+
+        if ($withLinks) {
+            // Always reconstruct via the handler system. The handler encapsulates the
+            // storage strategy: 2.x reads from the JSON blob; 3.0 reads from SQL tables.
+            // Validation runs only when TRASER translation is requested so that TRASER
+            // is not a hard dependency for every read.
+            $envelope = $this->getReconstructedMetadataEnvelope(
+                $dataset->id,
+                $withLinks->version,
+                validate: $translateRequested,
+                prefetched: $withLinks,
+            );
+
+            if ($translateRequested) {
+                $translated = MMC::translateDataModelType(
+                    json_encode($envelope),
+                    $outputSchemaModel,
+                    $outputSchemaVersion,
+                    Config::get('metadata.GWDM.name'),
+                    $envelope['gwdmVersion'],
+                );
+
+                if (! $translated['wasTranslated']) {
+                    $traserError = is_array($translated['traser_message'])
+                        ? json_encode($translated['traser_message'])
+                        : ($translated['traser_message'] ?? 'unknown error');
+                    throw new \RuntimeException($traserError);
+                }
+
+                $withLinks->metadata = json_encode(['metadata' => $translated['metadata']]);
+            } else {
+                $withLinks->metadata = $envelope;
+            }
+
+            $dataset->setRelation('versions', collect([$withLinks]));
+        }
+
+        $dataset->linkages = $this->getLinkages($latestVersionId);
+
+        $dataset->team->has_published_dar_template = DataAccessTemplate::where('team_id', $dataset->team->id)
+            ->where('published', 1)
+            ->exists();
+
+        return $dataset;
+    }
+
+    /**
+     * Fast path for ?view=metadataOnly — skips all relation loading (DURs, tools,
+     * collections, publications, named entities, linkages, team DAR check) and
+     * returns only the reconstructed GWDM metadata envelope.
+     *
+     * Supports the same x-gwdm-version header and schema_model/schema_version
+     * TRASER translation as the full show path.
+     *
+     * @return array{gwdmVersion: string, metadata: array}
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException when the requested GWDM version has no rows
+     * @throws \InvalidArgumentException when schema_model/schema_version are mismatched
+     * @throws \RuntimeException when TRASER translation fails
+     */
+    public function getMetadataOnly(
+        Dataset $dataset,
+        ?string $outputSchemaModel = null,
+        ?string $outputSchemaVersion = null,
+    ): array {
+        if ($outputSchemaModel && ! $outputSchemaVersion) {
+            throw new \InvalidArgumentException('schema_model provided without schema_version');
+        }
+        if ($outputSchemaVersion && ! $outputSchemaModel) {
+            throw new \InvalidArgumentException('schema_version provided without schema_model');
+        }
+
+        $requestedGwdmVersion = $this->gwdmVersionContext->requestedVersion();
+
+        $allVersions = $dataset->versions()
+            ->select(['id', 'version', 'gwdm_version'])
+            ->orderBy('version', 'desc')
+            ->get();
+
+        if ($requestedGwdmVersion !== null) {
+            $row = $allVersions->firstWhere('gwdm_version', $requestedGwdmVersion);
+            if ($row === null) {
+                throw new \Illuminate\Database\Eloquent\ModelNotFoundException(
+                    "No dataset version found with GWDM version '{$requestedGwdmVersion}'."
+                );
+            }
+            $latestVersionId = $row->id;
+        } else {
+            $latestVersionId = $allVersions->first()?->id;
+        }
+
+        $translateRequested = $outputSchemaModel && $outputSchemaVersion;
+
+        // Only need linked versions when translating via TRASER.
+        $dv = $translateRequested
+            ? DatasetVersion::where('id', $latestVersionId)->with(['reducedLinkedDatasetVersions'])->first()
+            : DatasetVersion::find($latestVersionId);
+
+        if (! $dv) {
+            return [];
+        }
+
+        $envelope = $this->getReconstructedMetadataEnvelope(
+            $dataset->id,
+            $dv->version,
+            validate: $translateRequested,
+            prefetched: $dv,
+        );
+
+        if ($translateRequested) {
             $translated = MMC::translateDataModelType(
-                json_encode($fullMetadata),
+                json_encode($envelope),
                 $outputSchemaModel,
                 $outputSchemaVersion,
                 Config::get('metadata.GWDM.name'),
-                Config::get('metadata.GWDM.version'),
+                $envelope['gwdmVersion'],
             );
 
-            if (!$translated['wasTranslated']) {
-                throw new \RuntimeException('Failed to translate metadata to requested schema');
+            if (! $translated['wasTranslated']) {
+                $traserError = is_array($translated['traser_message'])
+                    ? json_encode($translated['traser_message'])
+                    : ($translated['traser_message'] ?? 'unknown error');
+                throw new \RuntimeException($traserError);
             }
 
-            $withLinks = DatasetVersion::where('id', $latestVersion->id)
-                ->with(['reducedLinkedDatasetVersions'])
-                ->first();
-            $withLinks->metadata = json_encode(['metadata' => $translated['metadata']]);
-            $dataset->setRelation('versions', [$withLinks]);
-            $dataset->linkages = $this->getLinkages($latestVersionId, $withLinks->metadata);
-
-        } elseif ($outputSchemaModel) {
-            throw new \InvalidArgumentException('schema_model provided without schema_version');
-        } elseif ($outputSchemaVersion) {
-            throw new \InvalidArgumentException('schema_version provided without schema_model');
-        } else {
-            $withLinks = DatasetVersion::where('id', $latestVersionId)
-                ->with(['linkedDatasetVersions'])
-                ->first();
-
-            if ($withLinks) {
-                // If the latest version is a delta, inject the reconstructed full
-                // metadata so the Resource sees a consistent envelope regardless of
-                // whether the row is a snapshot or a delta.
-                if ($withLinks->patch !== null) {
-                    $withLinks->metadata = $this->getReconstructedMetadataEnvelope(
-                        $dataset->id,
-                        $withLinks->version
-                    );
-                }
-
-                $dataset->setRelation('versions', [$withLinks]);
-            }
-
-            // Pass the already-fetched metadata so getLinkages does not need to
-            // re-query the version row for its linkage section.
-            $dataset->linkages = $this->getLinkages(
-                $latestVersionId,
-                $withLinks?->metadata
-            );
+            return [
+                'gwdmVersion' => $envelope['gwdmVersion'],
+                'metadata' => $translated['metadata'],
+            ];
         }
 
-        $teamPublishedDARTemplates = DataAccessTemplate::where([
-            ['team_id', $dataset->team->id],
-            ['published', 1],
-        ])->pluck('id');
-        $dataset->team->has_published_dar_template = !$teamPublishedDARTemplates->isEmpty();
-
-        return $dataset;
+        return [
+            'gwdmVersion' => $envelope['gwdmVersion'],
+            'metadata' => $envelope['metadata'],
+        ];
     }
 
     /**
@@ -207,7 +321,7 @@ class DatasetService
             ->where('version', $version)
             ->exists();
 
-        if (!$exists) {
+        if (! $exists) {
             return null;
         }
 
@@ -226,6 +340,82 @@ class DatasetService
             ->get();
     }
 
+    public function getMetadataVersionSummary(Dataset $dataset): array
+    {
+        $rows = DatasetVersion::where('dataset_id', $dataset->id)
+            ->selectRaw('gwdm_version, count(*) as count')
+            ->groupBy('gwdm_version')
+            ->orderBy('gwdm_version')
+            ->get();
+
+        return [
+            'total_versions' => $rows->sum('count'),
+            'gwdm_versions' => $rows->map(fn ($r) => [
+                'gwdm_version' => $r->gwdm_version,
+                'count' => (int) $r->count,
+            ])->values()->all(),
+        ];
+    }
+
+    /**
+     * Validate every stored version of a dataset against TRASER.
+     *
+     * Reconstructs each version's full GWDM metadata and posts it to the TRASER
+     * /validate endpoint. Each version is validated independently — one failure
+     * does not abort the rest. Returns per-version results with any TRASER error
+     * details.
+     *
+     * @return array<int, array{version: int, gwdm_version: string, valid: bool, errors: mixed}>
+     */
+    public function validateAllVersions(Dataset $dataset): array
+    {
+        $versions = DatasetVersion::where('dataset_id', $dataset->id)
+            ->select(['id', 'version', 'gwdm_version', 'created_at', 'title', 'short_title'])
+            ->orderBy('version')
+            ->get();
+
+        $results = [];
+        $schemaName = Config::get('metadata.GWDM.name');
+
+        foreach ($versions as $row) {
+            $versionNum = $row->version;
+            $gwdmVersion = $row->gwdm_version
+                ?? $this->gwdmVersionContext->targetVersion();
+
+            try {
+                $gwdm = $this->reconstructGwdmMetadata($dataset->id, $versionNum);
+                $handler = $this->handlerFactory->resolve($gwdmVersion);
+
+                $supplementary = $handler->afterRead($row);
+                if (! empty($supplementary)) {
+                    $gwdm = array_merge($gwdm, $supplementary);
+                }
+
+                $metadataJson = json_encode(['metadata' => $gwdm]);
+                $result = MMC::validateDataModelTypeWithErrors($metadataJson, $schemaName, $gwdmVersion);
+
+                $results[] = [
+                    'version' => $versionNum,
+                    'gwdm_version' => $gwdmVersion,
+                    'created_at' => $row->created_at,
+                    'required_issued' => $gwdm['required']['issued'] ?? null,
+                    'valid' => $result['valid'],
+                    'errors' => $result['errors'],
+                ];
+            } catch (\Throwable $e) {
+                $results[] = [
+                    'version' => $versionNum,
+                    'gwdm_version' => $gwdmVersion,
+                    'created_at' => $row->created_at,
+                    'valid' => false,
+                    'errors' => $e->getMessage(),
+                ];
+            }
+        }
+
+        return $results;
+    }
+
     /**
      * Create a new dataset, translating metadata via MMC/TRASER.
      *
@@ -242,82 +432,94 @@ class DatasetService
     ): array {
         $input['metadata'] = $this->extractMetadata($input['metadata']);
 
-        $payload            = $input['metadata'];
-        $payload['extra']   = [
-            'id'            => 'placeholder',
-            'pid'           => 'placeholder',
-            'datasetType'   => 'Health and disease',
-            'publisherId'   => $team->pid,
+        $payload = $input['metadata'];
+        $payload['extra'] = [
+            'id' => 'placeholder',
+            'pid' => 'placeholder',
+            'datasetType' => 'Health and disease',
+            'publisherId' => $team->pid,
             'publisherName' => $team->name,
         ];
 
-        $isDraft        = $input['status'] === Dataset::STATUS_DRAFT;
+        $targetGwdmVersion = $this->gwdmVersionContext->targetVersion();
+        $isDraft = $input['status'] === Dataset::STATUS_DRAFT;
         $traserResponse = MMC::translateDataModelType(
             json_encode($payload),
             Config::get('metadata.GWDM.name'),
-            Config::get('metadata.GWDM.version'),
+            $targetGwdmVersion,
             $inputSchema,
             $inputVersion,
-            !$isDraft,
-            !$isDraft,
+            ! $isDraft,
+            ! $isDraft,
         );
 
-        if (!$traserResponse['wasTranslated']) {
+        if (! $traserResponse['wasTranslated']) {
             return ['translated' => false, 'response' => $traserResponse];
         }
 
         $input['metadata']['original_metadata'] = $input['metadata']['metadata'];
-        $input['metadata']['metadata']           = $traserResponse['metadata'];
+        $input['metadata']['metadata'] = $traserResponse['metadata'];
 
-        $pid               = $input['pid'] ?? (string) Str::uuid();
+        $pid = $input['pid'] ?? (string) Str::uuid();
         $isCohortDiscovery = $input['is_cohort_discovery'] ?? false;
 
         $dataset = MMC::createDataset([
-            'user_id'             => $input['user_id'],
-            'team_id'             => $input['team_id'],
-            'mongo_object_id'     => $input['mongo_object_id'] ?? null,
-            'mongo_id'            => $input['mongo_id'] ?? null,
-            'mongo_pid'           => $input['mongo_pid'] ?? null,
-            'datasetid'           => $input['datasetid'] ?? null,
-            'created'             => now(),
-            'updated'             => now(),
-            'submitted'           => now(),
-            'pid'                 => $pid,
-            'create_origin'       => $input['create_origin'],
-            'status'              => $input['status'],
+            'user_id' => $input['user_id'],
+            'team_id' => $input['team_id'],
+            'mongo_object_id' => $input['mongo_object_id'] ?? null,
+            'mongo_id' => $input['mongo_id'] ?? null,
+            'mongo_pid' => $input['mongo_pid'] ?? null,
+            'datasetid' => $input['datasetid'] ?? null,
+            'created' => now(),
+            'updated' => now(),
+            'submitted' => now(),
+            'pid' => $pid,
+            'create_origin' => $input['create_origin'],
+            'status' => $input['status'],
             'is_cohort_discovery' => $isCohortDiscovery,
-            'partner_context'     => $partnerContext,
+            'partner_context' => $partnerContext,
         ]);
 
-        $required = $this->buildRequiredBlock($dataset, 1);
+        $handler = $this->handlerFactory->resolve($targetGwdmVersion);
+        $gwdm = $handler->prepareMetadata(
+            $input['metadata']['metadata'],
+            $dataset,
+            $team,
+            1,
+        );
+        $envelope = $handler->buildEnvelope($gwdm, $input['metadata']['original_metadata']);
+        [$title, $shortTitle] = $handler->extractTitleFields($gwdm);
 
-        if (version_compare(Config::get('metadata.GWDM.version'), '1.1', '<')) {
-            $input['metadata']['metadata']['summary']['publisher'] = [
-                'publisherId'   => $team->pid,
-                'publisherName' => $team->name,
-            ];
-        } else {
-            $required['version'] = $input['metadata']['metadata']['required']['version']
-                ?? $this->formatVersion(1);
-        }
+        // Create the base version row and its handler-owned structured tables
+        // atomically so a GWDM 3.0 section-write failure cannot leave an orphaned
+        // version with no metadata (see persistMetadataVersion for the same rule).
+        $version = DB::transaction(function () use (
+            $dataset,
+            $envelope,
+            $title,
+            $shortTitle,
+            $targetGwdmVersion,
+            $handler,
+            $gwdm,
+        ) {
+            $version = MMC::createDatasetVersion([
+                'dataset_id' => $dataset->id,
+                'metadata' => json_encode($envelope),
+                'version' => 1,
+                // Base snapshot — no patch; title/short_title populated explicitly now
+                // that the columns are no longer GENERATED (see migration 2026_03_11_133601).
+                'patch' => null,
+                'title' => $title,
+                'short_title' => $shortTitle,
+                'gwdm_version' => $targetGwdmVersion,
+            ]);
 
-        $input['metadata']['metadata']['required'] = $required;
-        $input['metadata']['gwdmVersion']          = Config::get('metadata.GWDM.version');
+            $handler->afterStore($dataset, $version, $gwdm);
 
-        [$title, $shortTitle] = $this->extractTitleFields($input['metadata']['metadata']);
+            return $version;
+        });
 
-        $version = MMC::createDatasetVersion([
-            'dataset_id'  => $dataset->id,
-            'metadata'    => json_encode($input['metadata']),
-            'version'     => 1,
-            // Base snapshot — no patch; title/short_title populated explicitly now
-            // that the columns are no longer GENERATED (see migration 2026_03_11_133601).
-            'patch'       => null,
-            'title'       => $title,
-            'short_title' => $shortTitle,
-        ]);
-
-        $this->mapCoverage($input['metadata'], $version);
+        $this->mapCoverage(['metadata' => $gwdm], $version);
         $this->dispatchJobs($dataset, $version->id, $input['metadata']['metadata'], $elasticIndexing, $input['status']);
 
         return [
@@ -349,64 +551,67 @@ class DatasetService
     ): int {
         $payload = $this->extractMetadata($input['metadata']);
         $payload['extra'] = [
-            'id'            => $dataset->id,
-            'pid'           => $dataset->pid,
-            'datasetType'   => 'Health and disease',
-            'publisherId'   => $team->pid,
+            'id' => $dataset->id,
+            'pid' => $dataset->pid,
+            'datasetType' => 'Health and disease',
+            'publisherId' => $team->pid,
             'publisherName' => $team->name,
         ];
 
-        $inputSchema       = $input['metadata']['schemaModel'] ?? null;
-        $inputVersion      = $input['metadata']['schemaVersion'] ?? null;
+        $inputSchema = $input['metadata']['schemaModel'] ?? null;
+        $inputVersion = $input['metadata']['schemaVersion'] ?? null;
         $submittedMetadata = $input['metadata'];
-        $isDraft           = $input['status'] === Dataset::STATUS_DRAFT;
+        $isDraft = $input['status'] === Dataset::STATUS_DRAFT;
+        $targetGwdmVersion = $this->gwdmVersionContext->targetVersion();
 
         $traserResponse = MMC::translateDataModelType(
             json_encode($payload),
             Config::get('metadata.GWDM.name'),
-            Config::get('metadata.GWDM.version'),
+            $targetGwdmVersion,
             $inputSchema,
             $inputVersion,
-            !$isDraft,
-            !$isDraft,
+            ! $isDraft,
+            ! $isDraft,
         );
 
-        if (!$traserResponse['wasTranslated']) {
+        if (! $traserResponse['wasTranslated']) {
             throw new \RuntimeException('metadata is in an unknown format and cannot be processed');
         }
 
         $versionNumber = $dataset->lastMetadataVersionNumber()->version;
-
-        // Rebuild required.revisions to include all existing versions plus the
-        // new one that is about to be written. This fixes a pre-existing gap
-        // where the revisions array was only ever set on creation (version 1).
         $newVersionNumber = $versionNumber + 1;
-        $traserResponse['metadata']['required'] = array_merge(
-            $traserResponse['metadata']['required'] ?? [],
-            $this->buildRequiredBlock($dataset, $newVersionNumber)
+
+        $handler = $this->handlerFactory->resolve($targetGwdmVersion);
+        $gwdm = $handler->prepareMetadata(
+            $traserResponse['metadata'],
+            $dataset,
+            $team,
+            $newVersionNumber,
         );
 
         $dataset->update([
-            'user_id'             => $userId,
-            'team_id'             => $teamId,
-            'updated'             => now(),
-            'pid'                 => $dataset->pid,
-            'create_origin'       => $createOrigin,
-            'status'              => $input['status'],
+            'user_id' => $userId,
+            'team_id' => $teamId,
+            'updated' => now(),
+            'pid' => $dataset->pid,
+            'create_origin' => $createOrigin,
+            'status' => $input['status'],
             'is_cohort_discovery' => $input['is_cohort_discovery'] ?? false,
         ]);
 
         $datasetVersionId = $this->persistMetadataVersion(
             $dataset,
-            $traserResponse['metadata'],
+            $gwdm,
             $submittedMetadata,
             $versionNumber,
         );
 
-        // TODO - Needs investigation as elastic indexing is handled within Observers
-        // and potentially duplicated here. Ideally, the observers would spawn
-        // jobs for indexing to reduce synchronous network blocking.
-        // $this->dispatchJobs($dataset, $datasetVersionId, $submittedMetadata, $elasticIndexing, $input['status']);
+        // Dispatch LinkageExtraction + TermExtraction. These are complementary to
+        // (not duplicated by) DatasetVersionObserver, which dispatches the Extract*
+        // and indexing jobs on the "created" event — the observer never dispatches
+        // linkage or term extraction. Pass the prepared GWDM object (not the input
+        // wrapper) so the TED payload shape matches create() and updateV2().
+        $this->dispatchJobs($dataset, $datasetVersionId, $gwdm, $elasticIndexing, $input['status']);
 
         return $newVersionNumber;
     }
@@ -429,54 +634,58 @@ class DatasetService
         bool $elasticIndexing,
         Team $team,
     ): int {
-        $payload          = $this->extractMetadata($input['metadata']);
+        $payload = $this->extractMetadata($input['metadata']);
         $payload['extra'] = [
-            'id'            => $dataset->id,
-            'pid'           => $dataset->pid,
-            'datasetType'   => 'Health and disease',
-            'publisherId'   => $team->pid,
+            'id' => $dataset->id,
+            'pid' => $dataset->pid,
+            'datasetType' => 'Health and disease',
+            'publisherId' => $team->pid,
             'publisherName' => $team->name,
         ];
 
-        $inputSchema       = $input['metadata']['schemaModel'] ?? null;
-        $inputVersion      = $input['metadata']['schemaVersion'] ?? null;
+        $inputSchema = $input['metadata']['schemaModel'] ?? null;
+        $inputVersion = $input['metadata']['schemaVersion'] ?? null;
         $submittedMetadata = $input['metadata']['metadata'];
-        $isDraft           = $input['status'] === Dataset::STATUS_DRAFT;
+        $isDraft = $input['status'] === Dataset::STATUS_DRAFT;
+        $targetGwdmVersion = $this->gwdmVersionContext->targetVersion();
 
         $traserResponse = MMC::translateDataModelType(
             json_encode($payload),
             Config::get('metadata.GWDM.name'),
-            Config::get('metadata.GWDM.version'),
+            $targetGwdmVersion,
             $inputSchema,
             $inputVersion,
-            !$isDraft,
-            !$isDraft,
+            ! $isDraft,
+            ! $isDraft,
         );
 
-        if (!$traserResponse['wasTranslated']) {
+        if (! $traserResponse['wasTranslated']) {
             throw new \RuntimeException('metadata is in an unknown format and cannot be processed');
         }
 
         $versionNumber = $dataset->lastMetadataVersionNumber()->version;
 
-        $traserResponse['metadata']['required'] = array_merge(
-            $traserResponse['metadata']['required'] ?? [],
-            $this->buildRequiredBlock($dataset, $versionNumber)
+        $handler = $this->handlerFactory->resolve($targetGwdmVersion);
+        $gwdm = $handler->prepareMetadata(
+            $traserResponse['metadata'],
+            $dataset,
+            $team,
+            $versionNumber,
         );
 
         $dataset->update([
-            'user_id'             => $userId,
-            'team_id'             => $teamId,
-            'updated'             => now(),
-            'pid'                 => $dataset->pid,
-            'create_origin'       => $createOrigin,
-            'status'              => $input['status'],
+            'user_id' => $userId,
+            'team_id' => $teamId,
+            'updated' => now(),
+            'pid' => $dataset->pid,
+            'create_origin' => $createOrigin,
+            'status' => $input['status'],
             'is_cohort_discovery' => $input['is_cohort_discovery'] ?? false,
         ]);
 
         $datasetVersionId = $this->persistMetadataVersionLegacy(
             $dataset,
-            $traserResponse['metadata'],
+            $gwdm,
             $submittedMetadata,
             $versionNumber,
         );
@@ -508,7 +717,7 @@ class DatasetService
     public function updateCohortDiscovery(Dataset $dataset, bool $isCohortDiscovery): void
     {
         if ($dataset->status !== Dataset::STATUS_ACTIVE) {
-            throw new \RuntimeException('Dataset status is ' . strtoupper($dataset->status));
+            throw new \RuntimeException('Dataset status is '.strtoupper($dataset->status));
         }
 
         $dataset->is_cohort_discovery = $isCohortDiscovery;
@@ -521,23 +730,26 @@ class DatasetService
     }
 
     /**
-     * Resolve dataset linkages by merging gateway-tracked relations with
-     * any free-text linkages stored in the metadata's linkage.datasetLinkage field.
-     *
-     * Only returns linkages whose target dataset is ACTIVE.
-     */
     /**
-     * @param array|string|null $preloadedMetadata  Already-decoded metadata array (or JSON string)
-     *                                               from the caller. When provided the extra
-     *                                               DatasetVersion fetch is skipped entirely.
+     * Return dataset linkages for the given version, sourced entirely from SQL.
+     * Resolved rows are joined to datasets; unresolved rows carry the raw reference
+     * data stored during extraction. Only resolved linkages whose target is ACTIVE
+     * are included; unresolved rows are always included.
      */
-    public function getLinkages(int $datasetVersionId, array|string|null $preloadedMetadata = null): array
+    public function getLinkages(int $datasetVersionId): array
     {
-        $datasetLinkages = DatasetVersionHasDatasetVersion::query()
+        // SQL is the complete source of truth for linkage data. Resolved rows are joined
+        // to dataset_versions/datasets; unresolved rows (target_id = NULL) carry the raw
+        // title/url from the original metadata so nothing is discarded.
+        return DatasetVersionHasDatasetVersion::query()
             ->where('dataset_version_has_dataset_version.dataset_version_source_id', $datasetVersionId)
-            ->join('dataset_versions', 'dataset_versions.id', '=', 'dataset_version_has_dataset_version.dataset_version_target_id')
-            ->join('datasets', 'datasets.id', '=', 'dataset_versions.dataset_id')
-            ->where('datasets.status', Dataset::STATUS_ACTIVE)
+            ->where('dataset_version_has_dataset_version.direct_linkage', 1)
+            ->leftJoin('dataset_versions', 'dataset_versions.id', '=', 'dataset_version_has_dataset_version.dataset_version_target_id')
+            ->leftJoin('datasets', 'datasets.id', '=', 'dataset_versions.dataset_id')
+            ->where(function ($q) {
+                $q->whereNull('datasets.id')
+                    ->orWhere('datasets.status', Dataset::STATUS_ACTIVE);
+            })
             ->select([
                 'dataset_version_has_dataset_version.linkage_type',
                 'dataset_versions.short_title',
@@ -545,48 +757,15 @@ class DatasetService
             ])
             ->get()
             ->map(fn ($row) => [
-                'title'        => $row->short_title,
-                'url'          => config('gateway.gateway_url') . '/en/dataset/' . $row->target_dataset_id,
-                'dataset_id'   => $row->target_dataset_id,
+                'title' => $row->short_title ?? $row->raw_title,
+                'url' => $row->target_dataset_id
+                    ? config('gateway.gateway_url').'/en/dataset/'.$row->target_dataset_id
+                    : $row->raw_url,
+                'dataset_id' => $row->target_dataset_id,
                 'linkage_type' => $row->linkage_type,
             ])
             ->values()
             ->toArray();
-
-        if ($preloadedMetadata !== null) {
-            $metadata = is_string($preloadedMetadata)
-                ? json_decode($preloadedMetadata, true)
-                : $preloadedMetadata;
-        } else {
-            $metadata = DatasetVersion::where('id', $datasetVersionId)
-                ->select('metadata')
-                ->first()['metadata'] ?? [];
-        }
-
-        $metadataLinkage = $metadata['metadata']['linkage']['datasetLinkage'] ?? [];
-        $allTitles       = [];
-
-        foreach ($metadataLinkage as $linkageType => $link) {
-            if ($link && is_array($link)) {
-                foreach ($link as $l) {
-                    $allTitles[] = ['title' => $l['title'], 'linkage_type' => $linkageType];
-                }
-            }
-        }
-
-        $gatewayTitles = array_column($datasetLinkages, 'title');
-        foreach ($allTitles as $title) {
-            if ($title['title'] && !in_array($title['title'], $gatewayTitles)) {
-                $datasetLinkages[] = [
-                    'title'        => $title['title'],
-                    'url'          => null,
-                    'dataset_id'   => null,
-                    'linkage_type' => $title['linkage_type'],
-                ];
-            }
-        }
-
-        return $datasetLinkages;
     }
 
     /**
@@ -599,23 +778,28 @@ class DatasetService
         array $previousMetadata,
         int $versionNumber,
     ): int {
-        $metadataSaveObject = [
-            'gwdmVersion'       => Config::get('metadata.GWDM.version'),
-            'metadata'          => $newMetadata,
-            'original_metadata' => $previousMetadata,
-        ];
+        $targetGwdmVersion = $this->gwdmVersionContext->targetVersion();
+        $handler = $this->handlerFactory->resolve($targetGwdmVersion);
 
-        [$title, $shortTitle] = $this->extractTitleFields($newMetadata);
+        $envelope = $handler->buildEnvelope($newMetadata, $previousMetadata);
+        [$title, $shortTitle] = $handler->extractTitleFields($newMetadata);
 
         $dv = DatasetVersion::where([
             'dataset_id' => $dataset->id,
-            'version'    => $versionNumber,
+            'version' => $versionNumber,
         ])->first();
 
-        $dv->metadata    = json_encode($metadataSaveObject);
-        $dv->title       = $title;
-        $dv->short_title = $shortTitle;
-        $dv->save();
+        // Overwrite the version row and rewrite its structured tables atomically
+        // (see persistMetadataVersion for the same rationale).
+        DB::transaction(function () use ($dv, $envelope, $title, $shortTitle, $targetGwdmVersion, $handler, $dataset, $newMetadata) {
+            $dv->metadata = json_encode($envelope);
+            $dv->title = $title;
+            $dv->short_title = $shortTitle;
+            $dv->gwdm_version = $targetGwdmVersion;
+            $dv->save();
+
+            $handler->afterStore($dataset, $dv, $newMetadata);
+        });
 
         return $dv->id;
     }
@@ -632,8 +816,8 @@ class DatasetService
      *
      * The worst-case forward walk is (SNAPSHOT_INTERVAL - 1) delta applications.
      *
-     * @return array  The GWDM metadata object (i.e. the value of metadata.metadata
-     *                in a full snapshot row).
+     * @return array The GWDM metadata object (i.e. the value of metadata.metadata
+     *               in a full snapshot row).
      *
      * @throws \RuntimeException when no base snapshot can be found.
      */
@@ -646,13 +830,18 @@ class DatasetService
             ->orderBy('version', 'desc')
             ->first();
 
-        if (!$snapshot) {
+        if (! $snapshot) {
             throw new \RuntimeException(
                 "No base snapshot found for dataset {$datasetId} at or before version {$targetVersion}."
             );
         }
 
-        $gwdm = $snapshot->metadata['metadata'];
+        $storedData = (array) $snapshot->metadata;
+        $gwdmVersion = $snapshot->gwdm_version
+            ?? $storedData['gwdmVersion']
+            ?? $this->gwdmVersionContext->targetVersion();
+
+        $gwdm = $this->handlerFactory->resolve($gwdmVersion)->extractStoredGwdm($storedData);
 
         if ($snapshot->version === $targetVersion) {
             return $gwdm;
@@ -682,18 +871,61 @@ class DatasetService
      * Build the full metadata envelope ({gwdmVersion, metadata, original_metadata})
      * for a given version, suitable for returning in API responses or passing to TRASER.
      */
-    private function getReconstructedMetadataEnvelope(int $datasetId, int $targetVersion): array
-    {
-        // We always need the row itself for gwdmVersion and original_metadata.
-        $row = DatasetVersion::where('dataset_id', $datasetId)
+    public function getReconstructedMetadataEnvelope(
+        int $datasetId,
+        int $targetVersion,
+        bool $validate = true,
+        ?DatasetVersion $prefetched = null,
+    ): array {
+        $row = $prefetched ?? DatasetVersion::where('dataset_id', $datasetId)
             ->where('version', $targetVersion)
-            ->first(['metadata', 'patch']);
+            ->first();
 
-        $gwdm = $this->reconstructGwdmMetadata($datasetId, $targetVersion);
+        // Prefer the indexed column; fall back to JSON envelope; then context default.
+        $storedVersion = $row->gwdm_version
+            ?? $row->metadata['gwdmVersion']
+            ?? $this->gwdmVersionContext->targetVersion();
+
+        $handler = $this->handlerFactory->resolve($storedVersion);
+
+        // Pre-populate section relations on $row so afterRead() can access them
+        // without firing individual per-section queries. No-op for 2.x handlers.
+        $handler->preloadSections($row);
+
+        // When the prefetched version is itself a full snapshot (patch IS NULL),
+        // extract the stored GWDM directly — skips the snapshot search query
+        // inside reconstructGwdmMetadata on every snapshot row.
+        if ($prefetched !== null && $prefetched->patch === null) {
+            $gwdm = $handler->extractStoredGwdm((array) $prefetched->metadata);
+        } else {
+            $gwdm = $this->reconstructGwdmMetadata($datasetId, $targetVersion);
+        }
+
+        // For 3.0+, afterRead() merges supplementary data from structured SQL tables.
+        $supplementary = $handler->afterRead($row);
+        if (! empty($supplementary)) {
+            $gwdm = array_merge($gwdm, $supplementary);
+        }
+
+        // Validate the reconstructed metadata only when explicitly requested.
+        // Data is validated at write time; re-validating on every read would make
+        // TRASER a hard dependency for all dataset show requests.
+        if ($validate) {
+            $metadataJson = json_encode(['metadata' => $gwdm]);
+            $isValid = MMC::validateDataModelType($metadataJson, Config::get('metadata.GWDM.name'), $storedVersion);
+            if (! $isValid) {
+                \Log::warning('GWDM read validation failed', [
+                    'dataset_id' => $datasetId,
+                    'version' => $targetVersion,
+                    'gwdm_version' => $storedVersion,
+                ]);
+                throw new \RuntimeException("Reconstructed GWDM for version {$storedVersion} failed schema validation.");
+            }
+        }
 
         return [
-            'gwdmVersion'       => $row->metadata['gwdmVersion'] ?? Config::get('metadata.GWDM.version'),
-            'metadata'          => $gwdm,
+            'gwdmVersion' => $storedVersion,
+            'metadata' => $gwdm,
             'original_metadata' => $row->metadata['original_metadata'] ?? [],
         ];
     }
@@ -704,12 +936,12 @@ class DatasetService
      * REARRANGE_ARRAYS prevents the diff engine from emitting a full array
      * replacement when items are merely reordered — keeping patches surgical.
      *
-     * @return array  A JSON-serialisable RFC 6902 patch array.
+     * @return array A JSON-serialisable RFC 6902 patch array.
      */
     private function computePatch(array $from, array $to): array
     {
         $fromObj = json_decode(json_encode($from));
-        $toObj   = json_decode(json_encode($to));
+        $toObj = json_decode(json_encode($to));
 
         $diff = new JsonDiff($fromObj, $toObj, JsonDiff::REARRANGE_ARRAYS);
 
@@ -731,7 +963,7 @@ class DatasetService
      *                 capping the forward-walk cost at ≤ (SNAPSHOT_INTERVAL - 1) deltas for any
      *                 version in the next window.
      *
-     * @return int  The ID of the newly created DatasetVersion row.
+     * @return int The ID of the newly created DatasetVersion row.
      */
     private function persistMetadataVersion(
         Dataset $dataset,
@@ -740,46 +972,80 @@ class DatasetService
         int $versionNumber,
     ): int {
         $newVersionNumber = $versionNumber + 1;
+        $targetGwdmVersion = $this->gwdmVersionContext->targetVersion();
+        $handler = $this->handlerFactory->resolve($targetGwdmVersion);
 
-        [$title, $shortTitle] = $this->extractTitleFields($newGwdmMetadata);
+        [$title, $shortTitle] = $handler->extractTitleFields($newGwdmMetadata);
 
-        $isSnapshot = ($newVersionNumber % self::SNAPSHOT_INTERVAL === 0);
+        // Force a full snapshot when the GWDM schema version changes from the
+        // previous version to this one. A delta patch computed across differing
+        // schemas would be meaningless — and reconstruction resolves the handler
+        // from the nearest snapshot's gwdm_version — so every delta window must
+        // remain schema-homogeneous. The backfill applies the same rule.
+        $previousGwdmVersion = DatasetVersion::where('dataset_id', $dataset->id)
+            ->where('version', $versionNumber)
+            ->value('gwdm_version');
+        $schemaChanged = $previousGwdmVersion !== null && $previousGwdmVersion !== $targetGwdmVersion;
 
-        if ($isSnapshot) {
-            // For every SNAPSHOT_INTERVAL version we write a full snapshot so that
-            // reconstruction never has to walk more than (SNAPSHOT_INTERVAL - 1)
-            // deltas. The shape is identical to the base (v1) row.
-            $envelope = [
-                'gwdmVersion'       => Config::get('metadata.GWDM.version'),
-                'metadata'          => $newGwdmMetadata,
-                'original_metadata' => $previousMetadata,
-            ];
+        $isSnapshot = ($newVersionNumber % self::SNAPSHOT_INTERVAL === 0) || $schemaChanged;
 
-            $dv = DatasetVersion::create([
-                'dataset_id'  => $dataset->id,
-                'metadata'    => json_encode($envelope),
-                // Snapshot version, thus full rebuild of metadata and no patch.
-                'patch'       => null,
-                'version'     => $newVersionNumber,
-                'title'       => $title,
-                'short_title' => $shortTitle,
-            ]);
-        } else {
-            // Delta row: reconstruct the current full GWDM object, diff against
-            // the new metadata to produce a minimal RFC 6902 patch.
-            $currentGwdm = $this->reconstructGwdmMetadata($dataset->id, $versionNumber);
-            $patch       = $this->computePatch($currentGwdm, $newGwdmMetadata);
+        // Persist the version row and its handler-owned structured tables in a
+        // single transaction. Without this, a failure inside afterStore() (e.g.
+        // GWDM 3.0 SQL section writes) would leave a committed version row with
+        // no — or partial — section data. Gwdm30Handler::persist() opens its own
+        // transaction; nested here it becomes a savepoint of this outer one.
+        $dv = DB::transaction(function () use (
+            $isSnapshot,
+            $handler,
+            $dataset,
+            $newGwdmMetadata,
+            $previousMetadata,
+            $newVersionNumber,
+            $versionNumber,
+            $title,
+            $shortTitle,
+            $targetGwdmVersion,
+        ) {
+            if ($isSnapshot) {
+                // For every SNAPSHOT_INTERVAL version we write a full snapshot so that
+                // reconstruction never has to walk more than (SNAPSHOT_INTERVAL - 1)
+                // deltas. The shape is identical to the base (v1) row.
+                $envelope = $handler->buildEnvelope($newGwdmMetadata, $previousMetadata);
 
-            $dv = DatasetVersion::create([
-                'dataset_id'  => $dataset->id,
-                // Patch delta, therefore no metadata stored.
-                'metadata'    => [],
-                'patch'       => $patch,   // array — the cast handles JSON encoding
-                'version'     => $newVersionNumber,
-                'title'       => $title,
-                'short_title' => $shortTitle,
-            ]);
-        }
+                $dv = DatasetVersion::create([
+                    'dataset_id' => $dataset->id,
+                    'metadata' => json_encode($envelope),
+                    // Snapshot version, thus full rebuild of metadata and no patch.
+                    'patch' => null,
+                    'version' => $newVersionNumber,
+                    'title' => $title,
+                    'short_title' => $shortTitle,
+                    'gwdm_version' => $targetGwdmVersion,
+                ]);
+            } else {
+                // Delta row: reconstruct the current full GWDM object, diff against
+                // the new metadata to produce a minimal RFC 6902 patch.
+                $currentGwdm = $this->reconstructGwdmMetadata($dataset->id, $versionNumber);
+                $patch = $this->computePatch($currentGwdm, $newGwdmMetadata);
+
+                $dv = DatasetVersion::create([
+                    'dataset_id' => $dataset->id,
+                    // Patch delta, therefore no metadata stored.
+                    'metadata' => [],
+                    'patch' => $patch,   // array — the cast handles JSON encoding
+                    'version' => $newVersionNumber,
+                    'title' => $title,
+                    'short_title' => $shortTitle,
+                    'gwdm_version' => $targetGwdmVersion,
+                ]);
+            }
+
+            // Delegate to the handler's afterStore hook. For JSON versions this is a
+            // no-op; Gwdm30Handler uses it to write structured fields to SQL tables.
+            $handler->afterStore($dataset, $dv, $newGwdmMetadata);
+
+            return $dv;
+        });
 
         // -----------------------------------------------------------------------
         // Relation pivot table updates — DISCUSSION POINT FOR REVIEW
@@ -871,7 +1137,7 @@ class DatasetService
     {
         if (is_array($metadata) && Arr::has($metadata, 'metadata.metadata')) {
             $metadata = $metadata['metadata'];
-        } elseif (is_array($metadata) && !Arr::has($metadata, 'metadata')) {
+        } elseif (is_array($metadata) && ! Arr::has($metadata, 'metadata')) {
             $metadata = ['metadata' => $metadata];
         }
 
@@ -892,104 +1158,45 @@ class DatasetService
     }
 
     /**
-     * Build the GWDM required block for a given version, including the full
-     * revisions history up to and including $newVersionNumber.
-     *
-     * On create() this produces a single-entry revisions array (v1 only).
-     * On update() this is called after incrementing so $newVersionNumber already
-     * reflects the version about to be written; all prior versions are fetched
-     * from the DB and prepended.
-     */
-    private function buildRequiredBlock(Dataset $dataset, int $newVersionNumber): array
-    {
-        // Fetch all version numbers already persisted for this dataset (excluding
-        // the new version which has not yet been written).
-        $existingVersions = DatasetVersion::where('dataset_id', $dataset->id)
-            ->orderBy('version')
-            ->pluck('version')
-            ->toArray();
-
-        // Build a revision entry for every version including the new one.
-        $allVersionNumbers = array_merge($existingVersions, [$newVersionNumber]);
-        $allVersionNumbers = array_unique($allVersionNumbers);
-        sort($allVersionNumbers);
-
-        $revisions = array_map(fn ($v) => [
-            'url'     => config('gateway.gateway_url') . '/dataset/' . $dataset->id . '?version=' . $this->formatVersion($v),
-            'version' => $this->formatVersion($v),
-        ], $allVersionNumbers);
-
-        return [
-            'gatewayId'  => strval($dataset->id),
-            'gatewayPid' => $dataset->pid,
-            'issued'     => $dataset->created,
-            'modified'   => $dataset->updated,
-            'revisions'  => $revisions,
-        ];
-    }
-
-    private function formatVersion(int $version): string
-    {
-        return "{$version}.0.0";
-    }
-
-    /**
-     * Extract title and shortTitle from a GWDM metadata array.
-     *
-     * Returns [$title, $shortTitle] — either may be null if not present.
-     * Used to populate the now-regular (non-generated) title/short_title columns.
-     *
-     * @return array{0: string|null, 1: string|null}
-     */
-    private function extractTitleFields(array $gwdmMetadata): array
-    {
-        $title      = $gwdmMetadata['summary']['title'] ?? null;
-        $shortTitle = $gwdmMetadata['summary']['shortTitle'] ?? $title;
-
-        return [$title, $shortTitle];
-    }
-
-    /**
      * Map metadata coverage/spatial string to the SpatialCoverage controlled list.
      * Mirrors MetadataOnboard@mapCoverage (kept intact for V1).
      */
     private function mapCoverage(array $metadata, DatasetVersion $version): void
     {
-        if (!isset($metadata['metadata']['coverage']['spatial'])) {
+        if (! isset($metadata['metadata']['coverage']['spatial'])) {
             return;
         }
 
-        $coverage     = strtolower($metadata['metadata']['coverage']['spatial']);
+        $coverage = strtolower($metadata['metadata']['coverage']['spatial']);
         $allCoverages = SpatialCoverage::all();
-        $ukCoverages  = $allCoverages->filter(fn ($c) => $c->region !== 'Rest of the world');
-        $worldId      = $allCoverages->firstWhere('region', 'Rest of the world')?->id;
-        $matchFound   = false;
+        $ukCoverages = $allCoverages->filter(fn ($c) => $c->region !== 'Rest of the world');
+        $worldId = $allCoverages->firstWhere('region', 'Rest of the world')?->id;
+        $matchFound = false;
 
         foreach ($ukCoverages as $c) {
             if (str_contains($coverage, strtolower($c->region))) {
                 DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id'  => (int) $version->id,
+                    'dataset_version_id' => (int) $version->id,
                     'spatial_coverage_id' => (int) $c->id,
                 ]);
                 $matchFound = true;
             }
         }
 
-        if (!$matchFound) {
+        if (! $matchFound) {
             if (str_contains($coverage, 'united kingdom')) {
                 foreach ($ukCoverages as $c) {
                     DatasetVersionHasSpatialCoverage::updateOrCreate([
-                        'dataset_version_id'  => (int) $version->id,
+                        'dataset_version_id' => (int) $version->id,
                         'spatial_coverage_id' => (int) $c->id,
                     ]);
                 }
             } else {
                 DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id'  => (int) $version->id,
+                    'dataset_version_id' => (int) $version->id,
                     'spatial_coverage_id' => (int) $worldId,
                 ]);
             }
         }
     }
-
 }

--- a/app/Services/Gwdm/Gwdm1xHandler.php
+++ b/app/Services/Gwdm/Gwdm1xHandler.php
@@ -19,12 +19,9 @@ use App\Models\Team;
 class Gwdm1xHandler extends GwdmMetadataHandler
 {
     /**
-     * KNOWN LIMITATION: always attributes the metadata to the requesting team.
-     * There is currently no mechanism for a team to publish metadata attributed
-     * to a different team (e.g. team A submitting on behalf of team B) — $team
-     * is unconditionally the team resolved from the write request's auth context
-     * (see CheckAccess::checkAccessTeam()), and this output is never read back
-     * from the incoming payload. Tracked for a separate design/investigation.
+     * FALLBACK `summary.publisher` = { publisherId, publisherName } for the
+     * legacy GWDM < 1.1 shape. Used by resolvePublisher() only when the payload
+     * carries no usable publisher; attributes to the requesting team by pid.
      */
     public function buildPublisher(Team $team): array
     {
@@ -32,6 +29,16 @@ class Gwdm1xHandler extends GwdmMetadataHandler
             'publisherId'   => $team->pid,
             'publisherName' => $team->name,
         ];
+    }
+
+    /**
+     * Legacy GWDM < 1.1 publisher resolution: prefer the raw payload publisher,
+     * normalise `publisherId` to a pid (resolving a team by id-or-pid), and fall
+     * back to the requesting team when no resolvable publisher is present.
+     */
+    public function resolvePublisher(array $incoming, Team $team): array
+    {
+        return $this->resolvePublisherWithKeys($incoming, $team, 'publisherId', 'publisherName');
     }
 
     public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
@@ -51,7 +58,7 @@ class Gwdm1xHandler extends GwdmMetadataHandler
         $required = $this->buildRequiredBlock($dataset, $versionNumber);
         // DB-derived values win over whatever TRASER returned for the same keys
         $gwdm['required']             = array_merge($gwdm['required'] ?? [], $required);
-        $gwdm['summary']['publisher'] = $this->buildPublisher($team);
+        $gwdm['summary']['publisher'] = $this->resolvePublisher($gwdm['summary']['publisher'] ?? [], $team);
 
         return $gwdm;
     }

--- a/app/Services/Gwdm/Gwdm1xHandler.php
+++ b/app/Services/Gwdm/Gwdm1xHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+use App\Models\Dataset;
+use App\Models\Team;
+
+/**
+ * Handler for GWDM versions < 1.1 (legacy).
+ *
+ * Differences from 2.x:
+ *   - summary.publisher uses the OLD format: { publisherId, publisherName }
+ *   - required block does NOT include a 'version' field
+ *
+ * This handler exists to avoid any version_compare calls in DatasetService.
+ * In practice, no new datasets should be created with GWDM < 1.1; this handles
+ * legacy ingestion paths only.
+ */
+class Gwdm1xHandler extends GwdmMetadataHandler
+{
+    public function buildPublisher(Team $team): array
+    {
+        return [
+            'publisherId'   => $team->pid,
+            'publisherName' => $team->name,
+        ];
+    }
+
+    public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
+    {
+        return [
+            'gatewayId'  => strval($dataset->id),
+            'gatewayPid' => $dataset->pid,
+            'issued'     => $dataset->created,
+            'modified'   => $dataset->updated,
+            'revisions'  => $this->buildRevisions($dataset, $versionNumber),
+            // No 'version' field — not part of GWDM < 1.1 schema
+        ];
+    }
+
+    public function prepareMetadata(array $gwdm, Dataset $dataset, Team $team, int $versionNumber): array
+    {
+        $required = $this->buildRequiredBlock($dataset, $versionNumber);
+        // DB-derived values win over whatever TRASER returned for the same keys
+        $gwdm['required']             = array_merge($gwdm['required'] ?? [], $required);
+        $gwdm['summary']['publisher'] = $this->buildPublisher($team);
+
+        return $gwdm;
+    }
+}

--- a/app/Services/Gwdm/Gwdm1xHandler.php
+++ b/app/Services/Gwdm/Gwdm1xHandler.php
@@ -18,6 +18,14 @@ use App\Models\Team;
  */
 class Gwdm1xHandler extends GwdmMetadataHandler
 {
+    /**
+     * KNOWN LIMITATION: always attributes the metadata to the requesting team.
+     * There is currently no mechanism for a team to publish metadata attributed
+     * to a different team (e.g. team A submitting on behalf of team B) — $team
+     * is unconditionally the team resolved from the write request's auth context
+     * (see CheckAccess::checkAccessTeam()), and this output is never read back
+     * from the incoming payload. Tracked for a separate design/investigation.
+     */
     public function buildPublisher(Team $team): array
     {
         return [

--- a/app/Services/Gwdm/Gwdm20Handler.php
+++ b/app/Services/Gwdm/Gwdm20Handler.php
@@ -8,7 +8,8 @@ namespace App\Services\Gwdm;
  * Currently identical to Gwdm2xHandler — exists as a dedicated class so that
  * any future 2.0-specific gateway-side logic (required block changes, publisher
  * field mutations, afterStore hooks) can be added here without touching the
- * shared 2.x base or 2.1's handler.
+ * shared 2.x base. Gwdm21Handler extends this class, so any override added
+ * here is inherited by 2.1 automatically unless 2.1 overrides it back.
  */
 class Gwdm20Handler extends Gwdm2xHandler
 {

--- a/app/Services/Gwdm/Gwdm20Handler.php
+++ b/app/Services/Gwdm/Gwdm20Handler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+/**
+ * Handler for GWDM 2.0.
+ *
+ * Currently identical to Gwdm2xHandler — exists as a dedicated class so that
+ * any future 2.0-specific gateway-side logic (required block changes, publisher
+ * field mutations, afterStore hooks) can be added here without touching the
+ * shared 2.x base or 2.1's handler.
+ */
+class Gwdm20Handler extends Gwdm2xHandler
+{
+    // Override methods here when GWDM 2.0 gateway logic diverges from 2.x base.
+}

--- a/app/Services/Gwdm/Gwdm21Handler.php
+++ b/app/Services/Gwdm/Gwdm21Handler.php
@@ -6,16 +6,17 @@ namespace App\Services\Gwdm;
  * Handler for GWDM 2.1.
  *
  * GWDM 2.1 is a small extension of 2.0 — schema-level field differences are
- * handled by TRASER, not here. This handler exists as a dedicated class so that
- * any future 2.1-specific gateway-side logic can be added without touching the
- * shared 2.x base or 2.0's handler.
+ * handled by TRASER, not here. Extends Gwdm20Handler (rather than the shared
+ * Gwdm2xHandler base directly) so that any future 2.0-specific gateway-side
+ * fix is inherited by 2.1 automatically; override a method here only when 2.1
+ * must deliberately diverge from 2.0's behaviour.
  *
  * Example override candidates when 2.1 diverges:
  *   - buildRequiredBlock() if the required section gains new fields
  *   - buildPublisher() if the publisher object structure changes
  *   - afterStore() if 2.1 introduces structured SQL columns
  */
-class Gwdm21Handler extends Gwdm2xHandler
+class Gwdm21Handler extends Gwdm20Handler
 {
-    // Override methods here when GWDM 2.1 gateway logic diverges from 2.x base.
+    // Override methods here when GWDM 2.1 gateway logic diverges from 2.0.
 }

--- a/app/Services/Gwdm/Gwdm21Handler.php
+++ b/app/Services/Gwdm/Gwdm21Handler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+/**
+ * Handler for GWDM 2.1.
+ *
+ * GWDM 2.1 is a small extension of 2.0 — schema-level field differences are
+ * handled by TRASER, not here. This handler exists as a dedicated class so that
+ * any future 2.1-specific gateway-side logic can be added without touching the
+ * shared 2.x base or 2.0's handler.
+ *
+ * Example override candidates when 2.1 diverges:
+ *   - buildRequiredBlock() if the required section gains new fields
+ *   - buildPublisher() if the publisher object structure changes
+ *   - afterStore() if 2.1 introduces structured SQL columns
+ */
+class Gwdm21Handler extends Gwdm2xHandler
+{
+    // Override methods here when GWDM 2.1 gateway logic diverges from 2.x base.
+}

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -24,12 +24,35 @@ use App\Services\DatasetService;
  */
 class Gwdm2xHandler extends GwdmMetadataHandler
 {
+    /**
+     * KNOWN LIMITATION: always attributes the metadata to the requesting team.
+     * There is currently no mechanism for a team to publish metadata attributed
+     * to a different team (e.g. team A submitting on behalf of team B) — $team
+     * is unconditionally the team resolved from the write request's auth context
+     * (see CheckAccess::checkAccessTeam()), and this output is never read back
+     * from the incoming payload. Tracked for a separate design/investigation.
+     */
     public function buildPublisher(Team $team): array
     {
         return [
             'gatewayId' => $team->pid,
             'name'      => $team->name,
         ];
+    }
+
+    /**
+     * Single named resolution point for DatasetService within this handler.
+     *
+     * Constructor injection isn't viable: this handler is instantiated via
+     * `new Gwdm20Handler($version)` in GwdmHandlerFactory::resolve() with a
+     * runtime-only $version string, not container-resolved. DatasetService
+     * already depends on GwdmHandlerFactory to create these handlers, so
+     * injecting DatasetService back into the factory (to pass down here)
+     * would be circular.
+     */
+    protected function datasetService(): DatasetService
+    {
+        return app(DatasetService::class);
     }
 
     public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
@@ -74,7 +97,7 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         // junction tables. afterRead() rebuilds gwdm['linkage'] from those same
         // tables, so applying it here would read back stale/soon-to-be-deleted
         // linkage and clobber the freshly-authored linkage on a re-dispatch.
-        $gwdm = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+        $gwdm = $this->datasetService()->getReconstructedMetadataEnvelope(
             $dv->dataset_id,
             $dv->version,
             false,

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -25,12 +25,12 @@ use App\Services\DatasetService;
 class Gwdm2xHandler extends GwdmMetadataHandler
 {
     /**
-     * KNOWN LIMITATION: always attributes the metadata to the requesting team.
-     * There is currently no mechanism for a team to publish metadata attributed
-     * to a different team (e.g. team A submitting on behalf of team B) — $team
-     * is unconditionally the team resolved from the write request's auth context
-     * (see CheckAccess::checkAccessTeam()), and this output is never read back
-     * from the incoming payload. Tracked for a separate design/investigation.
+     * FALLBACK `summary.publisher` = { gatewayId, name } for GWDM 2.x.
+     *
+     * Used by resolvePublisher() only when the incoming payload has no usable
+     * publisher. Attributes to the requesting team ($team, from the write
+     * request's auth context) using the team's pid — never the internal MySQL
+     * primary key.
      */
     public function buildPublisher(Team $team): array
     {
@@ -38,6 +38,27 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             'gatewayId' => $team->pid,
             'name'      => $team->name,
         ];
+    }
+
+    /**
+     * GWDM 2.x publisher resolution: prefer the RAW payload publisher, normalise
+     * its `gatewayId` to a pid (resolving a team by id-or-pid), and fall back to
+     * the requesting team when the payload carries no resolvable publisher.
+     *
+     * This allows a team to publish metadata whose publisher is a different
+     * organisation (publisher = who the metadata says published it), while
+     * guaranteeing `gatewayId` is stored as a pid rather than a raw primary key.
+     * Historically this field was force-set to the requesting team's pid; that
+     * ignored the payload and could not represent publish-on-behalf.
+     *
+     * NAMING NOTE: the HDRUK 4.0.0 translation output also renames the canonical
+     * GWDM `summary.dataCustodian` to `publisher`; `publisher` (who published
+     * the metadata) and `dataCustodian` (who controls the data) can legitimately
+     * diverge. Candidate for a future naming cleanup.
+     */
+    public function resolvePublisher(array $incoming, Team $team): array
+    {
+        return $this->resolvePublisherWithKeys($incoming, $team, 'gatewayId', 'name');
     }
 
     /**
@@ -77,7 +98,7 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         $required['version'] = $gwdm['required']['version'] ?? $required['version'];
 
         $gwdm['required']             = array_merge($gwdm['required'] ?? [], $required);
-        $gwdm['summary']['publisher'] = $this->buildPublisher($team);
+        $gwdm['summary']['publisher'] = $this->resolvePublisher($gwdm['summary']['publisher'] ?? [], $team);
 
         return $gwdm;
     }

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Publication;
+use App\Models\PublicationHasDatasetVersion;
+use App\Models\Team;
+use App\Services\DatasetService;
+
+/**
+ * Handler for GWDM >= 1.1, covering versions 2.0 and 2.1.
+ *
+ * Differences from 1.x:
+ *   - summary.publisher uses the NEW format: { gatewayId, name }
+ *   - required block includes a 'version' field ("X.0.0")
+ *
+ * 2.0 and 2.1 share the same JSON blob storage strategy — both use
+ * the metadata column with RFC 6902 delta compression. Schema-level
+ * differences (new/changed GWDM fields in 2.1) are handled by TRASER,
+ * not by this handler.
+ */
+class Gwdm2xHandler extends GwdmMetadataHandler
+{
+    public function buildPublisher(Team $team): array
+    {
+        return [
+            'gatewayId' => $team->pid,
+            'name'      => $team->name,
+        ];
+    }
+
+    public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
+    {
+        return [
+            'gatewayId'  => strval($dataset->id),
+            'gatewayPid' => $dataset->pid,
+            'issued'     => $dataset->created,
+            'modified'   => $dataset->updated,
+            'version'    => $this->formatVersion($versionNumber),
+            'revisions'  => $this->buildRevisions($dataset, $versionNumber),
+        ];
+    }
+
+    public function prepareMetadata(array $gwdm, Dataset $dataset, Team $team, int $versionNumber): array
+    {   
+        $required = $this->buildRequiredBlock($dataset, $versionNumber);
+
+        // Preserve any version string the caller (or TRASER) already set,
+        // falling back to the computed one from the DB version number.
+        // DB-derived values win for all other required keys.
+        $required['version'] = $gwdm['required']['version'] ?? $required['version'];
+
+        $gwdm['required']             = array_merge($gwdm['required'] ?? [], $required);
+        $gwdm['summary']['publisher'] = $this->buildPublisher($team);
+
+        return $gwdm;
+    }
+
+    // ── Linkage extraction ────────────────────────────────────────────────────
+
+    public const LINKAGE_DESCRIPTION = 'Extracted from GWDM';
+
+    public function extractLinkages(DatasetVersion $dv): void
+    {
+        // Read the linkage section from the RECONSTRUCTED GWDM, not the raw
+        // metadata column: delta rows store only a patch (metadata = []), so
+        // reading the column directly would wipe existing linkage on every
+        // delta update. Reconstruction replays the delta chain to a full object.
+        $gwdm = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $dv->dataset_id,
+            $dv->version,
+            false,
+            $dv,
+        )['metadata'] ?? [];
+
+        $this->writeLinkages($dv, $gwdm);
+    }
+
+    /**
+     * Write dataset and publication linkage junction rows from a full GWDM array.
+     *
+     * Separated from extractLinkages() so GWDM 3.0 can invoke it synchronously
+     * from afterStore() with the input metadata — its linkage arrays are not
+     * recoverable via reconstruction (persist() does not store them, and the
+     * read path rebuilds them from the very junction tables written here).
+     */
+    protected function writeLinkages(DatasetVersion $dv, array $gwdm): void
+    {
+        $linkage = $gwdm['linkage'] ?? [];
+
+        $datasetLinkages = $linkage['datasetLinkage'] ?? null;
+        $datasetLinkages = $datasetLinkages !== '' ? $datasetLinkages : null;
+
+        $aboutLinkages = $linkage['publicationAboutDataset'] ?? null;
+        $aboutLinkages = $aboutLinkages !== '' ? $aboutLinkages : null;
+
+        $usingLinkages = $linkage['publicationUsingDataset'] ?? null;
+        $usingLinkages = $usingLinkages !== '' ? $usingLinkages : null;
+
+        $this->processDatasetLinkages($dv->id, $datasetLinkages);
+        $this->processPublicationLinkages($dv->id, $aboutLinkages, 'ABOUT');
+        $this->processPublicationLinkages($dv->id, $usingLinkages, 'USING');
+    }
+
+    protected function processDatasetLinkages(int $sourceVersionId, ?array $datasetLinkages): void
+    {
+        DatasetVersionHasDatasetVersion::where([
+            'dataset_version_source_id' => $sourceVersionId,
+            'direct_linkage'            => 1,
+            'description'               => self::LINKAGE_DESCRIPTION,
+        ])->delete();
+
+        if (is_null($datasetLinkages)) {
+            return;
+        }
+
+        foreach ($datasetLinkages as $key => $data) {
+            if (!$data) {
+                continue;
+            }
+            foreach ($data as $d) {
+                $targetVersionId = $this->findTargetDataset($d);
+
+                if (!$targetVersionId) {
+                    // Store unresolved reference so afterRead() can reconstruct it from SQL.
+                    DatasetVersionHasDatasetVersion::create([
+                        'dataset_version_source_id' => $sourceVersionId,
+                        'dataset_version_target_id' => null,
+                        'linkage_type'              => $key,
+                        'direct_linkage'            => 1,
+                        'description'               => self::LINKAGE_DESCRIPTION,
+                        'raw_url'                   => $d['url'] ?? null,
+                        'raw_pid'                   => $d['pid'] ?? null,
+                        'raw_title'                 => $d['title'] ?? null,
+                    ]);
+                    continue;
+                }
+
+                DatasetVersionHasDatasetVersion::firstOrCreate([
+                    'dataset_version_source_id' => $sourceVersionId,
+                    'dataset_version_target_id' => $targetVersionId,
+                    'linkage_type'              => $key,
+                    'direct_linkage'            => 1,
+                    'description'               => self::LINKAGE_DESCRIPTION,
+                ]);
+            }
+        }
+    }
+
+    protected function processPublicationLinkages(int $sourceVersionId, ?array $publicationLinkages, string $linkType): void
+    {
+        PublicationHasDatasetVersion::where([
+            'dataset_version_id' => $sourceVersionId,
+            'description'        => self::LINKAGE_DESCRIPTION,
+            'link_type'          => $linkType,
+        ])->delete();
+
+        if (is_null($publicationLinkages)) {
+            return;
+        }
+
+        foreach ($publicationLinkages as $doi) {
+            if (!$doi) {
+                continue;
+            }
+
+            $publicationId = $this->findTargetPublication($doi);
+
+            if (!$publicationId) {
+                // Store unresolved DOI so afterRead() can reconstruct it from SQL.
+                PublicationHasDatasetVersion::create([
+                    'publication_id'     => null,
+                    'dataset_version_id' => $sourceVersionId,
+                    'link_type'          => $linkType,
+                    'description'        => self::LINKAGE_DESCRIPTION,
+                    'raw_doi'            => $doi,
+                ]);
+                continue;
+            }
+
+            $linkage = PublicationHasDatasetVersion::withTrashed()->firstOrCreate([
+                'publication_id'     => $publicationId,
+                'dataset_version_id' => $sourceVersionId,
+                'link_type'          => $linkType,
+                'description'        => self::LINKAGE_DESCRIPTION,
+            ]);
+
+            if ($linkage->trashed()) {
+                $linkage->restore();
+            }
+        }
+    }
+
+    protected function findTargetDataset(array $data): ?int
+    {
+        $id    = $data['url'] ?? null;
+        $pid   = $data['pid'] ?? null;
+        $title = $data['title'] ?? null;
+
+        if ($id) {
+            $urlParts = explode('/', parse_url($id, PHP_URL_PATH));
+            $id = end($urlParts);
+            $dataset = Dataset::find($id);
+            if ($dataset) {
+                return $dataset->latestVersionID($dataset->id);
+            }
+        }
+
+        if ($pid) {
+            $dataset = Dataset::where('pid', $pid)->first();
+            if ($dataset) {
+                return $dataset->latestVersionID($dataset->id);
+            }
+        }
+
+        if ($title) {
+            $datasetVersion = DatasetVersion::filterTitle($title)->first();
+            if ($datasetVersion) {
+                return $datasetVersion->id;
+            }
+        }
+
+        return null;
+    }
+
+    protected function findTargetPublication(string $doi): ?int
+    {
+        $publication = Publication::whereRaw(
+            "REPLACE(REPLACE(paper_doi, 'https://doi.org/', ''), 'doi.org/', '') = ?",
+            [$doi]
+        )->first();
+
+        return $publication?->id;
+    }
+
+    // ── Read path ─────────────────────────────────────────────────────────────
+
+    /**
+     * Reconstruct the GWDM `linkage` section entirely from SQL junction tables,
+     * making SQL the single source of truth for 2.x linkage data on reads.
+     *
+     * Returns [] (falls through to the stored JSON blob) when no extracted rows
+     * exist — this covers legacy rows that pre-date this migration. Re-dispatching
+     * LinkageExtraction for those versions will backfill the SQL rows.
+     */
+    public function afterRead(DatasetVersion $dv): array
+    {
+        $resolvedDatasets = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_has_dataset_version.dataset_version_source_id', $dv->id)
+            ->where('dataset_version_has_dataset_version.direct_linkage', 1)
+            ->where('dataset_version_has_dataset_version.description', self::LINKAGE_DESCRIPTION)
+            ->whereNotNull('dataset_version_has_dataset_version.dataset_version_target_id')
+            ->join('dataset_versions as dv', 'dv.id', '=', 'dataset_version_has_dataset_version.dataset_version_target_id')
+            ->join('datasets as d', 'd.id', '=', 'dv.dataset_id')
+            ->select(
+                'dataset_version_has_dataset_version.linkage_type',
+                'dv.short_title',
+                'd.pid',
+                'd.id as dataset_id',
+            )
+            ->get();
+
+        $unresolvedDatasets = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_source_id', $dv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->whereNull('dataset_version_target_id')
+            ->get();
+
+        $publications = PublicationHasDatasetVersion::query()
+            ->where('publication_has_dataset_version.dataset_version_id', $dv->id)
+            ->where('publication_has_dataset_version.description', self::LINKAGE_DESCRIPTION)
+            ->leftJoin('publications', 'publications.id', '=', 'publication_has_dataset_version.publication_id')
+            ->get();
+
+        $hasExtractedRows = $resolvedDatasets->isNotEmpty()
+            || $unresolvedDatasets->isNotEmpty()
+            || $publications->isNotEmpty();
+
+        if (!$hasExtractedRows) {
+            return [];
+        }
+
+        $datasetLinkage = [];
+        foreach ($resolvedDatasets as $row) {
+            $datasetLinkage[$row->linkage_type][] = [
+                'url'   => config('gateway.gateway_url') . '/en/dataset/' . $row->dataset_id,
+                'pid'   => $row->pid,
+                'title' => $row->short_title,
+            ];
+        }
+        foreach ($unresolvedDatasets as $row) {
+            $datasetLinkage[$row->linkage_type][] = [
+                'url'   => $row->raw_url,
+                'pid'   => $row->raw_pid,
+                'title' => $row->raw_title,
+            ];
+        }
+
+        $aboutDataset = [];
+        $usingDataset = [];
+        foreach ($publications as $row) {
+            $doi = $row->paper_doi ?? $row->raw_doi;
+            if (!$doi) {
+                continue;
+            }
+            if ($row->link_type === 'ABOUT') {
+                $aboutDataset[] = $doi;
+            } else {
+                $usingDataset[] = $doi;
+            }
+        }
+
+        return [
+            'linkage' => [
+                'datasetLinkage'          => $datasetLinkage,
+                'publicationAboutDataset' => $aboutDataset,
+                'publicationUsingDataset' => $usingDataset,
+            ],
+        ];
+    }
+}

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -69,11 +69,17 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         // metadata column: delta rows store only a patch (metadata = []), so
         // reading the column directly would wipe existing linkage on every
         // delta update. Reconstruction replays the delta chain to a full object.
+        //
+        // $applySupplementary = false: this method is the WRITER of the linkage
+        // junction tables. afterRead() rebuilds gwdm['linkage'] from those same
+        // tables, so applying it here would read back stale/soon-to-be-deleted
+        // linkage and clobber the freshly-authored linkage on a re-dispatch.
         $gwdm = app(DatasetService::class)->getReconstructedMetadataEnvelope(
             $dv->dataset_id,
             $dv->version,
             false,
             $dv,
+            false,
         )['metadata'] ?? [];
 
         $this->writeLinkages($dv, $gwdm);

--- a/app/Services/Gwdm/GwdmHandlerFactory.php
+++ b/app/Services/Gwdm/GwdmHandlerFactory.php
@@ -12,7 +12,7 @@ namespace App\Services\Gwdm;
  * Resolution rules:
  *   < 1.1  → Gwdm1xHandler  (legacy publisher field format, no required.version)
  *   2.0    → Gwdm20Handler  (extends Gwdm2xHandler; override here when 2.0 diverges)
- *   2.1    → Gwdm21Handler  (extends Gwdm2xHandler; override here when 2.1 diverges)
+ *   2.1    → Gwdm21Handler  (extends Gwdm20Handler; inherits 2.0 fixes, override here when 2.1 diverges)
  *   3.0    → Gwdm30Handler  (extends Gwdm2xHandler; SQL structured table hooks)
  *   else   → Gwdm2xHandler  (catch-all for any 1.1+ version without a dedicated class)
  *

--- a/app/Services/Gwdm/GwdmHandlerFactory.php
+++ b/app/Services/Gwdm/GwdmHandlerFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+/**
+ * Resolves a GWDM version string to the appropriate metadata lifecycle handler.
+ *
+ * This is the ONLY place in the codebase that branches on the GWDM schema
+ * version for write-path operations. All scattered version_compare() calls
+ * in DatasetService have been replaced by a single handler resolution here.
+ *
+ * Resolution rules:
+ *   < 1.1  → Gwdm1xHandler  (legacy publisher field format, no required.version)
+ *   2.0    → Gwdm20Handler  (extends Gwdm2xHandler; override here when 2.0 diverges)
+ *   2.1    → Gwdm21Handler  (extends Gwdm2xHandler; override here when 2.1 diverges)
+ *   3.0    → Gwdm30Handler  (extends Gwdm2xHandler; SQL structured table hooks)
+ *   else   → Gwdm2xHandler  (catch-all for any 1.1+ version without a dedicated class)
+ *
+ * To add a new GWDM version:
+ *   1. Create a new handler class extending the most appropriate parent
+ *   2. Add a match arm to resolve()
+ *   3. Add the version string to SUPPORTED_VERSIONS — GwdmVersionContext will
+ *      pick it up automatically for x-gwdm-version header validation.
+ */
+class GwdmHandlerFactory
+{
+    /**
+     * All GWDM versions that are valid targets for the x-gwdm-version request
+     * header. This is the single source of truth — GwdmVersionContext reads
+     * from here rather than maintaining its own duplicate list.
+     *
+     * Note: legacy versions handled internally by the factory (e.g. < 1.1)
+     * are not listed here because they are not user-selectable via the header.
+     */
+    public const SUPPORTED_VERSIONS = ['2.0', '2.1'];
+
+    /** @return string[] */
+    public static function supportedVersions(): array
+    {
+        return self::SUPPORTED_VERSIONS;
+    }
+
+    public function resolve(string $version): GwdmMetadataHandler
+    {
+        return match (true) {
+            version_compare($version, '1.1', '<') => new Gwdm1xHandler($version),
+            $version === '2.0'                     => new Gwdm20Handler($version),
+            $version === '2.1'                     => new Gwdm21Handler($version),
+            default                                => new Gwdm2xHandler($version),
+        };
+    }
+}

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -74,17 +74,80 @@ abstract class GwdmMetadataHandler
     // ── Publisher field ───────────────────────────────────────────────────────
 
     /**
-     * Build the summary.publisher object for this schema version.
+     * Build the FALLBACK summary.publisher object for this schema version.
      *
-     * KNOWN LIMITATION: implementations always attribute the metadata to
-     * whichever team is passed in — there is currently no mechanism for a
-     * team to publish metadata attributed to a different team (e.g. team A
-     * submitting on behalf of team B). $team is unconditionally the team
-     * resolved from the write request's auth context (see
-     * CheckAccess::checkAccessTeam()), and this output is never read back
-     * from the incoming payload. Tracked for a separate design/investigation.
+     * This is used only when the incoming payload carries no usable publisher
+     * (see resolvePublisher()/resolvePublisherWithKeys()). It attributes the
+     * metadata to $team — the team resolved from the write request's auth
+     * context (see CheckAccess::checkAccessTeam()) — using the team's pid.
+     *
+     * The primary path is resolvePublisher(): publisher reflects the RAW
+     * submitted data (so a team may publish metadata whose publisher is a
+     * different organisation), with gatewayId normalised to a pid.
      */
     abstract public function buildPublisher(Team $team): array;
+
+    /**
+     * Resolve the publisher for this write from the incoming (post-TRASER)
+     * payload, normalised to a pid, with a fallback to the requesting team.
+     *
+     * Concrete handlers implement this with their own key names
+     * (2.x: gatewayId/name; 1.x: publisherId/publisherName) by delegating to
+     * resolvePublisherWithKeys().
+     */
+    abstract public function resolvePublisher(array $incoming, Team $team): array;
+
+    /**
+     * Resolve a Team from a publisher gateway identifier that may be either the
+     * internal primary key (numeric) or the persistent id (pid). Mirrors the
+     * id-or-pid tolerance in DataAccessApplicationController.
+     *
+     * Public + static so the legacy V1 inline write paths (MetadataOnboard,
+     * IntegrationDatasetController) can share the exact same resolution without
+     * instantiating a handler.
+     */
+    public static function resolveTeamFromGatewayId(mixed $gatewayId): ?Team
+    {
+        if ($gatewayId === null || $gatewayId === '') {
+            return null;
+        }
+
+        if (is_numeric($gatewayId)) {
+            return Team::find((int) $gatewayId);
+        }
+
+        return Team::where('pid', $gatewayId)->first();
+    }
+
+    /**
+     * Shared publisher-resolution core, parameterised by the version-specific
+     * id/name key names.
+     *
+     * Behaviour:
+     *   - Resolve the team from $incoming[$idKey] (by id or pid).
+     *   - If unresolvable (absent, empty, or no matching team) → fall back to
+     *     buildPublisher($team) (the requesting team, by pid).
+     *   - Otherwise preserve the incoming object (including extra keys such as
+     *     rorId), normalising $idKey to the resolved team's pid and defaulting
+     *     $nameKey to the resolved team's name when the payload omits it.
+     */
+    protected function resolvePublisherWithKeys(
+        array $incoming,
+        Team $team,
+        string $idKey,
+        string $nameKey,
+    ): array {
+        $resolved = self::resolveTeamFromGatewayId($incoming[$idKey] ?? null);
+
+        if (!$resolved) {
+            return $this->buildPublisher($team);
+        }
+
+        $incoming[$idKey]   = $resolved->pid;
+        $incoming[$nameKey] = $incoming[$nameKey] ?? $resolved->name;
+
+        return $incoming;
+    }
 
     // ── Storage envelope ──────────────────────────────────────────────────────
 

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -187,6 +187,32 @@ abstract class GwdmMetadataHandler
         // no-op for versions without linkage extraction support
     }
 
+    // ── Onboarding form defaults ──────────────────────────────────────────────
+
+    /**
+     * GWDM dot-paths, relative to the raw dataset_versions.metadata envelope
+     * (i.e. {gwdmVersion, metadata: {...GWDM...}, original_metadata}), used by
+     * FormHydrationController::getDefaultValues() to pre-populate onboarding
+     * form fields from a team's existing datasets.
+     *
+     * Shared across all JSON-based versions — the accessibility section shape
+     * has not changed between GWDM < 1.1 and 2.x. Override this when a version
+     * restructures these fields, or return [] when the fields are no longer
+     * JSON-addressable (e.g. GWDM 3.0, where this data lives in SQL tables).
+     */
+    public function defaultValuePaths(): array
+    {
+        return [
+            'dataUseLimitation'   => 'metadata.accessibility.usage.dataUseLimitation',
+            'dataUseRequirements' => 'metadata.accessibility.usage.dataUseRequirements',
+            'accessRights'        => 'metadata.accessibility.access.accessRights',
+            'accessService'       => 'metadata.accessibility.access.accessService',
+            'accessRequestCost'   => 'metadata.accessibility.access.accessRequestCost',
+            'deliveryLeadTime'    => 'metadata.accessibility.access.deliveryLeadTime',
+            'formats'             => 'metadata.accessibility.formatAndStandards.formats',
+        ];
+    }
+
     // ── Shared helpers ────────────────────────────────────────────────────────
 
     /**

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace App\Services\Gwdm;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+
+/**
+ * Per-version metadata lifecycle handler.
+ *
+ * Each concrete subclass encapsulates everything that differs between GWDM
+ * schema versions: the required block shape, the publisher field format, and
+ * any structured-table persistence (GWDM 3.0+).
+ *
+ * DatasetService delegates all version-specific mutations to the handler
+ * returned by GwdmHandlerFactory::resolve(). There should be no version_compare
+ * calls outside of GwdmHandlerFactory.
+ *
+ * Hierarchy:
+ *   GwdmMetadataHandler (abstract — shared logic)
+ *   ├── Gwdm1xHandler    (GWDM < 1.1 — legacy publisher field)
+ *   ├── Gwdm2xHandler    (GWDM >= 1.1 — covers 2.0 and 2.1)
+ *   └── Gwdm30Handler    (GWDM 3.0 — extends 2.x, adds SQL table hooks)
+ */
+abstract class GwdmMetadataHandler
+{
+    public function __construct(protected readonly string $resolvedVersion)
+    {
+    }
+
+    // ── Version identity ──────────────────────────────────────────────────────
+
+    /**
+     * Return the exact GWDM version string this instance was resolved for.
+     * Used when writing gwdmVersion into the metadata envelope.
+     */
+    public function version(): string
+    {
+        return $this->resolvedVersion;
+    }
+
+    // ── Metadata preparation (version-specific) ───────────────────────────────
+
+    /**
+     * Apply all version-specific mutations to the post-TRASER GWDM array.
+     *
+     * Concrete implementations must:
+     *   1. Call buildRequiredBlock() and write the result into $gwdm['required'],
+     *      merging over any existing required fields so DB-derived values win.
+     *   2. Call buildPublisher() and write the result into $gwdm['summary']['publisher'].
+     *
+     * @param  array   $gwdm          Post-TRASER GWDM metadata object
+     * @param  Dataset $dataset       The parent dataset row (for gatewayId, pid, dates)
+     * @param  Team    $team          Owning team (for publisher fields)
+     * @param  int     $versionNumber The version number being written (1 on create)
+     * @return array                  Mutated GWDM array ready for envelope + storage
+     */
+    abstract public function prepareMetadata(
+        array $gwdm,
+        Dataset $dataset,
+        Team $team,
+        int $versionNumber,
+    ): array;
+
+    // ── Required block ────────────────────────────────────────────────────────
+
+    /**
+     * Build the metadata.required section for this schema version.
+     * Gwdm1xHandler omits the 'version' field; Gwdm2xHandler+ includes it.
+     */
+    abstract public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array;
+
+    // ── Publisher field ───────────────────────────────────────────────────────
+
+    /** Build the summary.publisher object for this schema version. */
+    abstract public function buildPublisher(Team $team): array;
+
+    // ── Storage envelope ──────────────────────────────────────────────────────
+
+    /**
+     * Wrap the prepared GWDM array and original metadata into the JSON envelope
+     * stored in the dataset_versions.metadata column.
+     *
+     * Shape: { gwdmVersion, metadata: {...GWDM...}, original_metadata: {...} }
+     *
+     * Shared across all JSON-based versions (2.x and below). Gwdm30Handler
+     * may override this when structured SQL columns replace JSON storage.
+     */
+    public function buildEnvelope(array $gwdm, array $originalMetadata): array
+    {
+        return [
+            'gwdmVersion'       => $this->version(),
+            'metadata'          => $gwdm,
+            'original_metadata' => $originalMetadata,
+        ];
+    }
+
+    /**
+     * Extract the GWDM content from the raw stored envelope array.
+     *
+     * Default: handles the modern 2.x envelope {"metadata": {...}, ...} and
+     * the legacy format where raw GWDM was stored directly with no wrapper.
+     * Gwdm30Handler overrides this to return [] because all GWDM content
+     * is in SQL tables and populated by afterRead().
+     */
+    public function extractStoredGwdm(array $storedData): array
+    {
+        if (array_key_exists('metadata', $storedData)) {
+            return $storedData['metadata'];
+        }
+        return $storedData;
+    }
+
+    // ── Title extraction ──────────────────────────────────────────────────────
+
+    /**
+     * Extract the title and shortTitle from the GWDM summary section.
+     * These populate the indexed title/short_title columns on dataset_versions.
+     *
+     * @return array{0: string|null, 1: string|null}
+     */
+    public function extractTitleFields(array $gwdm): array
+    {
+        $title      = $gwdm['summary']['title'] ?? null;
+        $shortTitle = $gwdm['summary']['shortTitle'] ?? $title;
+
+        return [$title, $shortTitle];
+    }
+
+    // ── Persistence hooks (overridden by Gwdm30Handler) ───────────────────────
+
+    /**
+     * Called after the DatasetVersion row has been created/updated.
+     *
+     * No-op for all JSON-based versions. Gwdm30Handler uses this to write
+     * structured fields to dedicated SQL tables (linkages, accessibility, etc.).
+     */
+    public function afterStore(Dataset $dataset, DatasetVersion $dv, array $gwdm): void
+    {
+        // no-op for 2.x and below
+    }
+
+    /**
+     * Called when reconstructing a version for a read response.
+     *
+     * Returns supplementary data to merge into the envelope — empty for JSON
+     * versions; populated for Gwdm30Handler when reading from SQL tables.
+     */
+    public function afterRead(DatasetVersion $dv): array
+    {
+        return [];
+    }
+
+    /**
+     * Pre-populate section data onto a DatasetVersion via setRelation() so that
+     * afterRead() can access it without firing individual per-section queries.
+     *
+     * No-op for JSON-based versions. Gwdm30Handler overrides this to load all
+     * structured SQL section tables. A future Gwdm31Handler would do the same.
+     */
+    public function preloadSections(DatasetVersion $dv): void
+    {
+        // no-op for 2.x and below
+    }
+
+    /**
+     * Extract linkage data from this version and write it to the appropriate
+     * junction tables. Called by the LinkageExtraction job.
+     *
+     * No-op for the base class. Gwdm2xHandler writes to the
+     * dataset_version_has_dataset_version and publication_has_dataset_version
+     * junction tables. Gwdm30Handler inherits this method unchanged.
+     */
+    public function extractLinkages(DatasetVersion $dv): void
+    {
+        // no-op for versions without linkage extraction support
+    }
+
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Build the revisions array for the required block, covering all persisted
+     * versions plus the new one about to be written.
+     */
+    protected function buildRevisions(Dataset $dataset, int $newVersionNumber): array
+    {
+        $existing = DatasetVersion::where('dataset_id', $dataset->id)
+            ->orderBy('version')
+            ->pluck('version')
+            ->toArray();
+
+        $all = array_unique(array_merge($existing, [$newVersionNumber]));
+        sort($all);
+
+        return array_map(fn (int $v) => [
+            'url'     => config('gateway.gateway_url') . '/dataset/' . $dataset->id . '?version=' . $this->formatVersion($v),
+            'version' => $this->formatVersion($v),
+        ], $all);
+    }
+
+    protected function formatVersion(int $version): string
+    {
+        return "{$version}.0.0";
+    }
+}

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -73,7 +73,17 @@ abstract class GwdmMetadataHandler
 
     // ── Publisher field ───────────────────────────────────────────────────────
 
-    /** Build the summary.publisher object for this schema version. */
+    /**
+     * Build the summary.publisher object for this schema version.
+     *
+     * KNOWN LIMITATION: implementations always attribute the metadata to
+     * whichever team is passed in — there is currently no mechanism for a
+     * team to publish metadata attributed to a different team (e.g. team A
+     * submitting on behalf of team B). $team is unconditionally the team
+     * resolved from the write request's auth context (see
+     * CheckAccess::checkAccessTeam()), and this output is never read back
+     * from the incoming payload. Tracked for a separate design/investigation.
+     */
     abstract public function buildPublisher(Team $team): array;
 
     // ── Storage envelope ──────────────────────────────────────────────────────

--- a/config/partners.php
+++ b/config/partners.php
@@ -116,9 +116,10 @@ return [
     */
     'schema' => [
 
-        'HDRUK' => ['model' => 'HDRUK', 'version' => '4.0.0'],
+        'HDRUK' => ['model' => 'HDRUK', 'version' => env('HDRUK_CURRENT_VERSION', '4.0.0')],
         'CRUK'  => ['model' => 'CRUK',  'version' => '1.1.0'],
-        'PRUK'  => ['model' => 'PRUK',  'version' => null],
+        // PRUK schema version is not yet finalised — placeholder until confirmed.
+        'PRUK'  => ['model' => 'PRUK',  'version' => '0.0.0'],
 
     ],
 

--- a/config/partners.php
+++ b/config/partners.php
@@ -100,4 +100,26 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Output schema defaults
+    |--------------------------------------------------------------------------
+    | The TRASER translation target for each partner. These are used as the
+    | fallback when no x-schema-model / x-schema-version header is sent.
+    | Per-request headers always take priority over these defaults.
+    |
+    | 'model'   — schema model name passed to TRASER (e.g. 'HDRUK', 'CRUK')
+    | 'version' — schema version string; null lets TRASER use its own default
+    |
+    | Note: the internal storage format is always GWDM — that is managed
+    | separately by GwdmVersionContext and is unrelated to this section.
+    */
+    'schema' => [
+
+        'HDRUK' => ['model' => 'HDRUK', 'version' => '4.0.0'],
+        'CRUK'  => ['model' => 'CRUK',  'version' => '1.1.0'],
+        'PRUK'  => ['model' => 'PRUK',  'version' => null],
+
+    ],
+
 ];

--- a/database/deployment-steps/2026_07_14_140156_backfill_gwdm_version.php
+++ b/database/deployment-steps/2026_07_14_140156_backfill_gwdm_version.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Back-fill dataset_versions.gwdm_version from the JSON metadata envelope.
+ *
+ * The column (migration 2026_06_17_000001) defaults to '2.0', which is correct for
+ * new rows but wrong for legacy rows written under GWDM 1.x / 2.0 — their real
+ * version lives in metadata->gwdmVersion. This step copies it across so version
+ * resolution (handler selection, snapshot-on-schema-change, backfill source
+ * selection) reads the true schema version for existing data.
+ *
+ * COALESCE falls back to '2.0' where the JSON path is absent (delta rows store a
+ * reduced envelope, legacy rows may have a bare/empty metadata array).
+ *
+ * MySQL-only: JSON_UNQUOTE/JSON_EXTRACT are unavailable in SQLite (the test DB),
+ * where the '2.0' column default already covers fixtures — so this is a no-op there.
+ */
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+        if (DB::connection()->getDriverName() !== 'mysql') {
+            $this->info('Skipping gwdm_version back-fill: connection is not MySQL.');
+
+            return;
+        }
+
+        $affected = DB::update("
+            UPDATE dataset_versions
+            SET gwdm_version = COALESCE(
+                JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
+                '2.0'
+            )
+            WHERE deleted_at IS NULL
+        ");
+
+        $this->info("Back-filled gwdm_version on {$affected} dataset_versions row(s).");
+    }
+};

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -25,10 +25,6 @@ return new class () extends Migration {
             $table->index('gwdm_version');
         });
 
-        // Data back-fill of existing rows from metadata->gwdmVersion is handled by a
-        // deployment step (database/deployment-steps/*_backfill_gwdm_version.php),
-        // which runs via `php artisan deploy:run` after migrations. New rows get the
-        // '2.0' column default until the service layer sets an explicit version.
     }
 
     public function down(): void

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a queryable gwdm_version column to dataset_versions.
+ *
+ * Previously the GWDM version was only stored inside the JSON metadata envelope
+ * (metadata->gwdmVersion), which is unindexed and NULL on delta rows (where
+ * metadata stores only {gwdmVersion, original_metadata} without the full GWDM).
+ *
+ * This column is the authoritative discriminator for:
+ *   - Which GWDM schema version a row was written under
+ *   - Selecting the latest version for a specific schema context
+ *     (e.g. "give me the most recent GWDM 2.1 row for dataset 42")
+ *   - Future GWDM 3.0 rows that use structured SQL columns instead of JSON
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->string('gwdm_version', 20)->default('2.0')->after('version');
+            $table->index('gwdm_version');
+        });
+
+        // Back-fill from the JSON envelope.
+        //
+        // Snapshot rows (patch IS NULL) have gwdmVersion set in metadata->gwdmVersion.
+        // Delta rows (patch IS NOT NULL) store a reduced envelope where metadata = []
+        // or metadata = {gwdmVersion, original_metadata} — JSON_EXTRACT may return NULL.
+        //
+        // COALESCE falls back to '2.0' for any row where the JSON path is absent
+        // (delta rows, legacy rows, or rows where metadata is a bare empty array).
+        // This is always correct because no GWDM 2.1+ data exists in the DB today.
+        //
+        // Guarded to MySQL only — JSON_UNQUOTE/JSON_EXTRACT are not available in
+        // SQLite (used by the test suite). The column default of '2.0' covers
+        // test fixtures correctly.
+        if (DB::connection()->getDriverName() === 'mysql') {
+            DB::statement("
+                UPDATE dataset_versions
+                SET gwdm_version = COALESCE(
+                    JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
+                    '2.0'
+                )
+                WHERE deleted_at IS NULL
+            ");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('dataset_versions', function (Blueprint $table) {
+            $table->dropIndex(['gwdm_version']);
+            $table->dropColumn('gwdm_version');
+        });
+    }
+};

--- a/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
+++ b/database/migrations/2026_06_17_000001_add_gwdm_version_to_dataset_versions_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -26,29 +25,10 @@ return new class () extends Migration {
             $table->index('gwdm_version');
         });
 
-        // Back-fill from the JSON envelope.
-        //
-        // Snapshot rows (patch IS NULL) have gwdmVersion set in metadata->gwdmVersion.
-        // Delta rows (patch IS NOT NULL) store a reduced envelope where metadata = []
-        // or metadata = {gwdmVersion, original_metadata} — JSON_EXTRACT may return NULL.
-        //
-        // COALESCE falls back to '2.0' for any row where the JSON path is absent
-        // (delta rows, legacy rows, or rows where metadata is a bare empty array).
-        // This is always correct because no GWDM 2.1+ data exists in the DB today.
-        //
-        // Guarded to MySQL only — JSON_UNQUOTE/JSON_EXTRACT are not available in
-        // SQLite (used by the test suite). The column default of '2.0' covers
-        // test fixtures correctly.
-        if (DB::connection()->getDriverName() === 'mysql') {
-            DB::statement("
-                UPDATE dataset_versions
-                SET gwdm_version = COALESCE(
-                    JSON_UNQUOTE(JSON_EXTRACT(NULLIF(metadata, 'null'), '$.gwdmVersion')),
-                    '2.0'
-                )
-                WHERE deleted_at IS NULL
-            ");
-        }
+        // Data back-fill of existing rows from metadata->gwdmVersion is handled by a
+        // deployment step (database/deployment-steps/*_backfill_gwdm_version.php),
+        // which runs via `php artisan deploy:run` after migrations. New rows get the
+        // '2.0' column default until the service layer sets an explicit version.
     }
 
     public function down(): void

--- a/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
+++ b/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
@@ -39,7 +39,10 @@ return new class () extends Migration {
             // Raw reference fields for unresolved linkages (target_id = NULL rows).
             $table->string('raw_url', 2048)->nullable()->after('dataset_version_target_id');
             $table->string('raw_pid', 255)->nullable()->after('raw_url');
-            $table->string('raw_title', 1000)->nullable()->after('raw_pid');
+            // text(): free text pulled from external, unvalidated linkage references —
+            // unlike the internal title/short_title columns there's no app-side bound
+            // on length, and a VARCHAR cap risks a strict-mode INSERT failure.
+            $table->text('raw_title')->nullable()->after('raw_pid');
 
             // Re-add FK as nullable (NULL = unresolved, non-NULL = resolved).
             if (!$isSqlite) {

--- a/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
+++ b/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
@@ -1,0 +1,97 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Make both linkage junction tables the complete source of truth for linkage data.
+ *
+ * Previously, LinkageExtraction skipped any reference it could not resolve to a known
+ * dataset or publication. This meant unresolvable free-text titles and DOIs only lived
+ * in the JSON metadata blob, requiring a dual-source merge on every read.
+ *
+ * After this migration:
+ *   - dataset_version_has_dataset_version stores unresolved dataset references as rows
+ *     with dataset_version_target_id = NULL and the raw url/pid/title preserved.
+ *   - publication_has_dataset_version stores unresolved publication references as rows
+ *     with publication_id = NULL and the raw DOI preserved.
+ *   - Gwdm2xHandler::afterRead() can reconstruct the full GWDM linkage section from SQL.
+ *
+ * NOTE: Existing rows that were extracted before this migration contain only resolved
+ * references. Re-dispatching LinkageExtraction for those dataset versions will backfill
+ * any unresolved references that were previously discarded.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        $isSqlite = DB::connection()->getDriverName() === 'sqlite';
+
+        Schema::table('dataset_version_has_dataset_version', function (Blueprint $table) use ($isSqlite) {
+            // SQLite rebuilds the whole table on ALTER — named FK drop is not supported.
+            if (!$isSqlite) {
+                $table->dropForeign('ld_dataset_version_target_id_fk');
+            }
+
+            $table->unsignedBigInteger('dataset_version_target_id')->nullable()->change();
+
+            // Raw reference fields for unresolved linkages (target_id = NULL rows).
+            $table->string('raw_url', 2048)->nullable()->after('dataset_version_target_id');
+            $table->string('raw_pid', 255)->nullable()->after('raw_url');
+            $table->string('raw_title', 1000)->nullable()->after('raw_pid');
+
+            // Re-add FK as nullable (NULL = unresolved, non-NULL = resolved).
+            if (!$isSqlite) {
+                $table->foreign('dataset_version_target_id', 'ld_dataset_version_target_id_fk')
+                    ->references('id')->on('dataset_versions')
+                    ->onDelete('cascade');
+            }
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->dropForeign(['publication_id']);
+
+            $table->unsignedBigInteger('publication_id')->nullable()->change();
+
+            $table->string('raw_doi', 2048)->nullable()->after('publication_id');
+
+            $table->foreign('publication_id')
+                ->references('id')->on('publications')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        $isSqlite = DB::connection()->getDriverName() === 'sqlite';
+
+        Schema::table('dataset_version_has_dataset_version', function (Blueprint $table) use ($isSqlite) {
+            if (!$isSqlite) {
+                $table->dropForeign('ld_dataset_version_target_id_fk');
+            }
+            $table->dropColumn(['raw_url', 'raw_pid', 'raw_title']);
+            DB::table('dataset_version_has_dataset_version')
+                ->whereNull('dataset_version_target_id')
+                ->delete();
+            $table->unsignedBigInteger('dataset_version_target_id')->nullable(false)->change();
+            if (!$isSqlite) {
+                $table->foreign('dataset_version_target_id', 'ld_dataset_version_target_id_fk')
+                    ->references('id')->on('dataset_versions')
+                    ->onDelete('cascade');
+            }
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->dropForeign(['publication_id']);
+            $table->dropColumn('raw_doi');
+            \DB::table('publication_has_dataset_version')
+                ->whereNull('publication_id')
+                ->delete();
+            $table->unsignedBigInteger('publication_id')->nullable(false)->change();
+            $table->foreign('publication_id')
+                ->references('id')->on('publications')
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/tests/Feature/DatasetLinkageCoverageFixTest.php
+++ b/tests/Feature/DatasetLinkageCoverageFixTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Regression coverage for the GWDM version-handler review fixes:
+ *
+ *  - H-a: getLinkages() must project raw_url/raw_title so UNRESOLVED (free-text)
+ *         linkages round-trip with their title/url instead of rendering null.
+ *  - H-b: extractLinkages() must read the reconstructed-from-blob GWDM WITHOUT the
+ *         afterRead() SQL overlay, so re-running extraction cannot feed stale
+ *         junction-table linkage back into the rows it is about to rewrite.
+ *  - M5:  spatial coverage is scoped to the latest version, so editing coverage
+ *         (England -> Scotland) reflects only the new value, not a growing union.
+ *
+ * Drives DatasetService/handlers directly; the x-gwdm-version header steers the
+ * target GWDM version via GwdmVersionContext.
+ */
+class DatasetLinkageCoverageFixTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /** Create a 2.0 dataset and return [datasetId, versionId]. */
+    private function createDataset(array $metadata, string $status = Dataset::STATUS_ACTIVE): array
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $this->setGwdmHeader('2.0');
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => $status,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+
+        $this->assertTrue($created['translated']);
+
+        return [$created['dataset_id'], $created['version_id']];
+    }
+
+    // ── H-a ─────────────────────────────────────────────────────────────────
+
+    public function test_unresolved_linkage_roundtrips_title_and_url_via_get_linkages(): void
+    {
+        $this->disableObservers();
+
+        [, $versionId] = $this->createDataset($this->getMetadataV2p0());
+
+        // An unresolved (free-text) linkage: no target dataset, raw reference only.
+        DatasetVersionHasDatasetVersion::create([
+            'dataset_version_source_id' => $versionId,
+            'dataset_version_target_id' => null,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => 1,
+            'description' => 'Extracted from GWDM',
+            'raw_url' => 'https://example.org/dataset/unknown-ref',
+            'raw_pid' => 'free-text-pid',
+            'raw_title' => 'Free Text Linked Dataset',
+        ]);
+
+        $linkages = $this->service()->getLinkages($versionId);
+
+        $this->assertCount(1, $linkages);
+        $this->assertSame('Free Text Linked Dataset', $linkages[0]['title']);
+        $this->assertSame('https://example.org/dataset/unknown-ref', $linkages[0]['url']);
+        $this->assertNull($linkages[0]['dataset_id']);
+        $this->assertSame('isDerivedFrom', $linkages[0]['linkage_type']);
+    }
+
+    // ── H-b ─────────────────────────────────────────────────────────────────
+
+    public function test_extract_linkages_uses_blob_not_stale_sql_overlay(): void
+    {
+        $this->disableObservers();
+
+        // Stored blob linkage points to the "blob" reference.
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['linkage']['datasetLinkage'] = [
+            'isDerivedFrom' => [
+                ['url' => 'https://example.org/dataset/99999999', 'title' => 'Blob Linked'],
+            ],
+        ];
+        $metadata['metadata']['linkage']['publicationAboutDataset'] = null;
+        $metadata['metadata']['linkage']['publicationUsingDataset'] = null;
+
+        [, $versionId] = $this->createDataset($metadata, Dataset::STATUS_DRAFT);
+
+        // Simulate pre-existing (stale) junction-table linkage that afterRead() would
+        // overlay on the read path. If extractLinkages() consumed that overlay it would
+        // rewrite STALE and drop the freshly-authored blob linkage.
+        DatasetVersionHasDatasetVersion::create([
+            'dataset_version_source_id' => $versionId,
+            'dataset_version_target_id' => null,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => 1,
+            'description' => 'Extracted from GWDM',
+            'raw_url' => 'https://example.org/dataset/STALE',
+            'raw_title' => 'STALE Linked',
+        ]);
+
+        $dv = DatasetVersion::find($versionId);
+        app(GwdmHandlerFactory::class)->resolve('2.0')->extractLinkages($dv);
+
+        $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $versionId)
+            ->where('direct_linkage', 1)
+            ->where('description', 'Extracted from GWDM')
+            ->get();
+
+        // The blob reference wins; the stale SQL overlay must not survive.
+        $this->assertTrue(
+            $rows->contains(fn ($r) => str_contains((string) $r->raw_url, '99999999')),
+            'extractLinkages must write the blob-sourced linkage',
+        );
+        $this->assertFalse(
+            $rows->contains(fn ($r) => str_contains((string) $r->raw_url, 'STALE')),
+            'extractLinkages must not resurrect stale SQL-overlay linkage',
+        );
+    }
+
+    // ── M5 ──────────────────────────────────────────────────────────────────
+
+    public function test_spatial_coverage_is_scoped_to_latest_version(): void
+    {
+        $this->disableObservers();
+
+        $team = Team::first();
+        $user = User::first();
+
+        // v1 coverage: England.
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['coverage']['spatial'] = 'England';
+        [$datasetId] = $this->createDataset($metadata);
+
+        $regionsV1 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('England', $regionsV1);
+        $this->assertNotContains('Scotland', $regionsV1);
+
+        // v2 coverage: Scotland (replaces, does not accumulate).
+        $updateMetadata = $this->getMetadataV2p0();
+        $updateMetadata['metadata']['coverage']['spatial'] = 'Scotland';
+
+        $this->setGwdmHeader('2.0');
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $updateMetadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $regionsV2 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('Scotland', $regionsV2);
+        $this->assertNotContains(
+            'England',
+            $regionsV2,
+            'allSpatialCoverages must reflect only the latest version, not a union across versions',
+        );
+    }
+}

--- a/tests/Feature/DatasetSpatialCoverageTest.php
+++ b/tests/Feature/DatasetSpatialCoverageTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Covers Dataset::allSpatialCoverages being scoped to the latest version only,
+ * so editing coverage (e.g. England -> Scotland) reflects just the new value
+ * rather than a growing union across every version ever written.
+ *
+ * Drives DatasetService directly; the x-gwdm-version header steers the target
+ * GWDM version via GwdmVersionContext.
+ */
+class DatasetSpatialCoverageTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /** Create a 2.0 dataset and return [datasetId, versionId]. */
+    private function createDataset(array $metadata, string $status = Dataset::STATUS_ACTIVE): array
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $this->setGwdmHeader('2.0');
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => $status,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+
+        $this->assertTrue($created['translated']);
+
+        return [$created['dataset_id'], $created['version_id']];
+    }
+
+    public function test_spatial_coverage_is_scoped_to_latest_version(): void
+    {
+        $this->disableObservers();
+
+        $team = Team::first();
+        $user = User::first();
+
+        // v1 coverage: England.
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['coverage']['spatial'] = 'England';
+        [$datasetId] = $this->createDataset($metadata);
+
+        $regionsV1 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('England', $regionsV1);
+        $this->assertNotContains('Scotland', $regionsV1);
+
+        // v2 coverage: Scotland (replaces, does not accumulate).
+        $updateMetadata = $this->getMetadataV2p0();
+        $updateMetadata['metadata']['coverage']['spatial'] = 'Scotland';
+
+        $this->setGwdmHeader('2.0');
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $updateMetadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $regionsV2 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('Scotland', $regionsV2);
+        $this->assertNotContains(
+            'England',
+            $regionsV2,
+            'allSpatialCoverages must reflect only the latest version, not a union across versions',
+        );
+    }
+}

--- a/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
+++ b/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
@@ -87,21 +86,5 @@ class DatasetVersionGwdmVersionColumnTest extends TestCase
         $this->assertNotNull($linked);
         $this->assertSame('Target Title', $linked->title);
         $this->assertSame('TT', $linked->shortTitle);
-    }
-
-    public function test_gwdm_version_backfill_deployment_step_runs_once(): void
-    {
-        $step = '2026_07_14_140156_backfill_gwdm_version';
-
-        $this->assertDatabaseMissing('deployment_steps', ['step' => $step]);
-
-        // deploy:run executes the pending step and records it. On SQLite the
-        // back-fill body no-ops (driver guard) but the step is still marked run.
-        Artisan::call('deploy:run');
-        $this->assertDatabaseHas('deployment_steps', ['step' => $step]);
-
-        // Run-once: a second deploy:run does not re-execute it.
-        Artisan::call('deploy:run');
-        $this->assertStringContainsString('Nothing to run', Artisan::output());
     }
 }

--- a/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
+++ b/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * PR1 coverage for the queryable gwdm_version column on dataset_versions
+ * (migration 2026_06_17_000001) and the reduced-relation selectRaw change on
+ * DatasetVersion that now reads the title column directly rather than extracting
+ * it from the JSON metadata envelope.
+ */
+class DatasetVersionGwdmVersionColumnTest extends TestCase
+{
+    private function seededDatasetId(): int
+    {
+        return Dataset::query()->firstOrFail()->id;
+    }
+
+    public function test_gwdm_version_column_exists_and_defaults_to_2_0(): void
+    {
+        $this->assertTrue(Schema::hasColumn('dataset_versions', 'gwdm_version'));
+
+        $dv = DatasetVersion::withoutEvents(fn () => DatasetVersion::create([
+            'dataset_id' => $this->seededDatasetId(),
+            'version' => 1,
+            'metadata' => json_encode(['gwdmVersion' => '2.0']),
+        ]));
+
+        // No explicit gwdm_version supplied -> the column default applies.
+        $this->assertSame('2.0', $dv->fresh()->gwdm_version);
+    }
+
+    public function test_gwdm_version_is_mass_assignable(): void
+    {
+        $dv = DatasetVersion::withoutEvents(fn () => DatasetVersion::create([
+            'dataset_id' => $this->seededDatasetId(),
+            'version' => 1,
+            'gwdm_version' => '2.1',
+            'metadata' => json_encode(['gwdmVersion' => '2.1']),
+        ]));
+
+        $this->assertSame('2.1', $dv->fresh()->gwdm_version);
+    }
+
+    public function test_reduced_linked_dataset_versions_reads_title_column_for_delta_row(): void
+    {
+        $datasetId = $this->seededDatasetId();
+
+        [$source, $target] = DatasetVersion::withoutEvents(function () use ($datasetId) {
+            $source = DatasetVersion::create([
+                'dataset_id' => $datasetId,
+                'version' => 101,
+                'metadata' => json_encode(['gwdmVersion' => '2.0']),
+                'title' => 'Source Title',
+                'short_title' => 'ST',
+            ]);
+
+            // Delta row: patch present, title lives only in the column (not in the
+            // reduced metadata envelope). The selectRaw must still surface it.
+            $target = DatasetVersion::create([
+                'dataset_id' => $datasetId,
+                'version' => 102,
+                'patch' => json_encode([]),
+                'metadata' => json_encode(['gwdmVersion' => '2.0']),
+                'title' => 'Target Title',
+                'short_title' => 'TT',
+            ]);
+
+            return [$source, $target];
+        });
+
+        DB::table('dataset_version_has_dataset_version')->insert([
+            'dataset_version_source_id' => $source->id,
+            'dataset_version_target_id' => $target->id,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => true,
+        ]);
+
+        $linked = $source->reducedLinkedDatasetVersions()->first();
+
+        $this->assertNotNull($linked);
+        $this->assertSame('Target Title', $linked->title);
+        $this->assertSame('TT', $linked->shortTitle);
+    }
+}

--- a/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
+++ b/tests/Feature/DatasetVersionGwdmVersionColumnTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
@@ -86,5 +87,21 @@ class DatasetVersionGwdmVersionColumnTest extends TestCase
         $this->assertNotNull($linked);
         $this->assertSame('Target Title', $linked->title);
         $this->assertSame('TT', $linked->shortTitle);
+    }
+
+    public function test_gwdm_version_backfill_deployment_step_runs_once(): void
+    {
+        $step = '2026_07_14_140156_backfill_gwdm_version';
+
+        $this->assertDatabaseMissing('deployment_steps', ['step' => $step]);
+
+        // deploy:run executes the pending step and records it. On SQLite the
+        // back-fill body no-ops (driver guard) but the step is still marked run.
+        Artisan::call('deploy:run');
+        $this->assertDatabaseHas('deployment_steps', ['step' => $step]);
+
+        // Run-once: a second deploy:run does not re-execute it.
+        Artisan::call('deploy:run');
+        $this->assertStringContainsString('Nothing to run', Artisan::output());
     }
 }

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -14,20 +14,13 @@ use Tests\Traits\Authorization;
 use Tests\Traits\MockExternalApis;
 
 /**
- * Regression coverage for the GWDM version-handler review fixes:
+ * Covers dataset/publication linkage extraction and read-back via
+ * DatasetService/Gwdm2xHandler.
  *
- *  - H-a: getLinkages() must project raw_url/raw_title so UNRESOLVED (free-text)
- *         linkages round-trip with their title/url instead of rendering null.
- *  - H-b: extractLinkages() must read the reconstructed-from-blob GWDM WITHOUT the
- *         afterRead() SQL overlay, so re-running extraction cannot feed stale
- *         junction-table linkage back into the rows it is about to rewrite.
- *  - M5:  spatial coverage is scoped to the latest version, so editing coverage
- *         (England -> Scotland) reflects only the new value, not a growing union.
- *
- * Drives DatasetService/handlers directly; the x-gwdm-version header steers the
- * target GWDM version via GwdmVersionContext.
+ * Drives DatasetService/handlers directly; the x-gwdm-version header steers
+ * the target GWDM version via GwdmVersionContext.
  */
-class DatasetLinkageCoverageFixTest extends TestCase
+class DatasetVersionLinkageTest extends TestCase
 {
     use Authorization;
     use MockExternalApis {
@@ -75,8 +68,6 @@ class DatasetLinkageCoverageFixTest extends TestCase
         return [$created['dataset_id'], $created['version_id']];
     }
 
-    // ── H-a ─────────────────────────────────────────────────────────────────
-
     public function test_unresolved_linkage_roundtrips_title_and_url_via_get_linkages(): void
     {
         $this->disableObservers();
@@ -104,9 +95,7 @@ class DatasetLinkageCoverageFixTest extends TestCase
         $this->assertSame('isDerivedFrom', $linkages[0]['linkage_type']);
     }
 
-    // ── H-b ─────────────────────────────────────────────────────────────────
-
-    public function test_extract_linkages_uses_blob_not_stale_sql_overlay(): void
+    public function test_extract_linkages_reads_blob_not_stale_sql_overlay(): void
     {
         $this->disableObservers();
 
@@ -151,48 +140,6 @@ class DatasetLinkageCoverageFixTest extends TestCase
         $this->assertFalse(
             $rows->contains(fn ($r) => str_contains((string) $r->raw_url, 'STALE')),
             'extractLinkages must not resurrect stale SQL-overlay linkage',
-        );
-    }
-
-    // ── M5 ──────────────────────────────────────────────────────────────────
-
-    public function test_spatial_coverage_is_scoped_to_latest_version(): void
-    {
-        $this->disableObservers();
-
-        $team = Team::first();
-        $user = User::first();
-
-        // v1 coverage: England.
-        $metadata = $this->getMetadataV2p0();
-        $metadata['metadata']['coverage']['spatial'] = 'England';
-        [$datasetId] = $this->createDataset($metadata);
-
-        $regionsV1 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
-        $this->assertContains('England', $regionsV1);
-        $this->assertNotContains('Scotland', $regionsV1);
-
-        // v2 coverage: Scotland (replaces, does not accumulate).
-        $updateMetadata = $this->getMetadataV2p0();
-        $updateMetadata['metadata']['coverage']['spatial'] = 'Scotland';
-
-        $this->setGwdmHeader('2.0');
-        $this->service()->update(
-            Dataset::find($datasetId),
-            ['metadata' => $updateMetadata, 'status' => Dataset::STATUS_ACTIVE],
-            $user->id,
-            $team->id,
-            Dataset::ORIGIN_MANUAL,
-            false,
-            $team,
-        );
-
-        $regionsV2 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
-        $this->assertContains('Scotland', $regionsV2);
-        $this->assertNotContains(
-            'England',
-            $regionsV2,
-            'allSpatialCoverages must reflect only the latest version, not a union across versions',
         );
     }
 }

--- a/tests/Feature/DatasetVersionSchemaChangeTest.php
+++ b/tests/Feature/DatasetVersionSchemaChangeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * PR2 coverage for H4 — persistMetadataVersion() must force a full snapshot when
+ * the GWDM schema version changes between the previous version and the new one,
+ * so every delta window stays schema-homogeneous (a patch diffed across differing
+ * schemas would be meaningless, and reconstruction resolves its handler from the
+ * nearest snapshot's gwdm_version).
+ *
+ * Drives DatasetService directly (the V3 HTTP route that normally calls update()
+ * lands in a later PR of the stack); the x-gwdm-version header steers the target
+ * version via GwdmVersionContext.
+ */
+class DatasetVersionSchemaChangeTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    public function test_schema_change_forces_snapshot_while_same_schema_stays_delta(): void
+    {
+        // This test asserts the service's snapshot/delta versioning decision, not
+        // Elasticsearch indexing. Disable observers so no ReindexDataset/IndexDataset
+        // jobs are dispatched from the create/update model writes.
+        $this->disableObservers();
+
+        $team = Team::first();
+        $user = User::first();
+        $metadata = $this->getMetadataV2p0();
+
+        // --- v1 @ GWDM 2.0 : base row is always a snapshot ---
+        $this->setGwdmHeader('2.0');
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+
+        $this->assertTrue($created['translated']);
+        $datasetId = $created['dataset_id'];
+
+        $v1 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 1)->first();
+        $this->assertNull($v1->patch, 'v1 base row must be a snapshot');
+        $this->assertSame('2.0', $v1->gwdm_version);
+
+        // --- v2 @ GWDM 2.0 : schema unchanged -> delta row ---
+        $this->setGwdmHeader('2.0');
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $metadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $v2 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 2)->first();
+        $this->assertNotNull($v2->patch, 'same-schema update should be a delta (patch present)');
+        $this->assertSame('2.0', $v2->gwdm_version);
+
+        // --- v3 @ GWDM 2.1 : schema change -> forced snapshot (H4) ---
+        $this->setGwdmHeader('2.1');
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $this->getMetadataV2p1(), 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $v3 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 3)->first();
+        $this->assertNull($v3->patch, 'H4: a schema change must force a full snapshot (patch null)');
+        $this->assertSame('2.1', $v3->gwdm_version);
+    }
+}

--- a/tests/Feature/DatasetVersionSchemaChangeTest.php
+++ b/tests/Feature/DatasetVersionSchemaChangeTest.php
@@ -12,15 +12,15 @@ use Tests\Traits\Authorization;
 use Tests\Traits\MockExternalApis;
 
 /**
- * PR2 coverage for H4 — persistMetadataVersion() must force a full snapshot when
- * the GWDM schema version changes between the previous version and the new one,
- * so every delta window stays schema-homogeneous (a patch diffed across differing
- * schemas would be meaningless, and reconstruction resolves its handler from the
- * nearest snapshot's gwdm_version).
+ * persistMetadataVersion() must force a full snapshot when the GWDM schema
+ * version changes between the previous version and the new one, so every
+ * delta window stays schema-homogeneous — a patch diffed across differing
+ * schemas would be meaningless, and reconstruction resolves its handler from
+ * the nearest snapshot's gwdm_version.
  *
- * Drives DatasetService directly (the V3 HTTP route that normally calls update()
- * lands in a later PR of the stack); the x-gwdm-version header steers the target
- * version via GwdmVersionContext.
+ * Drives DatasetService directly (the V3 HTTP route that normally calls
+ * update() lands in a later branch of this stack); the x-gwdm-version header
+ * steers the target version via GwdmVersionContext.
  */
 class DatasetVersionSchemaChangeTest extends TestCase
 {
@@ -107,7 +107,7 @@ class DatasetVersionSchemaChangeTest extends TestCase
         );
 
         $v3 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 3)->first();
-        $this->assertNull($v3->patch, 'H4: a schema change must force a full snapshot (patch null)');
+        $this->assertNull($v3->patch, 'a schema change must force a full snapshot (patch null)');
         $this->assertSame('2.1', $v3->gwdm_version);
     }
 }

--- a/tests/Feature/FormHydrationTest.php
+++ b/tests/Feature/FormHydrationTest.php
@@ -250,6 +250,10 @@ class FormHydrationTest extends TestCase
             ]);
 
         $defaultValues = $response->decodeResponseJson()['data']['defaultValues'];
+        // The data-custodian default identifier must be the team's pid (persistent,
+        // public id), NOT the internal MySQL primary key — this hydrates
+        // summary.dataCustodian.identifier, which downstream flows resolve as a pid.
+        $this->assertEquals(Team::find($teamId)->pid, $defaultValues['identifier']);
         $this->assertEquals($defaultValues['Name of Data Custodian'], 'Form hydration test team');
         $this->assertEquals($defaultValues['Jurisdiction'], ['UK']);
         $this->assertNull($defaultValues['Organisation Logo']);

--- a/tests/Feature/GwdmHandlerFactoryTest.php
+++ b/tests/Feature/GwdmHandlerFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\Gwdm\Gwdm1xHandler;
+use App\Services\Gwdm\Gwdm20Handler;
+use App\Services\Gwdm\Gwdm21Handler;
+use App\Services\Gwdm\Gwdm2xHandler;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Tests\TestCase;
+
+/**
+ * PR2 coverage for the single point of GWDM version branching. This factory is
+ * the ONLY place allowed to switch on the schema version; all scattered
+ * version_compare() calls in DatasetService were replaced by resolve() here.
+ *
+ * NOTE: in this PR the 3.0 arm is intentionally absent — GWDM 3.0 is enabled in
+ * a later PR of the stack once its handler + SQL tables exist. This test guards
+ * that 3.0 is not yet user-selectable so enabling it early cannot 500.
+ */
+class GwdmHandlerFactoryTest extends TestCase
+{
+    protected bool $shouldFakeQueue = false;
+
+    private function factory(): GwdmHandlerFactory
+    {
+        return new GwdmHandlerFactory();
+    }
+
+    public function test_resolves_legacy_versions_to_1x_handler(): void
+    {
+        $this->assertInstanceOf(Gwdm1xHandler::class, $this->factory()->resolve('1.0'));
+    }
+
+    public function test_resolves_2_0_and_2_1_to_dedicated_handlers(): void
+    {
+        $this->assertInstanceOf(Gwdm20Handler::class, $this->factory()->resolve('2.0'));
+        $this->assertInstanceOf(Gwdm21Handler::class, $this->factory()->resolve('2.1'));
+    }
+
+    public function test_resolves_unknown_1_1_plus_version_to_2x_catch_all(): void
+    {
+        $this->assertInstanceOf(Gwdm2xHandler::class, $this->factory()->resolve('1.5'));
+    }
+
+    public function test_supported_versions_are_2_0_and_2_1_only(): void
+    {
+        // 3.0 is deliberately NOT yet supported in this PR of the stack.
+        $this->assertSame(['2.0', '2.1'], GwdmHandlerFactory::supportedVersions());
+        $this->assertNotContains('3.0', GwdmHandlerFactory::supportedVersions());
+    }
+}

--- a/tests/Feature/GwdmVersionContextTest.php
+++ b/tests/Feature/GwdmVersionContextTest.php
@@ -7,13 +7,14 @@ use Config;
 use Tests\TestCase;
 
 /**
- * PR2 coverage for the GWDM version request context — the read/write header split
- * that the whole handler-resolution refactor pivots on.
+ * Covers the GWDM version request context — the read/write header split that
+ * the handler-resolution refactor pivots on.
  *
- * Guards the C2 fix (requestedVersion() must return null on an absent header so the
- * read path falls back to the genuine latest version, rather than a config default)
- * and the deliberate asymmetry between the write path (targetVersion, config
- * fallback) and the read path (requestedVersion, null on absent header).
+ * Guards two things: requestedVersion() must return null when the
+ * x-gwdm-version header is absent (so the read path falls back to the
+ * dataset's genuine latest version, not a config default), and the
+ * deliberate asymmetry between the write path (targetVersion(), config
+ * fallback) and the read path (requestedVersion(), null on absent header).
  */
 class GwdmVersionContextTest extends TestCase
 {
@@ -66,7 +67,7 @@ class GwdmVersionContextTest extends TestCase
         Config::set('metadata.GWDM.version', '2.1');
         $this->setHeader(null);
 
-        // C2: read path must NOT substitute the config default — null signals the
+        // Read path must NOT substitute the config default — null signals the
         // caller to use the genuine latest version of the dataset.
         $this->assertNull($this->context()->requestedVersion());
     }

--- a/tests/Feature/GwdmVersionContextTest.php
+++ b/tests/Feature/GwdmVersionContextTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Context\GwdmVersionContext;
+use Config;
+use Tests\TestCase;
+
+/**
+ * PR2 coverage for the GWDM version request context — the read/write header split
+ * that the whole handler-resolution refactor pivots on.
+ *
+ * Guards the C2 fix (requestedVersion() must return null on an absent header so the
+ * read path falls back to the genuine latest version, rather than a config default)
+ * and the deliberate asymmetry between the write path (targetVersion, config
+ * fallback) and the read path (requestedVersion, null on absent header).
+ */
+class GwdmVersionContextTest extends TestCase
+{
+    protected bool $shouldFakeQueue = false;
+
+    private function context(): GwdmVersionContext
+    {
+        return new GwdmVersionContext();
+    }
+
+    private function setHeader(?string $value): void
+    {
+        if ($value === null) {
+            request()->headers->remove('x-gwdm-version');
+
+            return;
+        }
+
+        request()->headers->set('x-gwdm-version', $value);
+    }
+
+    public function test_target_version_falls_back_to_config_when_header_absent(): void
+    {
+        Config::set('metadata.GWDM.version', '2.1');
+        $this->setHeader(null);
+
+        // Write path: no header -> configured system-wide GWDM version.
+        $this->assertSame('2.1', $this->context()->targetVersion());
+    }
+
+    public function test_target_version_uses_supported_header_when_present(): void
+    {
+        Config::set('metadata.GWDM.version', '2.0');
+        $this->setHeader('2.1');
+
+        $this->assertSame('2.1', $this->context()->targetVersion());
+    }
+
+    public function test_target_version_ignores_unsupported_header_and_falls_back(): void
+    {
+        Config::set('metadata.GWDM.version', '2.0');
+        $this->setHeader('9.9');
+
+        // An unrecognised write header is ignored (not fatal) -> config fallback.
+        $this->assertSame('2.0', $this->context()->targetVersion());
+    }
+
+    public function test_requested_version_returns_null_when_header_absent(): void
+    {
+        Config::set('metadata.GWDM.version', '2.1');
+        $this->setHeader(null);
+
+        // C2: read path must NOT substitute the config default — null signals the
+        // caller to use the genuine latest version of the dataset.
+        $this->assertNull($this->context()->requestedVersion());
+    }
+
+    public function test_requested_version_returns_supported_header(): void
+    {
+        $this->setHeader('2.0');
+
+        $this->assertSame('2.0', $this->context()->requestedVersion());
+    }
+
+    public function test_requested_version_throws_on_unsupported_header(): void
+    {
+        $this->setHeader('9.9');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->context()->requestedVersion();
+    }
+}

--- a/tests/Unit/Console/Commands/NormalisePublisherGatewayIdTest.php
+++ b/tests/Unit/Console/Commands/NormalisePublisherGatewayIdTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Console\Commands\NormalisePublisherGatewayId;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use Config;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Coverage for the publisher gatewayId backfill:
+ *   - snapshot rows: fix summary.publisher.gatewayId in the full envelope;
+ *   - delta rows: fix a /summary/publisher/gatewayId patch op value;
+ *   - --dry-run makes no changes.
+ */
+class NormalisePublisherGatewayIdTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected function setUp(): void
+    {
+        $this->commonSetUp();
+
+        // Avoid Elasticsearch indexing / job dispatch on version writes.
+        Dataset::flushEventListeners();
+        DatasetVersion::flushEventListeners();
+    }
+
+    private function snapshotEnvelope(int|string $gatewayId, string $title = 'T'): array
+    {
+        return [
+            'gwdmVersion' => Config::get('metadata.GWDM.version'),
+            'metadata' => [
+                'summary' => [
+                    'title' => $title,
+                    'publisher' => ['gatewayId' => $gatewayId, 'name' => 'Org'],
+                ],
+            ],
+            'original_metadata' => ['summary' => ['publisher' => ['gatewayId' => $gatewayId]]],
+        ];
+    }
+
+    public function test_backfills_snapshot_gateway_id_to_pid(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+
+        // gatewayId wrongly stored as the numeric primary key.
+        $dv = DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'patch' => null,
+            'metadata' => $this->snapshotEnvelope((string) $team->id),
+            'title' => 'T',
+            'short_title' => 'T',
+        ]);
+
+        $this->artisan(NormalisePublisherGatewayId::class)->assertExitCode(0);
+
+        $fresh = DatasetVersion::find($dv->id);
+        $this->assertSame($team->pid, $fresh->metadata['metadata']['summary']['publisher']['gatewayId']);
+        // original_metadata left untouched (audit trail).
+        $this->assertSame((string) $team->id, $fresh->metadata['original_metadata']['summary']['publisher']['gatewayId']);
+    }
+
+    public function test_backfills_delta_patch_op_value_to_pid(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+
+        DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'patch' => null,
+            'metadata' => $this->snapshotEnvelope($team->pid),
+            'title' => 'T',
+            'short_title' => 'T',
+        ]);
+
+        $delta = DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 2,
+            'patch' => [[
+                'op' => 'replace',
+                'path' => '/summary/publisher/gatewayId',
+                'value' => (string) $team->id,
+            ]],
+            'metadata' => [],
+            'title' => 'T',
+            'short_title' => 'T',
+        ]);
+
+        $this->artisan(NormalisePublisherGatewayId::class)->assertExitCode(0);
+
+        $fresh = DatasetVersion::find($delta->id);
+        $this->assertSame($team->pid, $fresh->patch[0]['value']);
+    }
+
+    public function test_dry_run_makes_no_changes(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+        $dataset = Dataset::factory()->for($team)->create(['status' => Dataset::STATUS_ACTIVE]);
+
+        $dv = DatasetVersion::create([
+            'dataset_id' => $dataset->id,
+            'version' => 1,
+            'patch' => null,
+            'metadata' => $this->snapshotEnvelope((string) $team->id),
+            'title' => 'T',
+            'short_title' => 'T',
+        ]);
+
+        $this->artisan(NormalisePublisherGatewayId::class, ['--dry-run' => true])->assertExitCode(0);
+
+        $fresh = DatasetVersion::find($dv->id);
+        // Unchanged: still the raw primary key.
+        $this->assertSame((string) $team->id, $fresh->metadata['metadata']['summary']['publisher']['gatewayId']);
+    }
+}

--- a/tests/Unit/Gwdm/PublisherResolutionTest.php
+++ b/tests/Unit/Gwdm/PublisherResolutionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\Gwdm;
+
+use App\Models\Team;
+use App\Services\Gwdm\Gwdm1xHandler;
+use App\Services\Gwdm\Gwdm2xHandler;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Covers the raw + normalise + team-fallback behaviour of resolvePublisher()
+ * on the GWDM handlers.
+ *
+ *   - RAW: an incoming publisher naming a *different* organisation is honoured
+ *     (enables publish-on-behalf), not overwritten with the requesting team.
+ *   - NORMALISE: the gateway identifier is stored as a pid, whether the payload
+ *     supplied a primary key or a pid.
+ *   - FALLBACK: an absent or unresolvable publisher falls back to the requesting
+ *     team (by pid).
+ */
+class PublisherResolutionTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    protected function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function handler2x(): Gwdm2xHandler
+    {
+        return new Gwdm2xHandler('2.0');
+    }
+
+    private function handler1x(): Gwdm1xHandler
+    {
+        return new Gwdm1xHandler('1.0');
+    }
+
+    public function test_2x_preserves_incoming_pid_and_extra_keys(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler2x()->resolvePublisher(
+            ['gatewayId' => $team->pid, 'name' => 'Custom Publisher', 'rorId' => '012345678'],
+            $team,
+        );
+
+        $this->assertSame($team->pid, $result['gatewayId']);
+        $this->assertSame('Custom Publisher', $result['name']);
+        $this->assertSame('012345678', $result['rorId']);
+    }
+
+    public function test_2x_normalises_numeric_id_to_pid(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler2x()->resolvePublisher(
+            ['gatewayId' => (string) $team->id, 'name' => 'Org'],
+            $team,
+        );
+
+        $this->assertSame($team->pid, $result['gatewayId']);
+        $this->assertSame('Org', $result['name']);
+    }
+
+    public function test_2x_honours_a_different_publishing_team_normalised_to_pid(): void
+    {
+        // Requesting team A submits metadata whose publisher is team B.
+        $teamA = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+        $teamB = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler2x()->resolvePublisher(
+            ['gatewayId' => (string) $teamB->id],
+            $teamA,
+        );
+
+        // Raw data honoured: publisher is team B, normalised to team B's pid.
+        $this->assertSame($teamB->pid, $result['gatewayId']);
+        $this->assertSame($teamB->name, $result['name']);
+    }
+
+    public function test_2x_falls_back_to_requesting_team_when_publisher_absent(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler2x()->resolvePublisher([], $team);
+
+        $this->assertSame(['gatewayId' => $team->pid, 'name' => $team->name], $result);
+    }
+
+    public function test_2x_falls_back_when_gateway_id_unresolvable(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler2x()->resolvePublisher(
+            ['gatewayId' => '99999999', 'name' => 'Ghost Org'],
+            $team,
+        );
+
+        $this->assertSame(['gatewayId' => $team->pid, 'name' => $team->name], $result);
+    }
+
+    public function test_1x_normalises_publisher_id_to_pid(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler1x()->resolvePublisher(
+            ['publisherId' => (string) $team->id],
+            $team,
+        );
+
+        $this->assertSame($team->pid, $result['publisherId']);
+        $this->assertSame($team->name, $result['publisherName']);
+    }
+
+    public function test_1x_falls_back_to_requesting_team_when_absent(): void
+    {
+        $team = Team::factory()->create(['pid' => 'pid-'.uniqid()]);
+
+        $result = $this->handler1x()->resolvePublisher([], $team);
+
+        $this->assertSame(['publisherId' => $team->pid, 'publisherName' => $team->name], $result);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

N/A.

## Describe your changes

**Fix PR** — stacked on PR2 (`feat/GAT-9018-2`). PR #1703.

`summary.publisher` is now driven by the raw (post-TRASER) payload rather than synthesised from the requesting team, while its gateway identifier is normalised to a team `pid` — enabling publish-on-behalf and stopping id/pid corruption.

- **`GwdmMetadataHandler`** — add `resolveTeamFromGatewayId()` (id-or-pid, public static) and `resolvePublisherWithKeys()`; `buildPublisher()` becomes the fallback-only builder; add abstract `resolvePublisher()`.
- **`Gwdm2xHandler` / `Gwdm1xHandler`** — `resolvePublisher()` (raw + normalise `gatewayId`/`publisherId` to pid + fall back to requesting team); `prepareMetadata()` uses it.
- **Legacy V1 inline write paths** (`MetadataOnboard` trait, `IntegrationDatasetController`) apply the same normalisation via `MetadataOnboard::normalisePublisher()`.
- **`app:normalise-publisher-gateway-id`** backfill command — fixes snapshot envelopes and delta patch ops (`gatewayId` + legacy `publisherId`), leaves `original_metadata` untouched; registered in `RunPostMigrations` before the datasets reindex.
- **`FormHydrationController`** — `dataCustodian` identifier default → team pid (+ test).

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9219

## Environment / Configuration changes (if applicable)

None.

## Requires migrations being run?

No schema migration. Adds a data backfill command (`app:normalise-publisher-gateway-id`) wired into `RunPostMigrations` (runs before the datasets reindex).

## If not using the pre-push hook. Confirm tests pass:

- New: `PublisherResolutionTest`, `NormalisePublisherGatewayIdTest`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable) — N/A
- [ ] I have added Swagger annotations for new endpoints (if applicable) — no new endpoints
- [ ] I have added audit logs for new operation logic (if applicable) — N/A
- [ ] I have added new environment variables to the .env.example file (if applicable) — N/A
- [ ] I have added new environment variables to terraform repository (if applicable) — N/A
