### PR TITLE
fix(GAT-9018): free-text linkage fallback + IndexElastic delta-row fixes

### DIFF
--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -19,7 +19,6 @@ use App\Http\Requests\V2\Dataset\DeleteDataset;
 use App\Http\Requests\V2\Dataset\UpdateDataset;
 use App\Exports\DatasetStructuralMetadataExport;
 use App\Http\Traits\GetValueByPossibleKeys;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -187,6 +186,15 @@ class DatasetController extends Controller
                 return $this->streamStructuralMetadataExport($dataset, $id);
             }
 
+            if ($request->query('view') === 'metadataOnly') {
+                $metadata = $this->datasetService->getMetadataOnly(
+                    $dataset,
+                    $request->query('schema_model') ?? $this->outputSchemaContext->schemaModel(),
+                    $request->query('schema_version') ?? $this->outputSchemaContext->schemaVersion(),
+                );
+                return response()->json(['message' => 'success', 'data' => $metadata]);
+            }
+
             $dataset = $this->datasetService->prepareForShow(
                 $dataset,
                 $request->query('schema_model') ?? $this->outputSchemaContext->schemaModel(),
@@ -209,7 +217,7 @@ class DatasetController extends Controller
 
         } catch (\InvalidArgumentException $e) {
             return response()->json(['message' => $e->getMessage()], 400);
-        } catch (ModelNotFoundException $e) {
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             return response()->json(['message' => $e->getMessage()], 404);
         } catch (\RuntimeException $e) {
             return response()->json(['message' => 'failed to translate', 'details' => $e->getMessage()], 400);

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -2,19 +2,14 @@
 
 namespace App\Http\Traits;
 
-use Auditor;
-use Config;
-use Exception;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use App\Models\Collection;
 use App\Models\CollectionHasDatasetVersion;
 use App\Models\CollectionHasDur;
+use App\Models\DataProviderColl;
+use App\Models\DataProviderCollHasTeam;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\DatasetVersionHasTool;
-use App\Models\DataProviderColl;
-use App\Models\DataProviderCollHasTeam;
 use App\Models\Dur;
 use App\Models\DurHasDatasetVersion;
 use App\Models\License;
@@ -31,27 +26,88 @@ use App\Models\ToolHasProgrammingPackage;
 use App\Models\ToolHasTag;
 use App\Models\ToolHasTypeCategory;
 use App\Models\TypeCategory;
+use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Auditor;
+use Config;
 use ElasticClientController as ECC;
+use Exception;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 
 trait IndexElastic
 {
     use GetValueByPossibleKeys;
 
     private $datasets = [];
+
     private $durs = [];
+
     private $tools = [];
+
     private $publications = [];
+
     private $collections = [];
+
+    /**
+     * Single named resolution point for DatasetService within this trait.
+     *
+     * Constructor injection isn't viable here: IndexElastic is a trait consumed
+     * by ~20 unrelated controllers/jobs/observers, so there is no single
+     * constructor to inject into without a much larger refactor.
+     */
+    private function datasetService(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /**
+     * Reconstruct the full GWDM envelope for a dataset's latest version.
+     *
+     * DatasetVersion->metadata cannot be read directly for indexing: delta rows
+     * store an empty metadata blob, and GWDM 3.0 rows omit the `metadata` key
+     * entirely (their data lives in dedicated SQL tables). Funnelling through
+     * DatasetService::getReconstructedMetadataEnvelope() yields a complete
+     * {gwdmVersion, metadata, original_metadata} envelope for every schema
+     * version and every snapshot/delta storage shape. Validation is skipped —
+     * data is validated at write time.
+     *
+     * @return array The reconstructed envelope, or [] when the dataset has no versions.
+     */
+    private function reconstructedLatestEnvelope(Dataset $dataset): array
+    {
+        $version = $dataset->latestVersion();
+
+        if (! $version) {
+            return [];
+        }
+
+        return $this->datasetService()->getReconstructedMetadataEnvelope(
+            $dataset->id,
+            $version->version,
+            false,
+            $version,
+        );
+    }
+
+    private function isElasticIndexable(array $envelope): bool
+    {
+        $version = $envelope['gwdmVersion'] ?? null;
+
+        if ($version === null) {
+            return true; // shouldnt hit here, but perserve original behaviour if
+        }
+
+        return app(GwdmHandlerFactory::class)->resolve($version)->supportsElasticIndexing();
+    }
 
     /**
      * Calls a re-indexing of Elastic search when a dataset is created, updated or added to a collection.
      *
-     * @param string $datasetId The dataset id from the DB.
-     * @param bool $returnParams Optional flag to return parameters.
-     *
-     * @return null|array
+     * @param  string  $datasetId  The dataset id from the DB.
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function reindexElastic(string $datasetId, bool $returnParams = false, bool $activeCheck = true): null|array
+    public function reindexElastic(string $datasetId, bool $returnParams = false, bool $activeCheck = true): ?array
     {
         try {
             $datasetMatch = Dataset::where('id', $datasetId)
@@ -71,7 +127,15 @@ trait IndexElastic
                 // throw new \Exception("Error: DatasetVersion is missing for dataset ID=$datasetId.");
             }
 
-            $metadata = $datasetMatch->latestVersion()->metadata;
+            $metadata = $this->reconstructedLatestEnvelope($datasetMatch);
+
+            if (! $this->isElasticIndexable($metadata)) {
+                $this->deleteDatasetFromElastic($datasetId);
+
+                return null;
+            }
+
+            $latestVersion = $datasetMatch->latestVersion();
 
             // inject relationships via Local functions
             $materialTypes = $this->getMaterialTypes($metadata);
@@ -82,8 +146,10 @@ trait IndexElastic
                 'abstract' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.abstract'], ''),
                 'keywords' => $this->normalizeDelimitedList($this->getValueByPossibleKeys($metadata, ['metadata.summary.keywords'], '')),
                 'description' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.description'], ''),
-                'shortTitle' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], ''),
-                'title' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.title'], ''),
+                // short_title/title are populated columns on every write (see DatasetVersion);
+                // only fall back to the envelope for legacy pre-migration rows where they're null.
+                'shortTitle' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], '') ?? $latestVersion->short_title,
+                'title' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.title'], '') ?? $latestVersion->title,
                 'populationSize' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.populationSize'], -1),
                 'publisherName' => $this->getValueByPossibleKeys($metadata, ['metadata.summary.publisher.name', 'metadata.summary.publisher.publisherName'], ''),
                 'startDate' => $this->getValueByPossibleKeys($metadata, ['metadata.provenance.temporal.startDate'], null),
@@ -94,7 +160,7 @@ trait IndexElastic
                 'sampleAvailability' => $materialTypes,
                 'conformsTo' => $this->normalizeDelimitedList($this->getValueByPossibleKeys($metadata, ['metadata.accessibility.formatAndStandards.conformsTo'], '')),
                 'hasTechnicalMetadata' => (bool) count($this->getValueByPossibleKeys($metadata, ['metadata.structuralMetadata'], [])),
-                'named_entities' =>  array_map(fn ($entity) => $entity['name'], $datasetMatch->allNamedEntities),
+                'named_entities' => array_map(fn ($entity) => $entity['name'], $datasetMatch->allNamedEntities),
                 'collectionName' => array_map(fn ($collection) => $collection['name'], $datasetMatch->allCollections),
                 'dataUseTitles' => array_map(fn ($dur) => $dur['project_title'], $datasetMatch->allDurs),
                 'geographicLocation' => array_map(fn ($spatialCoverage) => $spatialCoverage['region'], $datasetMatch->allSpatialCoverages),
@@ -116,14 +182,16 @@ trait IndexElastic
                 'index' => ECC::ELASTIC_NAME_DATASET,
                 'id' => $datasetMatch->id,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             if ($returnParams) {
                 unset($metadata);
+
                 return $params;
             }
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
@@ -135,7 +203,7 @@ trait IndexElastic
 
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -220,7 +288,7 @@ trait IndexElastic
             ]
         );
 
-        if (!count($rows)) {
+        if (! count($rows)) {
             return [];
         }
 
@@ -251,12 +319,10 @@ trait IndexElastic
     /**
      * Calls a re-indexing of Elastic search when a data provider id is given.
      *
-     * @param string $teamId The team id from the DB.
-     * @param bool $returnParams Optional flag to return parameters.
-     *
-     * @return null|array
+     * @param  string  $teamId  The team id from the DB.
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function reindexElasticDataProvider(string $teamId, bool $returnParams = false): null|array
+    public function reindexElasticDataProvider(string $teamId, bool $returnParams = false): ?array
     {
         try {
             $datasets = Dataset::where([
@@ -281,20 +347,23 @@ trait IndexElastic
             foreach ($datasets as $dataset) {
                 $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages);
                 foreach ($dataset['spatialCoverage'] as $loc) {
-                    if (!in_array($loc['region'], $locations)) {
+                    if (! in_array($loc['region'], $locations)) {
                         $locations[] = $loc['region'];
                     }
                 }
 
                 $latestVersion = $dataset->latestVersion();
                 if ($latestVersion) {
-                    $datasetVersionIds[] = $latestVersion->id;
-                    $metadata = $latestVersion->metadata;
-                    $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
-                    $types = explode(';,;', $metadata['metadata']['summary']['datasetType']);
-                    foreach ($types as $t) {
-                        if (!in_array($t, $dataTypes)) {
-                            $dataTypes[] = $t;
+                    $metadata = $this->reconstructedLatestEnvelope($dataset);
+
+                    if ($this->isElasticIndexable($metadata)) {
+                        $datasetVersionIds[] = $latestVersion->id;
+                        $datasetTitles[] = $latestVersion->short_title ?? $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], '');
+                        $types = $this->normalizeDelimitedList($this->getValueByPossibleKeys($metadata, ['metadata.summary.datasetType'], ''));
+                        foreach ($types as $t) {
+                            if (! in_array($t, $dataTypes)) {
+                                $dataTypes[] = $t;
+                            }
                         }
                     }
                 }
@@ -362,13 +431,14 @@ trait IndexElastic
                 'index' => 'dataprovider',
                 'id' => $teamId,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
             if ($returnParams) {
                 return $params;
             }
 
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
@@ -441,14 +511,12 @@ trait IndexElastic
     /**
      * Insert collection document into elastic index
      *
-     * @param integer $collectionId
-     * @param bool $returnParams Optional flag to return parameters.
-     * @return null|array
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function indexElasticCollections(int $collectionId, bool $returnParams = false): null|array
+    public function indexElasticCollections(int $collectionId, bool $returnParams = false): ?array
     {
         $collection = Collection::with(['team', 'keywords'])->where('id', $collectionId)->first();
-        $datasets = $collection->allDatasets  ?? [];
+        $datasets = $collection->allDatasets ?? [];
 
         $datasetIds = array_map(function ($dataset) {
             return $dataset['id'];
@@ -457,18 +525,25 @@ trait IndexElastic
         $collection = $collection->toArray();
         $team = $collection['team'];
 
-        $datasetTitles = array();
-        $datasetAbstracts = array();
+        $datasetTitles = [];
+        $datasetAbstracts = [];
         foreach ($datasetIds as $d) {
-            $metadata = Dataset::where(['id' => $d])
-                ->first()
-                ->latestVersion()
-                ->metadata;
-            $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
-            $datasetAbstracts[] = $metadata['metadata']['summary']['abstract'];
+            $datasetRow = Dataset::where(['id' => $d])->first();
+            $latestVersion = $datasetRow?->latestVersion();
+            if (! $latestVersion) {
+                continue;
+            }
+
+            $metadata = $this->reconstructedLatestEnvelope($datasetRow);
+            if (! $this->isElasticIndexable($metadata)) {
+                continue;
+            }
+
+            $datasetTitles[] = $latestVersion->short_title ?? $this->getValueByPossibleKeys($metadata, ['metadata.summary.shortTitle'], '');
+            $datasetAbstracts[] = $this->getValueByPossibleKeys($metadata, ['metadata.summary.abstract'], '');
         }
 
-        $keywords = array();
+        $keywords = [];
         foreach ($collection['keywords'] as $k) {
             $keywords[] = $k['name'];
         }
@@ -491,25 +566,26 @@ trait IndexElastic
                 'datasetTitles' => $datasetTitles,
                 'datasetAbstracts' => $datasetAbstracts,
                 'keywords' => $keywords,
-                'dataProviderColl' => $dataProviderColl
+                'dataProviderColl' => $dataProviderColl,
             ];
             $params = [
                 'index' => ECC::ELASTIC_NAME_COLLECTION,
                 'id' => $collectionId,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             if ($returnParams) {
                 return $params;
             }
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -519,26 +595,21 @@ trait IndexElastic
 
     /**
      * Insert data provider document into elastic index
-     *
-     * @param integer $id
-     * @return void
      */
     private function indexElasticDataProviderColl(int $id): void
     {
         $provider = DataProviderColl::where('id', $id)->with('teams')->first();
 
-
-        $datasetTitles = array();
-        $locations = array();
+        $datasetTitles = [];
+        $locations = [];
         foreach ($provider['teams'] as $team) {
             $datasets = Dataset::where('team_id', $team['id'])->with(['versions'])->get();
 
             foreach ($datasets as $dataset) {
-                $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages  ?? []);
-                $metadata = $dataset['versions'][0];
-                $datasetTitles[] = $metadata['metadata']['metadata']['summary']['shortTitle'];
+                $dataset->setAttribute('spatialCoverage', $dataset->allSpatialCoverages ?? []);
+                $datasetTitles[] = $dataset->latestVersion()?->short_title ?? '';
                 foreach ($dataset['spatialCoverage'] as $loc) {
-                    if (!in_array($loc['region'], $locations)) {
+                    if (! in_array($loc['region'], $locations)) {
                         $locations[] = $loc['region'];
                     }
                 }
@@ -556,7 +627,7 @@ trait IndexElastic
                 'index' => ECC::ELASTIC_NAME_DATAPROVIDERCOLL,
                 'id' => $id,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             ECC::indexDocument($params);
@@ -564,7 +635,7 @@ trait IndexElastic
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -575,12 +646,10 @@ trait IndexElastic
     /**
      * Calls a re-indexing of Elastic search when a data use is created or updated
      *
-     * @param string $id The dur id from the DB
-     * @param bool $returnParams Optional flag to return parameters.
-     *
-     * @return null|array
+     * @param  string  $id  The dur id from the DB
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function indexElasticDur(string $id, bool $returnParams = false): null|array
+    public function indexElasticDur(string $id, bool $returnParams = false): ?array
     {
         try {
 
@@ -588,7 +657,7 @@ trait IndexElastic
                 ->with(['keywords', 'team', 'sector'])
                 ->first();
 
-            $datasets = $durMatch->allDatasets  ?? [];
+            $datasets = $durMatch->allDatasets ?? [];
 
             $datasetIds = array_map(function ($dataset) {
                 return $dataset['id'];
@@ -596,23 +665,19 @@ trait IndexElastic
 
             $durMatch = $durMatch->toArray();
 
-            $datasetTitles = array();
+            $datasetTitles = [];
             foreach ($datasetIds as $d) {
-                $metadata = Dataset::where(['id' => $d])
-                    ->first()
-                    ->latestVersion()
-                    ->metadata;
-                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                $datasetTitles[] = Dataset::where(['id' => $d])->first()->latestVersion()->short_title ?? '';
             }
 
-            $keywords = array();
+            $keywords = [];
             foreach ($durMatch['keywords'] as $k) {
                 $keywords[] = $k['name'];
             }
 
             $sector = ($durMatch['sector'] != null) ? Sector::where(
                 [
-                    'id' => $durMatch['sector']
+                    'id' => $durMatch['sector'],
                 ]
             )->first()->name : null;
 
@@ -642,7 +707,7 @@ trait IndexElastic
                 'index' => ECC::ELASTIC_NAME_DUR,
                 'id' => $id,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             if ($returnParams) {
@@ -650,12 +715,13 @@ trait IndexElastic
             }
 
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -666,12 +732,10 @@ trait IndexElastic
     /**
      * Calls a re-indexing of Elastic search when a publication is created or updated
      *
-     * @param string $id The publication id from the DB
-     * @param bool $returnParams Optional flag to return parameters.
-     *
-     * @return null|array
+     * @param  string  $id  The publication id from the DB
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function indexElasticPublication(string $id, bool $returnParams = false): null|array
+    public function indexElasticPublication(string $id, bool $returnParams = false): ?array
     {
         try {
             $pubMatch = Publication::where(['id' => $id])->with(['keywords:id,name'])->first();
@@ -698,25 +762,26 @@ trait IndexElastic
             ];
 
             foreach ($datasets as $dataset) {
-                $metadata = Dataset::where(['id' => $dataset['id']])->first()->latestVersion()->metadata;
-                $latestVersionID = Dataset::where(['id' => $dataset['id']])->first()->latestVersion()->id;
-                $datasetTitles[] = $metadata['metadata']['summary']['shortTitle'];
+                $datasetModel = Dataset::where(['id' => $dataset['id']])->first();
+                $latestVersion = $datasetModel->latestVersion();
+                $latestVersionID = $latestVersion->id;
+                $datasetTitles[] = $latestVersion->short_title ?? '';
 
                 // change from 'UNKNOWN' to 'USING' - temp
                 $linkType = PublicationHasDatasetVersion::where([
-                    'publication_id' => (int)$id,
-                    'dataset_version_id' => (int)$latestVersionID
+                    'publication_id' => (int) $id,
+                    'dataset_version_id' => (int) $latestVersionID,
                 ])->first()->link_type ?? 'USING';
 
-                $datasetLinkTypes[] =  array_key_exists($linkType, $linkTypeMappings) ? $linkTypeMappings[$linkType] : 'Unknown';
+                $datasetLinkTypes[] = array_key_exists($linkType, $linkTypeMappings) ? $linkTypeMappings[$linkType] : 'Unknown';
             }
 
             // Split string to array of strings
-            $publicationTypes = explode(",", $pubMatch['publication_type']);
+            $publicationTypes = explode(',', $pubMatch['publication_type']);
 
             // replace any empty strings with Research articles
             foreach ($publicationTypes as $i => $value) {
-                if ($value === "") {
+                if ($value === '') {
                     $publicationTypes[$i] = 'Research articles';
                 }
             }
@@ -737,19 +802,20 @@ trait IndexElastic
                 'index' => ECC::ELASTIC_NAME_PUBLICATION,
                 'id' => $id,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
             if ($returnParams) {
                 return $params;
             }
 
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -760,11 +826,9 @@ trait IndexElastic
     /**
      * Insert tool document into elastic index
      *
-     * @param integer $toolId
-     * @param bool $returnParams Optional flag to return parameters.
-     * @return null|array
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function indexElasticTools(int $toolId, bool $returnParams = false): null|array
+    public function indexElasticTools(int $toolId, bool $returnParams = false): ?array
     {
         try {
             $tool = Tool::where('id', $toolId)
@@ -833,13 +897,12 @@ trait IndexElastic
                 ->pluck('name')
                 ->all();
 
-            $datasetTitles = array();
+            $datasetTitles = [];
             if ($tool->any_dataset) {
                 $datasetTitles[] = '_Can be used with any dataset';
             } else {
                 foreach ($datasets as $dataset) {
-                    $dataset_version = $dataset['versions'][0];
-                    $datasetTitles[] = $dataset_version['metadata']['metadata']['summary']['shortTitle'];
+                    $datasetTitles[] = $dataset->latestVersion()?->short_title ?? '';
                 }
                 usort($datasetTitles, 'strcasecmp');
             }
@@ -858,14 +921,14 @@ trait IndexElastic
                 'datasetTitles' => $datasetTitles,
                 'dataProviderColl' => $dataProviderColl,
                 'dataProvider' => $tool['team']['name'] ?? null,
-                'resultsInsights' => $tool['results_insights']
+                'resultsInsights' => $tool['results_insights'],
             ];
 
             $params = [
                 'index' => ECC::ELASTIC_NAME_TOOL,
                 'id' => $toolId,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             if ($returnParams) {
@@ -873,12 +936,13 @@ trait IndexElastic
             }
 
             ECC::indexDocument($params);
+
             return null;
 
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -889,9 +953,7 @@ trait IndexElastic
     /**
      * Reindex in bulk
      *
-     * @param array $ids
-     * @param callable $indexer Name of single index to call to get parameters
-     * @return void
+     * @param  callable  $indexer  Name of single index to call to get parameters
      */
     public function reindexElasticBulk(array $ids, callable $indexer): void
     {
@@ -911,10 +973,8 @@ trait IndexElastic
      * Calls a delete on the document in ElasticSearch index when a dataset is
      * deleted
      *
-     * @param string $id The id of the dataset to be deleted
-     * @param string $indexType index type: dataset, publication
-     *
-     * @return void
+     * @param  string  $id  The id of the dataset to be deleted
+     * @param  string  $indexType  index type: dataset, publication
      */
     public function deleteFromElastic(string $id, string $indexType): void
     {
@@ -923,7 +983,7 @@ trait IndexElastic
             $params = [
                 'index' => $indexType,
                 'id' => $id,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             ECC::deleteDocument($params);
@@ -968,26 +1028,31 @@ trait IndexElastic
         $this->deleteFromElastic($id, ECC::ELASTIC_NAME_DATAPROVIDERCOLL);
     }
 
-    public function getMaterialTypes(array $metadata): array|null
+    public function getMaterialTypes(array $metadata): ?array
     {
         $materialTypes = null;
-        if (version_compare(Config::get('metadata.GWDM.version'), "2.0", "<")) {
-            $containsTissue = !empty($this->getValueByPossibleKeys($metadata, [
+        // Check the reconstructed envelope's own gwdmVersion, not the global config
+        // default — a dataset's actual version can diverge from that default.
+        $rowGwdmVersion = $metadata['gwdmVersion'] ?? Config::get('metadata.GWDM.version');
+        if (version_compare($rowGwdmVersion, '2.0', '<')) {
+            $containsTissue = ! empty($this->getValueByPossibleKeys($metadata, [
                 'metadata.coverage.biologicalsamples',
                 'metadata.coverage.physicalSampleAvailability',
             ], ''));
         } else {
-            $tissues =  Arr::get($metadata, 'metadata.tissuesSampleCollection', null);
-            if (!is_null($tissues)) {
+            $tissues = Arr::get($metadata, 'metadata.tissuesSampleCollection', null);
+            if (! is_null($tissues)) {
                 $materialTypes = array_reduce($tissues, function ($return, $item) {
                     if ($item['materialType'] !== 'None/not available') {
                         $return[] = $item['materialType'];
                     }
+
                     return $return;
                 }, []);
                 $materialTypes = count($materialTypes) === 0 ? null : array_unique($materialTypes);
             }
         }
+
         return $materialTypes;
     }
 
@@ -996,17 +1061,16 @@ trait IndexElastic
         if ($materialTypes === null) {
             return false;
         }
+
         return count($materialTypes) > 0;
     }
 
     /**
      * Insert tool document into elastic index
      *
-     * @param integer $dataCustodianNetworkId
-     * @param bool $returnParams Optional flag to return parameters.
-     * @return null|array
+     * @param  bool  $returnParams  Optional flag to return parameters.
      */
-    public function indexElasticDataCustodianNetwork(int $dataCustodianNetworkId, bool $returnParams = false): null|array
+    public function indexElasticDataCustodianNetwork(int $dataCustodianNetworkId, bool $returnParams = false): ?array
     {
         try {
             $dpc = DataProviderColl::select('id', 'name', 'img_url', 'enabled', 'url', 'service', 'summary')
@@ -1014,7 +1078,7 @@ trait IndexElastic
                 ->where([
                     'id' => $dataCustodianNetworkId,
                     'enabled' => 1,
-            ])->first();
+                ])->first();
 
             $teamsResult = $this->getInfoTeams($dpc);
 
@@ -1049,7 +1113,7 @@ trait IndexElastic
                 'index' => ECC::ELASTIC_NAME_DATACUSTODIANNETWORK,
                 'id' => $dataCustodianNetworkId,
                 'body' => $toIndex,
-                'headers' => 'application/json'
+                'headers' => 'application/json',
             ];
 
             if ($returnParams) {
@@ -1057,11 +1121,12 @@ trait IndexElastic
             }
 
             ECC::indexDocument($params);
+
             return null;
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
-                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'action_name' => class_basename($this).'@'.__FUNCTION__,
                 'description' => $e->getMessage(),
             ]);
 
@@ -1097,6 +1162,7 @@ trait IndexElastic
         foreach ($datasetIds as $datasetId) {
             $datasetResources = $this->checkingDataset($datasetId);
         }
+
         return true;
     }
 
@@ -1110,16 +1176,12 @@ trait IndexElastic
         $publicationIds = array_column($dataset->allActivePublications, 'id') ?? [];
         $toolIds = array_column($dataset->allActiveTools, 'id') ?? [];
 
-        $version = $dataset->latestVersion();
-        $withLinks = DatasetVersion::where('id', $version['id'])
-            ->with(['linkedDatasetVersions'])
-            ->first();
+        $metadataSummary = $this->reconstructedLatestEnvelope($dataset)['metadata']['summary'] ?? [];
 
-        $dataset->setAttribute('versions', [$withLinks]);
-
-        $metadataSummary = $dataset['versions'][0]['metadata']['metadata']['summary'] ?? [];
-
-        $title = $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
+        // title/short_title are populated columns on every write; only fall back
+        // to the reconstructed envelope for legacy pre-migration rows.
+        $title = $dataset->latestVersion()?->title
+            ?? $this->getValueByPossibleKeys($metadataSummary, ['title'], '');
         $populationSize = $this->getValueByPossibleKeys($metadataSummary, ['populationSize'], -1);
         $datasetType = $this->getValueByPossibleKeys($metadataSummary, ['datasetType'], '');
 
@@ -1136,7 +1198,7 @@ trait IndexElastic
             'durs' => $durIds,
             'publications' => $publicationIds,
             'tools' => $toolIds,
-            'collections' => $collectionIds
+            'collections' => $collectionIds,
         ];
 
         return $datasetResources;
@@ -1147,21 +1209,22 @@ trait IndexElastic
         $collectionNames = [];
 
         $collectionHasDurs = CollectionHasDur::where([
-                'dur_id' => $durId,
-            ])
+            'dur_id' => $durId,
+        ])
             ->select('collection_id')
             ->get()
             ->toArray();
 
-        if (!count($collectionHasDurs)) {
+        if (! count($collectionHasDurs)) {
             return $collectionNames;
         }
         $collectionIds = convertArrayToArrayWithKeyName($collectionHasDurs, 'collection_id');
         $collectionNames = Collection::where('status', Collection::STATUS_ACTIVE)
-                            ->whereIn('id', $collectionIds)
-                            ->select('name')
-                            ->get()
-                            ->toArray();
+            ->whereIn('id', $collectionIds)
+            ->select('name')
+            ->get()
+            ->toArray();
+
         return convertArrayToArrayWithKeyName($collectionNames, 'name');
     }
 }

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -32,7 +32,6 @@ use Auditor;
 use Config;
 use ElasticClientController as ECC;
 use Exception;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 
 trait IndexElastic
@@ -1067,30 +1066,14 @@ trait IndexElastic
 
     public function getMaterialTypes(array $metadata): ?array
     {
-        $materialTypes = null;
-        // Check the reconstructed envelope's own gwdmVersion, not the global config
-        // default — a dataset's actual version can diverge from that default.
+        // Resolve the handler for the envelope's own gwdmVersion (a dataset's
+        // actual version can diverge from the global config default) and let it
+        // decide how material types are represented for that version.
         $rowGwdmVersion = $metadata['gwdmVersion'] ?? Config::get('metadata.GWDM.version');
-        if (version_compare($rowGwdmVersion, '2.0', '<')) {
-            $containsTissue = ! empty($this->getValueByPossibleKeys($metadata, [
-                'metadata.coverage.biologicalsamples',
-                'metadata.coverage.physicalSampleAvailability',
-            ], ''));
-        } else {
-            $tissues = Arr::get($metadata, 'metadata.tissuesSampleCollection', null);
-            if (! is_null($tissues)) {
-                $materialTypes = array_reduce($tissues, function ($return, $item) {
-                    if ($item['materialType'] !== 'None/not available') {
-                        $return[] = $item['materialType'];
-                    }
 
-                    return $return;
-                }, []);
-                $materialTypes = count($materialTypes) === 0 ? null : array_unique($materialTypes);
-            }
-        }
-
-        return $materialTypes;
+        return app(GwdmHandlerFactory::class)
+            ->resolve($rowGwdmVersion)
+            ->getMaterialTypes($metadata['metadata'] ?? []);
     }
 
     public function getContainsBioSamples(?array $materialTypes)

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -90,6 +90,32 @@ trait IndexElastic
         );
     }
 
+    /**
+     * Preload datasets by id (with their versions) keyed by id, so callers can
+     * resolve each dataset's latest version in memory rather than issuing a
+     * Dataset::where(...)->first() + latestVersion() query per row (N+1).
+     *
+     * @param  array<int|string>  $ids
+     * @return \Illuminate\Support\Collection<int, Dataset>
+     */
+    private function preloadDatasetsById(array $ids): \Illuminate\Support\Collection
+    {
+        return Dataset::whereIn('id', array_values(array_unique($ids)))
+            ->with(['versions' => fn ($q) => $q->select('id', 'dataset_id', 'version', 'short_title')])
+            ->get()
+            ->keyBy('id');
+    }
+
+    /**
+     * Resolve a preloaded dataset's latest version from its already-loaded
+     * `versions` relation (no query), mirroring Dataset::latestVersion()'s
+     * "highest version number" semantics.
+     */
+    private function latestLoadedVersion(?Dataset $dataset): ?DatasetVersion
+    {
+        return $dataset?->versions->sortByDesc('version')->first();
+    }
+
     private function isElasticIndexable(array $envelope): bool
     {
         $version = $envelope['gwdmVersion'] ?? null;
@@ -527,9 +553,10 @@ trait IndexElastic
 
         $datasetTitles = [];
         $datasetAbstracts = [];
+        $datasetsById = $this->preloadDatasetsById($datasetIds);
         foreach ($datasetIds as $d) {
-            $datasetRow = Dataset::where(['id' => $d])->first();
-            $latestVersion = $datasetRow?->latestVersion();
+            $datasetRow = $datasetsById->get($d);
+            $latestVersion = $this->latestLoadedVersion($datasetRow);
             if (! $latestVersion) {
                 continue;
             }
@@ -666,8 +693,9 @@ trait IndexElastic
             $durMatch = $durMatch->toArray();
 
             $datasetTitles = [];
+            $datasetsById = $this->preloadDatasetsById($datasetIds);
             foreach ($datasetIds as $d) {
-                $datasetTitles[] = Dataset::where(['id' => $d])->first()->latestVersion()->short_title ?? '';
+                $datasetTitles[] = $this->latestLoadedVersion($datasetsById->get($d))?->short_title ?? '';
             }
 
             $keywords = [];
@@ -761,17 +789,26 @@ trait IndexElastic
                 'UNKNOWN' => 'Unknown',
             ];
 
+            $datasetIds = collect($datasets)->pluck('id')->all();
+            $datasetsById = $this->preloadDatasetsById($datasetIds);
+
+            // Resolve each dataset's latest version once, then batch the
+            // link-type lookup, rather than querying per row (N+1).
+            $latestVersionByDataset = [];
+            foreach ($datasetIds as $datasetId) {
+                $latestVersionByDataset[$datasetId] = $this->latestLoadedVersion($datasetsById->get($datasetId));
+            }
+
+            $linkTypeByVersionId = PublicationHasDatasetVersion::where('publication_id', (int) $id)
+                ->whereIn('dataset_version_id', collect($latestVersionByDataset)->filter()->map->id->all())
+                ->pluck('link_type', 'dataset_version_id');
+
             foreach ($datasets as $dataset) {
-                $datasetModel = Dataset::where(['id' => $dataset['id']])->first();
-                $latestVersion = $datasetModel->latestVersion();
-                $latestVersionID = $latestVersion->id;
-                $datasetTitles[] = $latestVersion->short_title ?? '';
+                $latestVersion = $latestVersionByDataset[$dataset['id']] ?? null;
+                $datasetTitles[] = $latestVersion?->short_title ?? '';
 
                 // change from 'UNKNOWN' to 'USING' - temp
-                $linkType = PublicationHasDatasetVersion::where([
-                    'publication_id' => (int) $id,
-                    'dataset_version_id' => (int) $latestVersionID,
-                ])->first()->link_type ?? 'USING';
+                $linkType = ($latestVersion ? ($linkTypeByVersionId[$latestVersion->id] ?? null) : null) ?? 'USING';
 
                 $datasetLinkTypes[] = array_key_exists($linkType, $linkTypeMappings) ? $linkTypeMappings[$linkType] : 'Unknown';
             }

--- a/app/Jobs/ExtractPublicationsFromMetadata.php
+++ b/app/Jobs/ExtractPublicationsFromMetadata.php
@@ -6,7 +6,9 @@ use App\Http\Traits\IndexElastic;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Dataset;
+use App\Models\DatasetVersion;
 use App\Models\Publication;
+use App\Services\DatasetService;
 use Illuminate\Support\Arr;
 use Illuminate\Bus\Queueable;
 use Illuminate\Support\Facades\Http;
@@ -62,17 +64,15 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         $linkagePublicationAboutDataset = 'metadata.linkage.publicationAboutDataset';
         $linkagePublicationUsingDataset = 'metadata.linkage.publicationUsingDataset';
 
-        $metadata = \DB::table('dataset_versions')
-            ->where('id', $datasetVersionId)
-            ->select('id', 'dataset_id', 'metadata', \DB::raw('JSON_TYPE(metadata) as metadata_type'))
-            ->first();
+        // Reconstruct via DatasetService — the raw `metadata` column is empty on delta rows.
+        $dv = DatasetVersion::where('id', $datasetVersionId)->first();
 
-        if (is_null($metadata)) {
+        if (is_null($dv)) {
             \Log::warning('ExtractPublicationsFromMetadata :: Metadata not found.', $this->loggingContext);
             return;
         }
 
-        $dataset = Dataset::where('id', $metadata->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
+        $dataset = Dataset::where('id', $dv->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
         if (is_null($dataset)) {
             \Log::warning('ExtractPublicationsFromMetadata :: Dataset not found.', $this->loggingContext);
             return;
@@ -93,16 +93,9 @@ class ExtractPublicationsFromMetadata implements ShouldQueue
         $datasetUserId = (int) $dataset->user_id;
         $datasetTeamId = (int) $dataset->team_id;
 
-        $data = null;
-        if ($metadata->metadata_type === 'OBJECT') {
-            $data = json_decode($metadata->metadata, true);
-        }
+        $data = app(DatasetService::class)->getReconstructedMetadataEnvelope($dv->dataset_id, $dv->version, false, $dv);
 
-        if ($metadata->metadata_type === 'STRING') {
-            $data = json_decode(json_decode($metadata->metadata), true);
-        }
-
-        if (count($data ?: []) === 0) {
+        if (empty($data['metadata'])) {
             return;
         }
 

--- a/app/Jobs/ExtractToolsFromMetadata.php
+++ b/app/Jobs/ExtractToolsFromMetadata.php
@@ -6,6 +6,8 @@ use App\Models\Team;
 use App\Models\Tool;
 use App\Models\User;
 use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Services\DatasetService;
 use Illuminate\Support\Arr;
 use Illuminate\Bus\Queueable;
 use App\Http\Traits\IndexElastic;
@@ -59,17 +61,15 @@ class ExtractToolsFromMetadata implements ShouldQueue
         $linkageToolsDataset = 'metadata.linkage.tools';
         $type = 'Used on';
 
-        $metadata = \DB::table('dataset_versions')
-            ->where('id', $datasetVersionId)
-            ->select('id', 'dataset_id', 'metadata', \DB::raw('JSON_TYPE(metadata) as metadata_type'))
-            ->first();
+        // Reconstruct via DatasetService — the raw `metadata` column is empty on delta rows.
+        $dv = DatasetVersion::where('id', $datasetVersionId)->first();
 
-        if (is_null($metadata)) {
+        if (is_null($dv)) {
             \Log::info('ExtractToolsFromMetadata :: Metadata not found.', $this->loggingContext);
             return;
         }
 
-        $dataset = Dataset::where('id', $metadata->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
+        $dataset = Dataset::where('id', $dv->dataset_id)->select(['id', 'user_id', 'team_id'])->first();
         if (is_null($dataset)) {
             \Log::info('ExtractToolsFromMetadata :: Dataset not found.', $this->loggingContext);
             return;
@@ -92,16 +92,9 @@ class ExtractToolsFromMetadata implements ShouldQueue
 
         $this->cleanToolDatasetVersion($datasetVersionId, $type, (int)$dataset->id);
 
-        $data = null;
-        if ($metadata->metadata_type === 'OBJECT') {
-            $data = json_decode($metadata->metadata, true);
-        }
+        $data = app(DatasetService::class)->getReconstructedMetadataEnvelope($dv->dataset_id, $dv->version, false, $dv);
 
-        if ($metadata->metadata_type === 'STRING') {
-            $data = json_decode(json_decode($metadata->metadata), true);
-        }
-
-        if (count($data ?: []) === 0) {
+        if (empty($data['metadata'])) {
             return;
         }
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -403,13 +403,22 @@ class Dataset extends Model
     ): array {
         $targetTable = (new $targetClass())->getTable();
 
+        // Scope to the latest version only. Coverage pivot rows accumulate one set
+        // per version; unioning across all versions makes displayed coverage only
+        // ever grow (e.g. changing England -> Scotland would show both forever).
+        $latestVersionId = $this->latestVersionID($this->id);
+
+        if ($latestVersionId === null) {
+            return [];
+        }
+
         $results = DB::select("
             SELECT {$targetTable}.*, {$linkageTable}.dataset_version_id
             FROM {$targetTable}
             INNER JOIN {$linkageTable} ON {$targetTable}.id = {$linkageTable}.{$foreignKey}
             INNER JOIN dataset_versions ON dataset_versions.id = {$linkageTable}.dataset_version_id
-            WHERE dataset_versions.dataset_id = ?
-        ", [$this->id]);
+            WHERE dataset_versions.dataset_id = ? AND dataset_versions.id = ?
+        ", [$this->id, $latestVersionId]);
 
         return collect($results)
             ->groupBy('id')

--- a/app/Models/DatasetVersion.php
+++ b/app/Models/DatasetVersion.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Models\Base\BaseTypesenseModel;
+use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Observers\DatasetVersionObserver;
 use Illuminate\Database\Eloquent\Builder;
@@ -283,50 +285,24 @@ class DatasetVersion extends BaseTypesenseModel
 
     public function toSearchableArray(): array
     {
-        $meta = $this->metadata ?? [];
+        $envelope = app(DatasetService::class)->getReconstructedMetadataEnvelope(
+            $this->dataset_id,
+            $this->version,
+            false,
+            $this,
+        );
 
-        $keywords   = data_get($meta, 'metadata.summary.keywords', '');
-        $dataType   = data_get($meta, 'metadata.summary.datasetType', '');
-        $conformsTo = data_get($meta, 'metadata.accessibility.formatAndStandards.conformsTo', '');
-        $structural = data_get($meta, 'metadata.structuralMetadata', []);
-        if (is_string($structural)) {
-            $structural = json_decode($structural, true) ?? [];
-        }
-        if (!is_array($structural)) {
-            $structural = [];
-        }
+        $fields = app(GwdmHandlerFactory::class)
+            ->resolve($envelope['gwdmVersion'] ?? $this->gwdm_version ?? '2.0')
+            ->toSearchableFields($envelope);
 
-        return [
-            'id'                            => (string) $this->id,
-            'dataset_id'                    => (string) $this->dataset_id,
-            'title'                         => $this->title ?? '',
-            'shortTitle'                    => $this->short_title ?? '',
-            'abstract'                      => data_get($meta, 'metadata.summary.abstract', ''),
-            'description'                   => data_get($meta, 'metadata.summary.description', ''),
-            'keywords'                      => array_values(array_filter(explode(';,;', $keywords))),
-            'publisherName'                 => data_get(
-                $meta,
-                'metadata.summary.publisher.name',
-                data_get($meta, 'metadata.summary.publisher.publisherName', '')
-            ),
-            'dataType'                      => array_values(array_filter(explode(';,;', $dataType))),
-            'populationSize'                => (int) data_get($meta, 'metadata.summary.populationSize', -1),
-            'geographicLocation'            => $this->spatialCoverage->pluck('region')->all(),
-            'datasetDOI'                    => data_get($meta, 'metadata.summary.doiName', ''),
-            'conformsTo'                    => array_values(array_filter(explode(';,;', $conformsTo))),
-            'structuralTableNames'          => collect($structural)
-                                                ->pluck('name')
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnNames'         => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-            'structuralColumnDescriptions'  => collect($structural)
-                                                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
-                                                ->filter(fn ($v) => is_string($v) && $v !== '')
-                                                ->values()->all(),
-        ];
+        return array_merge($fields, [
+            'id' => (string) $this->id,
+            'dataset_id' => (string) $this->dataset_id,
+            'title' => $this->title ?? '',
+            'shortTitle' => $this->short_title ?? '',
+            'geographicLocation' => $this->spatialCoverage->pluck('region')->all(),
+        ]);
     }
 
     public function makeAllSearchableUsing(Builder $query): Builder

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -223,6 +223,97 @@ class DatasetService
     }
 
     /**
+     * Fast path for ?view=metadataOnly — skips all relation loading (DURs, tools,
+     * collections, publications, named entities, linkages, team DAR check) and
+     * returns only the reconstructed GWDM metadata envelope.
+     *
+     * Supports the same x-gwdm-version header and schema_model/schema_version
+     * TRASER translation as the full show path.
+     *
+     * @return array{gwdmVersion?: string, metadata?: array} empty when the dataset has no version rows
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException when the requested GWDM version has no rows
+     * @throws \InvalidArgumentException when schema_model/schema_version are mismatched
+     * @throws \RuntimeException when TRASER translation fails
+     */
+    public function getMetadataOnly(
+        Dataset $dataset,
+        ?string $outputSchemaModel = null,
+        ?string $outputSchemaVersion = null,
+    ): array {
+        if ($outputSchemaModel && ! $outputSchemaVersion) {
+            throw new \InvalidArgumentException('schema_model provided without schema_version');
+        }
+        if ($outputSchemaVersion && ! $outputSchemaModel) {
+            throw new \InvalidArgumentException('schema_version provided without schema_model');
+        }
+
+        $requestedGwdmVersion = $this->gwdmVersionContext->requestedVersion();
+
+        $allVersions = $dataset->versions()
+            ->select(['id', 'version', 'gwdm_version'])
+            ->orderBy('version', 'desc')
+            ->get();
+
+        if ($requestedGwdmVersion !== null) {
+            $row = $allVersions->firstWhere('gwdm_version', $requestedGwdmVersion);
+            if ($row === null) {
+                throw new \Illuminate\Database\Eloquent\ModelNotFoundException(
+                    "No dataset version found with GWDM version '{$requestedGwdmVersion}'."
+                );
+            }
+            $latestVersionId = $row->id;
+        } else {
+            $latestVersionId = $allVersions->first()?->id;
+        }
+
+        $translateRequested = $outputSchemaModel && $outputSchemaVersion;
+
+        // Only need linked versions when translating via TRASER.
+        $dv = $translateRequested
+            ? DatasetVersion::where('id', $latestVersionId)->with(['reducedLinkedDatasetVersions'])->first()
+            : DatasetVersion::find($latestVersionId);
+
+        if (! $dv) {
+            return [];
+        }
+
+        $envelope = $this->getReconstructedMetadataEnvelope(
+            $dataset->id,
+            $dv->version,
+            validate: $translateRequested,
+            prefetched: $dv,
+        );
+
+        if ($translateRequested) {
+            $translated = MMC::translateDataModelType(
+                json_encode($envelope),
+                $outputSchemaModel,
+                $outputSchemaVersion,
+                Config::get('metadata.GWDM.name'),
+                $envelope['gwdmVersion'],
+            );
+
+            if (! $translated['wasTranslated']) {
+                $traserError = is_array($translated['traser_message'])
+                    ? json_encode($translated['traser_message'])
+                    : ($translated['traser_message'] ?? 'unknown error');
+                throw new \RuntimeException($traserError);
+            }
+
+            return [
+                'gwdmVersion' => $envelope['gwdmVersion'],
+                'metadata' => $translated['metadata'],
+            ];
+        }
+
+        return [
+            'gwdmVersion' => $envelope['gwdmVersion'],
+            'metadata' => $envelope['metadata'],
+        ];
+    }
+
+    /**
      * Return the full reconstructed metadata envelope for a specific version of
      * a dataset. The envelope matches the snapshot shape:
      *   { gwdmVersion, metadata: {...GWDM...}, original_metadata: {...} }
@@ -962,32 +1053,41 @@ class DatasetService
         $allCoverages = SpatialCoverage::all();
         $ukCoverages = $allCoverages->filter(fn ($c) => $c->region !== 'Rest of the world');
         $worldId = $allCoverages->firstWhere('region', 'Rest of the world')?->id;
-        $matchFound = false;
+
+        // Collect the coverage IDs this version should map to, then sync the pivot
+        // (upsert desired + prune stale) so editing coverage DOWN actually removes
+        // entries rather than accumulating them.
+        $desiredIds = [];
 
         foreach ($ukCoverages as $c) {
             if (str_contains($coverage, strtolower($c->region))) {
-                DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id' => (int) $version->id,
-                    'spatial_coverage_id' => (int) $c->id,
-                ]);
-                $matchFound = true;
+                $desiredIds[] = (int) $c->id;
             }
         }
 
-        if (! $matchFound) {
+        if (empty($desiredIds)) {
             if (str_contains($coverage, 'united kingdom')) {
                 foreach ($ukCoverages as $c) {
-                    DatasetVersionHasSpatialCoverage::updateOrCreate([
-                        'dataset_version_id' => (int) $version->id,
-                        'spatial_coverage_id' => (int) $c->id,
-                    ]);
+                    $desiredIds[] = (int) $c->id;
                 }
-            } else {
-                DatasetVersionHasSpatialCoverage::updateOrCreate([
-                    'dataset_version_id' => (int) $version->id,
-                    'spatial_coverage_id' => (int) $worldId,
-                ]);
+            } elseif ($worldId !== null) {
+                $desiredIds[] = (int) $worldId;
             }
         }
+
+        foreach ($desiredIds as $coverageId) {
+            DatasetVersionHasSpatialCoverage::updateOrCreate([
+                'dataset_version_id' => (int) $version->id,
+                'spatial_coverage_id' => $coverageId,
+            ]);
+        }
+
+        // Prune any pivot rows for this version no longer present in the metadata.
+        DatasetVersionHasSpatialCoverage::where('dataset_version_id', (int) $version->id)
+            ->when(
+                ! empty($desiredIds),
+                fn ($q) => $q->whereNotIn('spatial_coverage_id', $desiredIds),
+            )
+            ->delete();
     }
 }

--- a/app/Services/Gwdm/Gwdm1xHandler.php
+++ b/app/Services/Gwdm/Gwdm1xHandler.php
@@ -39,7 +39,7 @@ class Gwdm1xHandler extends GwdmMetadataHandler
         }
 
         return [
-            'publisherId'   => (string) $team->id,
+            'publisherId' => (string) $team->id,
             'publisherName' => $team->name,
         ];
     }
@@ -47,11 +47,11 @@ class Gwdm1xHandler extends GwdmMetadataHandler
     public function buildRequiredBlock(Dataset $dataset, int $versionNumber): array
     {
         return [
-            'gatewayId'  => strval($dataset->id),
+            'gatewayId' => strval($dataset->id),
             'gatewayPid' => $dataset->pid,
-            'issued'     => $dataset->created,
-            'modified'   => $dataset->updated,
-            'revisions'  => $this->buildRevisions($dataset, $versionNumber),
+            'issued' => $dataset->created,
+            'modified' => $dataset->updated,
+            'revisions' => $this->buildRevisions($dataset, $versionNumber),
             // No 'version' field — not part of GWDM < 1.1 schema
         ];
     }
@@ -60,9 +60,18 @@ class Gwdm1xHandler extends GwdmMetadataHandler
     {
         $required = $this->buildRequiredBlock($dataset, $versionNumber);
         // DB-derived values win over whatever TRASER returned for the same keys
-        $gwdm['required']             = array_merge($gwdm['required'] ?? [], $required);
+        $gwdm['required'] = array_merge($gwdm['required'] ?? [], $required);
         $gwdm['summary']['publisher'] = $this->buildPublisher($team, $gwdm['summary']['publisher'] ?? []);
 
         return $gwdm;
+    }
+
+    /**
+     * Legacy GWDM (< 1.1) has no tissuesSampleCollection section, so no
+     * material types are exposed.
+     */
+    public function getMaterialTypes(array $metadata): ?array
+    {
+        return null;
     }
 }

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -9,6 +9,7 @@ use App\Models\Publication;
 use App\Models\PublicationHasDatasetVersion;
 use App\Models\Team;
 use App\Services\DatasetService;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -447,5 +448,29 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             ->get()
             ->mapWithKeys(fn (Dataset $d) => [$d->id => $d->latestMetadata?->short_title])
             ->all();
+    }
+
+    /**
+     * 2.x stores biological material types under `tissuesSampleCollection`.
+     *
+     * @param  array<string, mixed>  $metadata  inner GWDM metadata block
+     * @return array<int, string>|null
+     */
+    public function getMaterialTypes(array $metadata): ?array
+    {
+        $tissues = Arr::get($metadata, 'tissuesSampleCollection', null);
+        if (is_null($tissues)) {
+            return null;
+        }
+
+        $materialTypes = array_reduce($tissues, function ($carry, $item) {
+            if (($item['materialType'] ?? '') !== 'None/not available') {
+                $carry[] = $item['materialType'];
+            }
+
+            return $carry;
+        }, []);
+
+        return count($materialTypes) === 0 ? null : array_unique($materialTypes);
     }
 }

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -25,9 +25,7 @@ use App\Models\Team;
  */
 abstract class GwdmMetadataHandler
 {
-    public function __construct(protected readonly string $resolvedVersion)
-    {
-    }
+    public function __construct(protected readonly string $resolvedVersion) {}
 
     // ── Version identity ──────────────────────────────────────────────────────
 
@@ -50,11 +48,11 @@ abstract class GwdmMetadataHandler
      *      merging over any existing required fields so DB-derived values win.
      *   2. Call buildPublisher() and write the result into $gwdm['summary']['publisher'].
      *
-     * @param  array   $gwdm          Post-TRASER GWDM metadata object
-     * @param  Dataset $dataset       The parent dataset row (for gatewayId, pid, dates)
-     * @param  Team    $team          Owning team (for publisher fields)
-     * @param  int     $versionNumber The version number being written (1 on create)
-     * @return array                  Mutated GWDM array ready for envelope + storage
+     * @param  array  $gwdm  Post-TRASER GWDM metadata object
+     * @param  Dataset  $dataset  The parent dataset row (for gatewayId, pid, dates)
+     * @param  Team  $team  Owning team (for publisher fields)
+     * @param  int  $versionNumber  The version number being written (1 on create)
+     * @return array Mutated GWDM array ready for envelope + storage
      */
     abstract public function prepareMetadata(
         array $gwdm,
@@ -102,8 +100,8 @@ abstract class GwdmMetadataHandler
     public function buildEnvelope(array $gwdm, array $originalMetadata): array
     {
         return [
-            'gwdmVersion'       => $this->version(),
-            'metadata'          => $gwdm,
+            'gwdmVersion' => $this->version(),
+            'metadata' => $gwdm,
             'original_metadata' => $originalMetadata,
         ];
     }
@@ -121,6 +119,7 @@ abstract class GwdmMetadataHandler
         if (array_key_exists('metadata', $storedData)) {
             return $storedData['metadata'];
         }
+
         return $storedData;
     }
 
@@ -134,7 +133,7 @@ abstract class GwdmMetadataHandler
      */
     public function extractTitleFields(array $gwdm): array
     {
-        $title      = $gwdm['summary']['title'] ?? null;
+        $title = $gwdm['summary']['title'] ?? null;
         $shortTitle = $gwdm['summary']['shortTitle'] ?? $title;
 
         return [$title, $shortTitle];
@@ -198,20 +197,33 @@ abstract class GwdmMetadataHandler
     }
 
     /**
+     * Distinct biological material types for a GWDM metadata block (the inner
+     * `metadata` object). Version-specific: the base has no material-type
+     * concept and returns null; 2.x+ reads `tissuesSampleCollection`.
+     *
+     * @param  array<string, mixed>  $metadata  inner GWDM metadata block
+     * @return array<int, string>|null
+     */
+    public function getMaterialTypes(array $metadata): ?array
+    {
+        return null;
+    }
+
+    /**
      * Extract Typesense-searchable fields from a reconstructed GWDM envelope.
      * Override when a version's field shapes diverge from delimited strings.
      */
     public function toSearchableFields(array $envelope): array
     {
-        $keywords   = data_get($envelope, 'metadata.summary.keywords', '');
-        $dataType   = data_get($envelope, 'metadata.summary.datasetType', '');
+        $keywords = data_get($envelope, 'metadata.summary.keywords', '');
+        $dataType = data_get($envelope, 'metadata.summary.datasetType', '');
         $conformsTo = data_get($envelope, 'metadata.accessibility.formatAndStandards.conformsTo', '');
         $structural = data_get($envelope, 'metadata.structuralMetadata', []);
 
         if (is_string($structural)) {
             $structural = json_decode($structural, true) ?? [];
         }
-        if (!is_array($structural)) {
+        if (! is_array($structural)) {
             $structural = [];
         }
 
@@ -274,13 +286,13 @@ abstract class GwdmMetadataHandler
     public function defaultValuePaths(): array
     {
         return [
-            'dataUseLimitation'   => 'metadata.accessibility.usage.dataUseLimitation',
+            'dataUseLimitation' => 'metadata.accessibility.usage.dataUseLimitation',
             'dataUseRequirements' => 'metadata.accessibility.usage.dataUseRequirements',
-            'accessRights'        => 'metadata.accessibility.access.accessRights',
-            'accessService'       => 'metadata.accessibility.access.accessService',
-            'accessRequestCost'   => 'metadata.accessibility.access.accessRequestCost',
-            'deliveryLeadTime'    => 'metadata.accessibility.access.deliveryLeadTime',
-            'formats'             => 'metadata.accessibility.formatAndStandards.formats',
+            'accessRights' => 'metadata.accessibility.access.accessRights',
+            'accessService' => 'metadata.accessibility.access.accessService',
+            'accessRequestCost' => 'metadata.accessibility.access.accessRequestCost',
+            'deliveryLeadTime' => 'metadata.accessibility.access.deliveryLeadTime',
+            'formats' => 'metadata.accessibility.formatAndStandards.formats',
         ];
     }
 
@@ -301,7 +313,7 @@ abstract class GwdmMetadataHandler
         sort($all);
 
         return array_map(fn (int $v) => [
-            'url'     => config('gateway.gateway_url') . '/dataset/' . $dataset->id . '?version=' . $this->formatVersion($v),
+            'url' => config('gateway.gateway_url').'/dataset/'.$dataset->id.'?version='.$this->formatVersion($v),
             'version' => $this->formatVersion($v),
         ], $all);
     }

--- a/app/Services/Gwdm/GwdmMetadataHandler.php
+++ b/app/Services/Gwdm/GwdmMetadataHandler.php
@@ -190,6 +190,60 @@ abstract class GwdmMetadataHandler
     }
 
     /**
+     * Whether datasets on this GWDM version should be indexed into Elasticsearch.
+     */
+    public function supportsElasticIndexing(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Extract Typesense-searchable fields from a reconstructed GWDM envelope.
+     * Override when a version's field shapes diverge from delimited strings.
+     */
+    public function toSearchableFields(array $envelope): array
+    {
+        $keywords   = data_get($envelope, 'metadata.summary.keywords', '');
+        $dataType   = data_get($envelope, 'metadata.summary.datasetType', '');
+        $conformsTo = data_get($envelope, 'metadata.accessibility.formatAndStandards.conformsTo', '');
+        $structural = data_get($envelope, 'metadata.structuralMetadata', []);
+
+        if (is_string($structural)) {
+            $structural = json_decode($structural, true) ?? [];
+        }
+        if (!is_array($structural)) {
+            $structural = [];
+        }
+
+        return [
+            'abstract' => data_get($envelope, 'metadata.summary.abstract', ''),
+            'description' => data_get($envelope, 'metadata.summary.description', ''),
+            'keywords' => array_values(array_filter(explode(';,;', $keywords))),
+            'publisherName' => data_get(
+                $envelope,
+                'metadata.summary.publisher.name',
+                data_get($envelope, 'metadata.summary.publisher.publisherName', '')
+            ),
+            'dataType' => array_values(array_filter(explode(';,;', $dataType))),
+            'populationSize' => (int) data_get($envelope, 'metadata.summary.populationSize', -1),
+            'datasetDOI' => data_get($envelope, 'metadata.summary.doiName', ''),
+            'conformsTo' => array_values(array_filter(explode(';,;', $conformsTo))),
+            'structuralTableNames' => collect($structural)
+                ->pluck('name')
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnNames' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('name'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+            'structuralColumnDescriptions' => collect($structural)
+                ->flatMap(fn ($t) => collect($t['columns'] ?? [])->pluck('description'))
+                ->filter(fn ($v) => is_string($v) && $v !== '')
+                ->values()->all(),
+        ];
+    }
+
+    /**
      * Return the flat dataset-linkage list for a version (the frontend
      * `linkages` attribute: {title, url, dataset_id, linkage_type}).
      *

--- a/app/Services/Search/DatasetHydrator.php
+++ b/app/Services/Search/DatasetHydrator.php
@@ -2,18 +2,19 @@
 
 namespace App\Services\Search;
 
-use App\Models\Dataset;
 use App\Models\DataAccessTemplate;
+use App\Models\Dataset;
 use App\Models\Team;
 use App\Services\DatasetService;
-use Illuminate\Support\Arr;
+use App\Services\Gwdm\GwdmHandlerFactory;
 use Config;
+use Illuminate\Support\Arr;
 
 class DatasetHydrator
 {
     public function hydrate(array $hits, string $viewType = 'full'): array
     {
-        $matchedIds = array_map(fn ($h) => (int)$h['_id'], $hits);
+        $matchedIds = array_map(fn ($h) => (int) $h['_id'], $hits);
 
         // Single query for all datasets + team + latestMetadata (replaces N individual queries)
         $models = Dataset::with(['team', 'latestMetadata'])
@@ -36,31 +37,33 @@ class DatasetHydrator
         $pidsToResolve = [];
         foreach ($models as $model) {
             $latestVersion = $model->latestMetadata;
-            if (!$latestVersion) {
+            if (! $latestVersion) {
                 continue;
             }
             $gatewayId = Arr::get($latestVersion->metadata, 'metadata.summary.publisher.gatewayId');
-            if ($gatewayId && str_contains((string)$gatewayId, '-')) {
+            if ($gatewayId && str_contains((string) $gatewayId, '-')) {
                 $pidsToResolve[] = $gatewayId;
             }
         }
-        $teamsByPid = !empty($pidsToResolve)
+        $teamsByPid = ! empty($pidsToResolve)
             ? Team::whereIn('pid', array_unique($pidsToResolve))->get()->keyBy('pid')
             : collect();
 
         // Hydrate hits in O(1) per result using keyed collection
         foreach ($hits as $i => $hit) {
-            $model = $models[(int)$hit['_id']] ?? null;
-            if (!$model) {
-                \Log::warning('No dataset found for search hit id=' . $hit['_id'] . ' — check search index / DB sync');
+            $model = $models[(int) $hit['_id']] ?? null;
+            if (! $model) {
+                \Log::warning('No dataset found for search hit id='.$hit['_id'].' — check search index / DB sync');
                 unset($hits[$i]);
+
                 continue;
             }
 
             $latestVersion = $model->latestMetadata;
-            if (!$latestVersion) {
-                \Log::warning('No version found for dataset id=' . $model->id);
+            if (! $latestVersion) {
+                \Log::warning('No version found for dataset id='.$model->id);
                 unset($hits[$i]);
+
                 continue;
             }
 
@@ -72,21 +75,22 @@ class DatasetHydrator
                 $metadata = $latestVersion->metadata['metadata'] ?? null;
             }
 
-            if (!$metadata) {
-                \Log::warning('Missing metadata structure for dataset version id=' . $latestVersion->id . ', dataset id=' . $model->id);
+            if (! $metadata) {
+                \Log::warning('Missing metadata structure for dataset version id='.$latestVersion->id.', dataset id='.$model->id);
                 unset($hits[$i]);
+
                 continue;
             }
 
             // Resolve gatewayId (PID to integer ID)
             $gatewayId = $metadata['summary']['publisher']['gatewayId'] ?? null;
-            if ($gatewayId && str_contains((string)$gatewayId, '-')) {
+            if ($gatewayId && str_contains((string) $gatewayId, '-')) {
                 $team = $teamsByPid->get($gatewayId);
                 if ($team) {
                     $metadata['summary']['publisher']['gatewayId'] = $team->id;
                 }
             } else {
-                $metadata['summary']['publisher']['gatewayId'] = (int)$gatewayId;
+                $metadata['summary']['publisher']['gatewayId'] = (int) $gatewayId;
             }
 
             $hits[$i]['_source']['created_at'] = $model->created_at;
@@ -99,15 +103,15 @@ class DatasetHydrator
             $hits[$i]['isCohortDiscovery'] = $model->is_cohort_discovery;
             $hits[$i]['dataProviderColl'] = $dataProviderCollsByTeam->get($model->team_id, []);
             $hits[$i]['team'] = [
-                'id'                        => $model->team->id,
-                'is_question_bank'          => $model->team->is_question_bank,
+                'id' => $model->team->id,
+                'is_question_bank' => $model->team->is_question_bank,
                 'has_published_dar_template' => $publishedDarByTeam->has($model->team_id),
-                'name'                      => $model->team->name,
-                'member_of'                 => $model->team->member_of,
-                'is_dar'                    => $model->team->is_dar,
-                'dar_modal_header'          => $model->team->dar_modal_header,
-                'dar_modal_content'         => $model->team->dar_modal_content,
-                'dar_modal_footer'          => $model->team->dar_modal_footer,
+                'name' => $model->team->name,
+                'member_of' => $model->team->member_of,
+                'is_dar' => $model->team->is_dar,
+                'dar_modal_header' => $model->team->dar_modal_header,
+                'dar_modal_content' => $model->team->dar_modal_content,
+                'dar_modal_footer' => $model->team->dar_modal_footer,
             ];
         }
 
@@ -117,14 +121,14 @@ class DatasetHydrator
     private function trimPayload(array $metadata): array
     {
         $materialTypes = $this->getMaterialTypes($metadata);
-        $containsBioSamples = !empty($materialTypes);
-        $hasTechnicalMetadata = (bool)count(Arr::get($metadata, 'structuralMetadata') ?? []);
+        $containsBioSamples = ! empty($materialTypes);
+        $hasTechnicalMetadata = (bool) count(Arr::get($metadata, 'structuralMetadata') ?? []);
 
         $accessServiceCategory = $metadata['accessibility']['access']['accessServiceCategory'] ?? null;
 
         $minimumKeys = ['summary', 'provenance', 'accessibility'];
         foreach (array_keys($metadata) as $key) {
-            if (!in_array($key, $minimumKeys)) {
+            if (! in_array($key, $minimumKeys)) {
                 unset($metadata[$key]);
             }
         }
@@ -138,22 +142,8 @@ class DatasetHydrator
 
     private function getMaterialTypes(array $metadata): ?array
     {
-        if (version_compare(Config::get('metadata.GWDM.version'), '2.0', '<')) {
-            return null;
-        }
-
-        $tissues = Arr::get($metadata, 'tissuesSampleCollection', null);
-        if (is_null($tissues)) {
-            return null;
-        }
-
-        $materialTypes = array_reduce($tissues, function ($carry, $item) {
-            if (($item['materialType'] ?? '') !== 'None/not available') {
-                $carry[] = $item['materialType'];
-            }
-            return $carry;
-        }, []);
-
-        return count($materialTypes) === 0 ? null : array_unique($materialTypes);
+        return app(GwdmHandlerFactory::class)
+            ->resolve(Config::get('metadata.GWDM.version'))
+            ->getMaterialTypes($metadata);
     }
 }

--- a/tests/Feature/DatasetSpatialCoverageTest.php
+++ b/tests/Feature/DatasetSpatialCoverageTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Dataset;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Covers Dataset::allSpatialCoverages being scoped to the latest version only,
+ * so editing coverage (e.g. England -> Scotland) reflects just the new value
+ * rather than a growing union across every version ever written.
+ *
+ * Drives DatasetService directly; the x-gwdm-version header steers the target
+ * GWDM version via GwdmVersionContext.
+ */
+class DatasetSpatialCoverageTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /** Create a 2.0 dataset and return [datasetId, versionId]. */
+    private function createDataset(array $metadata, string $status = Dataset::STATUS_ACTIVE): array
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $this->setGwdmHeader('2.0');
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => $status,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+
+        $this->assertTrue($created['translated']);
+
+        return [$created['dataset_id'], $created['version_id']];
+    }
+
+    public function test_spatial_coverage_is_scoped_to_latest_version(): void
+    {
+        $this->disableObservers();
+
+        $team = Team::first();
+        $user = User::first();
+
+        // v1 coverage: England.
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['coverage']['spatial'] = 'England';
+        [$datasetId] = $this->createDataset($metadata);
+
+        $regionsV1 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('England', $regionsV1);
+        $this->assertNotContains('Scotland', $regionsV1);
+
+        // v2 coverage: Scotland (replaces, does not accumulate).
+        $updateMetadata = $this->getMetadataV2p0();
+        $updateMetadata['metadata']['coverage']['spatial'] = 'Scotland';
+
+        $this->setGwdmHeader('2.0');
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $updateMetadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $regionsV2 = collect(Dataset::find($datasetId)->allSpatialCoverages)->pluck('region')->all();
+        $this->assertContains('Scotland', $regionsV2);
+        $this->assertNotContains(
+            'England',
+            $regionsV2,
+            'allSpatialCoverages must reflect only the latest version, not a union across versions',
+        );
+    }
+}

--- a/tests/Feature/GwdmHandlerMaterialTypesTest.php
+++ b/tests/Feature/GwdmHandlerMaterialTypesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Tests\TestCase;
+
+/**
+ * getMaterialTypes() is version-specific and lives on the GWDM handlers (the
+ * version_compare() that used to gate it in IndexElastic/DatasetHydrator was
+ * removed). Legacy (< 1.1) exposes no material types; 1.1+ reads
+ * tissuesSampleCollection.
+ */
+class GwdmHandlerMaterialTypesTest extends TestCase
+{
+    protected bool $shouldFakeQueue = false;
+
+    private function factory(): GwdmHandlerFactory
+    {
+        return new GwdmHandlerFactory;
+    }
+
+    public function test_1x_handler_returns_null_even_when_tissues_present(): void
+    {
+        $result = $this->factory()->resolve('1.0')->getMaterialTypes([
+            'tissuesSampleCollection' => [['materialType' => 'DNA']],
+        ]);
+
+        $this->assertNull($result);
+    }
+
+    public function test_2x_handler_extracts_dedupes_and_excludes_none(): void
+    {
+        $result = $this->factory()->resolve('2.1')->getMaterialTypes([
+            'tissuesSampleCollection' => [
+                ['materialType' => 'DNA'],
+                ['materialType' => 'RNA'],
+                ['materialType' => 'DNA'],
+                ['materialType' => 'None/not available'],
+            ],
+        ]);
+
+        $this->assertEqualsCanonicalizing(['DNA', 'RNA'], array_values($result));
+    }
+
+    public function test_2x_handler_returns_null_when_absent_or_all_excluded(): void
+    {
+        $handler = $this->factory()->resolve('2.0');
+
+        $this->assertNull($handler->getMaterialTypes([]));
+        $this->assertNull($handler->getMaterialTypes([
+            'tissuesSampleCollection' => [['materialType' => 'None/not available']],
+        ]));
+    }
+
+    public function test_material_types_boundary_follows_the_factory_at_1_1(): void
+    {
+        // A version in [1.1, 2.0) resolves to the 2.x handler, so it now uses the
+        // modern tissuesSampleCollection path. This is a deliberate shift of the
+        // effective boundary from 2.0 to 1.1 (the factory's split point).
+        $result = $this->factory()->resolve('1.5')->getMaterialTypes([
+            'tissuesSampleCollection' => [['materialType' => 'DNA']],
+        ]);
+
+        $this->assertSame(['DNA'], array_values($result));
+    }
+}

--- a/tests/Feature/IndexElasticDeltaRowTest.php
+++ b/tests/Feature/IndexElasticDeltaRowTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\IndexDataset;
+use App\Models\Collection;
+use App\Models\CollectionHasDatasetVersion;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Regression coverage for GAT-9018: IndexElastic::reindexElasticDataProvider()
+ * and ::indexElasticCollections() used to read `$latestVersion->metadata`
+ * directly. Delta rows store `metadata = []` there, so
+ * `$metadata['metadata']['summary']['datasetType']` was null and
+ * explode(';,;', null) threw a TypeError in PHP 8.1+ (deprecated-to-fatal).
+ * Both methods now reconstruct via DatasetService::getReconstructedMetadataEnvelope(),
+ * matching what IndexElastic::reindexElastic() already did.
+ */
+class IndexElasticDeltaRowTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+        $this->disableObservers();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /**
+     * @return array{0: int, 1: DatasetVersion} dataset id and the resulting delta-row version
+     */
+    private function createDatasetWithDeltaVersion(Team $team, User $user, array $metadata): array
+    {
+        $this->setGwdmHeader('2.0');
+
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+        $datasetId = $created['dataset_id'];
+
+        // v2: identical schema -> delta row (metadata column stores `[]`).
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $metadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $v2 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 2)->first();
+        $this->assertNotNull($v2, 'v2 should have been created');
+        $this->assertNotNull($v2->patch, 'v2 must be a delta row for this regression test to be meaningful');
+        $this->assertSame([], $v2->metadata, 'delta row metadata column must be empty, confirming a raw-column read would crash/degrade');
+
+        return [$datasetId, $v2];
+    }
+
+    public function test_reindex_elastic_data_provider_does_not_crash_on_delta_row(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $metadata = $this->getMetadataV2p0();
+        [, $v2] = $this->createDatasetWithDeltaVersion($team, $user, $metadata);
+
+        $job = new IndexDataset('0');
+        $params = $job->reindexElasticDataProvider((string) $team->id, true);
+
+        $this->assertIsArray($params);
+        $this->assertContains('list of papers', $params['body']['dataType']);
+    }
+
+    public function test_index_elastic_collections_does_not_crash_on_delta_row(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+
+        $metadata = $this->getMetadataV2p0();
+        [$datasetId, $v2] = $this->createDatasetWithDeltaVersion($team, $user, $metadata);
+
+        $collection = Collection::factory()->create([
+            'team_id' => $team->id,
+            'status' => Collection::STATUS_ACTIVE,
+        ]);
+
+        CollectionHasDatasetVersion::create([
+            'collection_id' => $collection->id,
+            'dataset_version_id' => $v2->id,
+            'user_id' => $user->id,
+        ]);
+
+        $job = new IndexDataset('0');
+        $params = $job->indexElasticCollections($collection->id, true);
+
+        $this->assertIsArray($params);
+        $this->assertContains(
+            'Publications that mention HDR-UK (or any variant thereof) in Acknowledgements or Author Affiliations',
+            $params['body']['datasetAbstracts']
+        );
+    }
+}

--- a/tests/Feature/IndexElasticGwdmGatingTest.php
+++ b/tests/Feature/IndexElasticGwdmGatingTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\IndexDataset;
+use App\Models\Dataset;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DatasetService;
+use App\Services\Gwdm\Gwdm2xHandler;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Mockery;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Coverage for IndexElastic::isElasticIndexable(), the gate added so datasets
+ * on a GWDM version that doesn't support Elasticsearch indexing get deindexed
+ * rather than partially/incorrectly indexed (GwdmMetadataHandler::supportsElasticIndexing()).
+ *
+ * No handler currently returns false, so this test fakes the handler resolution
+ * to exercise the gate itself.
+ */
+class IndexElasticGwdmGatingTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+        $this->disableObservers();
+    }
+
+    public function test_reindex_elastic_deindexes_when_handler_does_not_support_elastic_indexing(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+        $metadata = $this->getMetadataV2p0();
+
+        request()->headers->set('x-gwdm-version', '2.0');
+        $created = app(DatasetService::class)->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+        $datasetId = $created['dataset_id'];
+
+        // Fake a handler that overrides supportsElasticIndexing() to false.
+        $fakeHandler = Mockery::mock(Gwdm2xHandler::class, ['2.0'])->makePartial();
+        $fakeHandler->shouldReceive('supportsElasticIndexing')->andReturn(false);
+
+        $fakeFactory = Mockery::mock(GwdmHandlerFactory::class)->makePartial();
+        $fakeFactory->shouldReceive('resolve')->andReturn($fakeHandler);
+        app()->instance(GwdmHandlerFactory::class, $fakeFactory);
+
+        $job = new IndexDataset((string) $datasetId);
+        $params = $job->reindexElastic((string) $datasetId, true);
+
+        $this->assertNull($params, 'a non-indexable version must skip building an ES document');
+    }
+
+    public function test_reindex_elastic_still_indexes_when_handler_supports_elastic_indexing(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+        $metadata = $this->getMetadataV2p0();
+
+        request()->headers->set('x-gwdm-version', '2.0');
+        $created = app(DatasetService::class)->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+        $datasetId = $created['dataset_id'];
+
+        $job = new IndexDataset((string) $datasetId);
+        $params = $job->reindexElastic((string) $datasetId, true);
+
+        $this->assertIsArray($params, 'an indexable version (real GWDM 2.0 today) must still build an ES document');
+        $this->assertSame((int) $datasetId, $params['id']);
+    }
+}

--- a/tests/Feature/Jobs/ExtractMetadataDeltaRowTest.php
+++ b/tests/Feature/Jobs/ExtractMetadataDeltaRowTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ExtractPublicationsFromMetadata;
+use App\Jobs\ExtractToolsFromMetadata;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Models\Publication;
+use App\Models\Team;
+use App\Models\Tool;
+use App\Models\User;
+use App\Services\DatasetService;
+use Tests\TestCase;
+use Tests\Traits\Authorization;
+use Tests\Traits\MockExternalApis;
+
+/**
+ * Regression coverage for GAT-9018: ExtractToolsFromMetadata::tool() and
+ * ExtractPublicationsFromMetadata::publication() used to read
+ * dataset_versions.metadata directly via a raw DB::table()+JSON_TYPE() check,
+ * which silently no-oped on delta rows — persistMetadataVersion() stores
+ * `metadata = []` there (SQL type ARRAY), matching neither the OBJECT nor
+ * STRING branch the jobs checked for. They now reconstruct via
+ * DatasetService::getReconstructedMetadataEnvelope(), which is correct for
+ * both snapshot and delta rows.
+ */
+class ExtractMetadataDeltaRowTest extends TestCase
+{
+    use Authorization;
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+        $this->disableObservers();
+    }
+
+    private function setGwdmHeader(string $version): void
+    {
+        request()->headers->set('x-gwdm-version', $version);
+    }
+
+    private function service(): DatasetService
+    {
+        return app(DatasetService::class);
+    }
+
+    /**
+     * @return array{0: int, 1: DatasetVersion} dataset id and the resulting delta-row version
+     */
+    private function createDatasetWithDeltaVersion(Team $team, User $user, array $metadata): array
+    {
+        $this->setGwdmHeader('2.0');
+
+        $created = $this->service()->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+        $datasetId = $created['dataset_id'];
+
+        // v2: identical schema -> delta row (metadata column stores `[]`, not the
+        // full envelope) — this is the shape that used to break both jobs.
+        $this->service()->update(
+            Dataset::find($datasetId),
+            ['metadata' => $metadata, 'status' => Dataset::STATUS_ACTIVE],
+            $user->id,
+            $team->id,
+            Dataset::ORIGIN_MANUAL,
+            false,
+            $team,
+        );
+
+        $v2 = DatasetVersion::where('dataset_id', $datasetId)->where('version', 2)->first();
+        $this->assertNotNull($v2, 'v2 should have been created');
+        $this->assertNotNull($v2->patch, 'v2 must be a delta row for this regression test to be meaningful');
+        $this->assertSame([], $v2->metadata, 'delta row metadata column must be empty, confirming a raw-column read would find nothing');
+
+        return [$datasetId, $v2];
+    }
+
+    public function test_tool_extraction_reads_delta_row_metadata_correctly(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+        $tool = Tool::factory()->create([
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'enabled' => 1,
+        ]);
+
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['linkage']['tools'] = config('gateway.gateway_url') . '/tool/' . $tool->id;
+
+        [, $v2] = $this->createDatasetWithDeltaVersion($team, $user, $metadata);
+
+        (new ExtractToolsFromMetadata($v2->id))->tool($v2->id);
+
+        $this->assertDatabaseHas('dataset_version_has_tool', [
+            'dataset_version_id' => $v2->id,
+            'tool_id' => $tool->id,
+            'link_type' => 'Used on',
+        ]);
+    }
+
+    public function test_publication_extraction_reads_delta_row_metadata_correctly(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+        $publication = Publication::factory()->create([
+            'team_id' => $team->id,
+            'owner_id' => $user->id,
+        ]);
+
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['linkage']['publicationAboutDataset'] = [
+            config('gateway.gateway_url') . '/publication/' . $publication->id,
+        ];
+
+        [, $v2] = $this->createDatasetWithDeltaVersion($team, $user, $metadata);
+
+        (new ExtractPublicationsFromMetadata($v2->id))->publication($v2->id);
+
+        $this->assertDatabaseHas('publication_has_dataset_version', [
+            'dataset_version_id' => $v2->id,
+            'publication_id' => $publication->id,
+            'link_type' => 'ABOUT',
+        ]);
+    }
+}


### PR DESCRIPTION
Stacked on feat/GAT-9018-2. Reinstates the fixes/features that were split out of PR2 because they're independent of the version-handler/DatasetService rearrangement — genuinely pre-existing bugs or new functionality, not caused by the refactor:

- Free-text linkage fallback: dataset/publication linkages that can't be resolved to a real row are now stored with their raw external url/pid/title/doi instead of being silently dropped. New raw_url/raw_pid/raw_title columns on dataset_version_has_dataset_version, raw_doi on publication_has_dataset_version, both FKs made nullable. Gwdm2xHandler::processDatasetLinkages()/processPublicationLinkages() write the unresolved fallback; afterRead() and DatasetService::getLinkages() read it back.
- IndexElastic delta-row fix: delta dataset_version rows store an empty metadata column by design, but ES indexing and the tool/publication extraction jobs read it directly, crashing or silently no-oping on delta rows. They now reconstruct the full envelope via DatasetService::getReconstructedMetadataEnvelope(). Adds GwdmMetadataHandler::supportsElasticIndexing() so datasets on a non-indexable GWDM version get deindexed rather than partially indexed, and moves Typesense field extraction into the handler hierarchy via toSearchableFields().
- Spatial-coverage pivot pruning fix: mapCoverage() and Dataset::getSpatialCoverageViaVersions() now scope to the latest version and prune stale pivot rows, so editing coverage down actually removes entries instead of accumulating across versions forever.

## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
