### PR TITLE
feat(GAT-9230): record error and disable after final job failure

### DIFF
--- a/app/Listeners/ProcessFederationFailure.php
+++ b/app/Listeners/ProcessFederationFailure.php
@@ -15,7 +15,12 @@ class ProcessFederationFailure
         $federationId = $event->federation->id;
         $jobUuid      = $event->jobUuid;
 
-        $event->federation->update(['is_running' => 0]);
+        $event->federation->update([
+            'is_running' => 0,
+            'error' => true,
+            'error_text' => substr($event->exception->getMessage(), 0, 200),
+            'enabled' => false,
+        ]);
 
         SendEmailCustomIntegration::dispatch($federationId, $jobUuid, 'failure', $event->exception->getMessage());
 

--- a/app/Listeners/ProcessFederationSuccess.php
+++ b/app/Listeners/ProcessFederationSuccess.php
@@ -15,7 +15,11 @@ class ProcessFederationSuccess
         $federationId = $event->federation->id;
         $jobUuid      = $event->jobUuid;
 
-        $event->federation->update(['is_running' => 0]);
+        $event->federation->update([
+            'is_running' => 0,
+            'error' => false,
+            'error_text' => null,
+        ]);
 
         SendEmailCustomIntegration::dispatch($federationId, $jobUuid, 'success');
 

--- a/app/Models/Federation.php
+++ b/app/Models/Federation.php
@@ -69,6 +69,8 @@ class Federation extends Model
         'tested',
         'pid',
         'is_running',
+        'error',
+        'error_text',
     ];
 
     /**
@@ -86,6 +88,7 @@ class Federation extends Model
         'enabled' => 'boolean',
         'tested' => 'boolean',
         'is_running' => 'boolean',
+        'error' => 'boolean',
     ];
 
     /** @return BelongsToMany<Team, $this> */

--- a/tests/Feature/ProcessFederationFailureTest.php
+++ b/tests/Feature/ProcessFederationFailureTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\FederationProcessed;
+use App\Events\FederationProcessingFailed;
+use App\Jobs\SendEmailCustomIntegration;
+use App\Models\Federation;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ProcessFederationFailureTest extends TestCase
+{
+    private function makeFederation(array $overrides = []): Federation
+    {
+        return Federation::factory()->create(array_merge([
+            'enabled' => true,
+            'tested' => true,
+            'is_running' => true,
+            'error' => false,
+            'error_text' => null,
+        ], $overrides));
+    }
+
+    public function test_failure_disables_the_federation_and_records_the_error(): void
+    {
+        $federation = $this->makeFederation();
+
+        Event::dispatch(new FederationProcessingFailed(
+            $federation,
+            new \RuntimeException('remote catalogue unreachable'),
+            'job-uuid-1'
+        ));
+
+        $fresh = $federation->fresh();
+
+        $this->assertFalse($fresh->is_running);
+        $this->assertFalse($fresh->enabled);
+        $this->assertTrue($fresh->error);
+        $this->assertStringContainsString('remote catalogue unreachable', $fresh->error_text);
+        Queue::assertPushed(SendEmailCustomIntegration::class, 1);
+    }
+
+    public function test_long_error_messages_are_persisted_without_error(): void
+    {
+        $federation = $this->makeFederation();
+        $longMessage = str_repeat('a', 250);
+
+        Event::dispatch(new FederationProcessingFailed(
+            $federation,
+            new \RuntimeException($longMessage),
+            'job-uuid-2'
+        ));
+
+        $fresh = $federation->fresh();
+
+        $this->assertTrue($fresh->error);
+        $this->assertLessThanOrEqual(200, strlen($fresh->error_text));
+    }
+
+    public function test_success_clears_a_previously_recorded_error(): void
+    {
+        $federation = $this->makeFederation([
+            'enabled' => true,
+            'is_running' => true,
+            'error' => true,
+            'error_text' => 'a previous failure',
+        ]);
+
+        Event::dispatch(new FederationProcessed($federation, 'job-uuid-3'));
+
+        $fresh = $federation->fresh();
+
+        $this->assertFalse($fresh->error);
+        $this->assertNull($fresh->error_text);
+    }
+}


### PR DESCRIPTION
ProcessFederation retries a failing job up to three times, before giving up and firing FederationProcessingFailed. The listener for that event only cleared is_running, queued a failure email, and logged the error. The error and error_text columns already present on the federations table were never populated, and a federation that failed kept getting rescheduled indefinitely.

Wire those columns up. On final failure, record the exception message (truncated to the column's 200-char limit) and clear enabled, the same flag getActiveFederations() checks before scheduling a run, so a broken federation stops being retried until someone investigates. ProcessFederationSuccess now clears error/error_text on success, so a federation that is manually re-enabled and starts working again doesn't keep showing a stale error from before.

Add fillable/cast entries for error/error_text on the Federation model, since they were never mass-assignable.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9230

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
