### PR TITLE
fix(GAT-9247): Correctly parse auth_secret_key to return when listing integration in FE

### DIFF
--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -116,10 +116,10 @@ class FederationController extends Controller
             })->with(['team', 'notifications.userNotification'])->paginate($perPage, ['*'], 'page');
 
             $federations->getCollection()->transform(function ($federation) {
-                $federation->auth_secret_key = $this->decryptAuthSecretKey(
+                $federation->setAttribute('auth_secret_key', $this->decryptAuthSecretKey(
                     $federation->auth_secret_key_location,
                     $federation->auth_type
-                );
+                ));
                 return $federation;
             });
 

--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -115,6 +115,14 @@ class FederationController extends Controller
                 $query->where('id', $teamId);
             })->with(['team', 'notifications.userNotification'])->paginate($perPage, ['*'], 'page');
 
+            $federations->getCollection()->transform(function ($federation) {
+                $federation->auth_secret_key = $this->decryptAuthSecretKey(
+                    $federation->auth_secret_key_location,
+                    $federation->auth_type
+                );
+                return $federation;
+            });
+
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
                 'team_id' => $teamId,
@@ -210,6 +218,11 @@ class FederationController extends Controller
             $federations = Federation::whereHas('team', function ($query) use ($teamId) {
                 $query->where('id', $teamId);
             })->where('id', $federationId)->with(['team', 'notifications.userNotification'])->first()->toArray();
+
+            $federations['auth_secret_key'] = $this->decryptAuthSecretKey(
+                $federations['auth_secret_key_location'] ?? null,
+                $federations['auth_type'] ?? null
+            );
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -997,6 +1010,26 @@ class FederationController extends Controller
 
             throw new Exception($e->getMessage());
         }
+    }
+
+    private function decryptAuthSecretKey(?string $secretLocation, ?string $authType): ?string
+    {
+        if (!$secretLocation || !in_array($authType, ['BEARER', 'API_KEY'])) {
+            return null;
+        }
+
+        try {
+            $payload = json_decode(app(GoogleSecretManagerService::class)->getSecret($secretLocation), true);
+        } catch (Exception $e) {
+            \Log::info('failed to retrieve federation secret ' . $secretLocation . ': ' . $e->getMessage());
+            return null;
+        }
+
+        return match ($authType) {
+            'BEARER' => $payload['bearer_token'] ?? null,
+            'API_KEY' => $payload['api_key'] ?? null,
+            default => null,
+        };
     }
 
     private function upsertFederationSecret(int $federationId, array $secretsPayload): string


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
