### PR TITLE
feat(GAT-9231): Add federation run-history API endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Federation\DeleteFederation;
 use App\Http\Requests\Federation\EditFederation;
 use App\Http\Requests\Federation\GetAllFederation;
 use App\Http\Requests\Federation\GetFederation;
+use App\Http\Requests\Federation\GetFederationHistory;
 use App\Http\Requests\Federation\RunNowFederation;
 use App\Http\Requests\Federation\UpdateFederation;
 use App\Http\Traits\LoggingContext;
@@ -18,6 +19,7 @@ use App\Jobs\TestFederation;
 use App\Models\EmailTemplate;
 use App\Models\Federation;
 use App\Models\FederationHasNotification;
+use App\Models\FederationJobRun;
 use App\Models\Notification;
 use App\Models\Role;
 use App\Models\TeamHasFederation;
@@ -1042,6 +1044,155 @@ class FederationController extends Controller
         $gsms->createSecret($auth_secret_key_location, json_encode($secretsPayload));
 
         return $auth_secret_key_location;
+    }
+
+    /**
+     * @OA\Get(
+     *    path="/api/v1/teams/{teamId}/federations/{federationId}/history",
+     *    operationId="get_federation_history",
+     *    tags={"Team-Federations"},
+     *    summary="FederationController@history",
+     *    description="Get run history for a federation",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\Parameter(
+     *       name="teamId",
+     *       in="path",
+     *       description="team id",
+     *       required=true,
+     *       example="1",
+     *       @OA\Schema(
+     *          type="integer",
+     *          description="team id",
+     *       ),
+     *    ),
+     *    @OA\Parameter(
+     *       name="federationId",
+     *       in="path",
+     *       description="federation id",
+     *       required=true,
+     *       example="1",
+     *       @OA\Schema(
+     *          type="integer",
+     *          description="federation id",
+     *       ),
+     *    ),
+     *    @OA\Parameter(
+     *       name="per_page",
+     *       in="query",
+     *       description="per page",
+     *       required=false,
+     *       example="25",
+     *       @OA\Schema(
+     *          type="integer",
+     *          description="per page",
+     *       ),
+     *    ),
+     *    @OA\Response(
+     *       response="200",
+     *       description="Success response",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="current_page", type="integer", example="1"),
+     *          @OA\Property(property="data", type="array",
+     *             @OA\Items(type="object",
+     *                @OA\Property(property="job_uuid", type="string", example="6d6b0e2e-6e4a-4a63-8f3c-2f9d9c8a1e11"),
+     *                @OA\Property(property="started_at", type="datetime", example="2025-03-13 14:00:00"),
+     *                @OA\Property(property="finished_at", type="datetime", example="2025-03-13 14:02:31"),
+     *                @OA\Property(property="status", type="string", example="failed", enum={"success", "failed", "in_progress"}),
+     *                @OA\Property(property="message", type="string", example="2 of 5 datasets failed", nullable=true),
+     *                @OA\Property(property="failed_datasets", type="array",
+     *                   @OA\Items(type="object",
+     *                      @OA\Property(property="pid", type="string", example="9c1e2f3a-...-abcdef"),
+     *                      @OA\Property(property="message", type="string", example="HDRUK/2.0.2: must NOT have additional properties"),
+     *                   ),
+     *                ),
+     *             ),
+     *          ),
+     *          @OA\Property(property="first_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams\/19\/federations\/1\/history?page=1"),
+     *          @OA\Property(property="from", type="integer", example="1"),
+     *          @OA\Property(property="last_page", type="integer", example="1"),
+     *          @OA\Property(property="last_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams\/19\/federations\/1\/history?page=1"),
+     *          @OA\Property(property="links", type="array", example="[]", @OA\Items(type="array", @OA\Items())),
+     *          @OA\Property(property="next_page_url", type="string", example="null"),
+     *          @OA\Property(property="path", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams\/19\/federations\/1\/history"),
+     *          @OA\Property(property="per_page", type="integer", example="25"),
+     *          @OA\Property(property="prev_page_url", type="string", example="null"),
+     *          @OA\Property(property="to", type="integer", example="3"),
+     *          @OA\Property(property="total", type="integer", example="3"),
+     *       ),
+     *    ),
+     * )
+     */
+    public function history(GetFederationHistory $request, int $teamId, int $federationId)
+    {
+        $loggingContext = $this->getLoggingContext($request);
+        $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
+
+        $jwtUser = $request->jwtUser();
+
+        try {
+            $perPage = $request->validated('per_page', Config::get('constants.per_page'));
+            $executions = FederationJobRun::executionsForFederation($federationId, $perPage);
+
+            $executions->getCollection()->transform(function (FederationJobRun $execution) use ($federationId) {
+                $rows = FederationJobRun::latestPerPidForExecution($federationId, $execution->job_uuid);
+
+                $failed = $rows->filter(fn ($row) => $row->status === 0);
+                $pending = $rows->filter(fn ($row) => is_null($row->status));
+
+                $failedDatasets = $failed->map(fn ($row) => [
+                    'pid' => $row->pid,
+                    'message' => collect($row->errorMessages())
+                        ->map(fn ($entry) => $entry['schema'] ? "{$entry['schema']}: {$entry['message']}" : $entry['message'])
+                        ->implode('; '),
+                ])->values()->all();
+
+                $onlyFailure = count($failedDatasets) === 1 ? $failedDatasets[0] : null;
+
+                if ($onlyFailure) {
+                    $status = 'failed';
+                    $message = $onlyFailure['message'];
+                } elseif (count($failedDatasets) > 1) {
+                    $status = 'failed';
+                    $message = count($failedDatasets) . " of {$rows->count()} datasets failed";
+                } elseif ($pending->count() > 0) {
+                    $status = 'in_progress';
+                    $message = null;
+                } else {
+                    $status = 'success';
+                    $message = null;
+                }
+
+                return [
+                    'job_uuid' => $execution->job_uuid,
+                    'started_at' => $execution->started_at,
+                    'finished_at' => $execution->finished_at,
+                    'status' => $status,
+                    'message' => $message,
+                    'failed_datasets' => $failedDatasets,
+                ];
+            });
+
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'team_id' => $teamId,
+                'action_type' => 'GET',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => 'Federation ' . $federationId . ' history',
+            ]);
+
+            return response()->json($executions);
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'team_id' => $teamId,
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+            \Log::info($e->getMessage(), $loggingContext);
+
+            throw new Exception($e->getMessage());
+        }
     }
 
     private function getSecretsPayload(array $input)

--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -106,8 +106,7 @@ class FederationController extends Controller
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
-        $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $perPage = request('per_page', Config::get('constants.per_page'));
@@ -211,8 +210,7 @@ class FederationController extends Controller
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
-        $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $federations = Federation::whereHas('team', function ($query) use ($teamId) {
@@ -318,7 +316,7 @@ class FederationController extends Controller
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
         $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $payload = [
@@ -486,7 +484,7 @@ class FederationController extends Controller
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
         $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $updateArray = [
@@ -655,7 +653,7 @@ class FederationController extends Controller
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
         $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $arrayKeys = [
@@ -814,8 +812,7 @@ class FederationController extends Controller
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
-        $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $federationNotifications = FederationHasNotification::where([
@@ -967,8 +964,7 @@ class FederationController extends Controller
         $loggingContext = $this->getLoggingContext($request);
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
 
-        $input = $request->all();
-        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+        $jwtUser = $request->jwtUser();
 
         try {
             $checkFederation = Federation::where([

--- a/app/Http/Requests/Federation/GetFederationHistory.php
+++ b/app/Http/Requests/Federation/GetFederationHistory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests\Federation;
+
+use App\Http\Requests\BaseFormRequest;
+use App\Models\TeamHasFederation;
+
+class GetFederationHistory extends BaseFormRequest
+{
+    /**
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'team_id' => [
+                'required',
+                'int',
+                'exists:teams,id',
+            ],
+            'federation_id' => [
+                'required',
+                'int',
+                'exists:federations,id',
+                function ($attribute, $value, $fail) {
+                    $exists = TeamHasFederation::where('federation_id', $value)
+                    ->where('team_id', $this->team_id)
+                        ->exists();
+
+                    if (!$exists) {
+                        $fail('The selected federation is not part of the specified team.');
+                    }
+                },
+            ],
+            'per_page' => [
+                'nullable',
+                'integer',
+                'min:1',
+            ],
+        ];
+    }
+
+    /**
+     * Add Route parameters to the FormRequest.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge([
+            'team_id' => $this->route('teamId'),
+            'federation_id' => $this->route('federationId'),
+        ]);
+    }
+}

--- a/app/Jobs/SendEmailCustomIntegration.php
+++ b/app/Jobs/SendEmailCustomIntegration.php
@@ -102,18 +102,13 @@ class SendEmailCustomIntegration implements ShouldQueue
 
     public function getFederationHistory(): array
     {
-        $pids = $this->getUniquePid();
+        $latestAttempts = FederationJobRun::latestPerPidForExecution($this->federationId, $this->jobUuid);
 
         $integrationSuccess = '<ul>';
         $integrationErrors  = '<ul>';
         $successCount       = 0;
 
-        foreach ($pids as $pid) {
-            $latestAttempt = FederationJobRun::where('job_uuid', $this->jobUuid)
-                ->where('pid', $pid)
-                ->latest()
-                ->first();
-
+        foreach ($latestAttempts as $latestAttempt) {
             if ($latestAttempt->status === 1) {
                 $details = data_get($latestAttempt, 'details.message', '');
                 $integrationSuccess .= "<li>PID: {$latestAttempt->pid} - {$details}</li>";
@@ -121,8 +116,9 @@ class SendEmailCustomIntegration implements ShouldQueue
             }
 
             if ($latestAttempt->status === 0) {
-                $details = data_get($latestAttempt, 'details.message', []);
-                $error   = is_array($details) ? $this->getErrors($details) : (string) $details;
+                $error = collect($latestAttempt->errorMessages())
+                    ->map(fn ($entry) => $entry['schema'] ? "{$entry['schema']}  - {$entry['message']}<br>" : $entry['message'])
+                    ->implode('');
                 $integrationErrors .= "<li>PID - {$latestAttempt->pid}:<br>{$error}</li>";
             }
         }
@@ -185,27 +181,4 @@ class SendEmailCustomIntegration implements ShouldQueue
         return '<ul>' . collect($users)->map(fn ($user) => "<li>{$user->name}</li>")->implode('') . '</ul>';
     }
 
-    public function getUniquePid(): array
-    {
-        return FederationJobRun::select('pid')
-            ->where('job_uuid', $this->jobUuid)
-            ->where('federation_id', $this->federationId)
-            ->distinct()
-            ->pluck('pid')
-            ->toArray();
-    }
-
-    public function getErrors(array $errors): string
-    {
-        $string = '';
-
-        foreach ($errors as $err) {
-            $stringSchema = "{$err['name']}/{$err['version']}";
-            foreach ($err['errors'] as $item) {
-                $string .= "{$stringSchema}  - {$item['message']}<br>";
-            }
-        }
-
-        return $string;
-    }
 }

--- a/app/Models/Federation.php
+++ b/app/Models/Federation.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Federation extends Model
 {
@@ -100,5 +101,11 @@ class Federation extends Model
     public function notifications(): BelongsToMany
     {
         return $this->belongsToMany(Notification::class, 'federation_has_notifications');
+    }
+
+    /** @return HasMany<FederationJobRun, $this> */
+    public function jobRuns(): HasMany
+    {
+        return $this->hasMany(FederationJobRun::class, 'federation_id');
     }
 }

--- a/app/Models/FederationJobRun.php
+++ b/app/Models/FederationJobRun.php
@@ -5,8 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 
+/**
+ * @property-read string|null $started_at only populated on rows returned by executionsForFederation()
+ * @property-read string|null $finished_at only populated on rows returned by executionsForFederation()
+ */
 class FederationJobRun extends Model
 {
     use SoftDeletes;
@@ -40,18 +45,39 @@ class FederationJobRun extends Model
         'details' => 'array',
     ];
 
-    /** Latest recorded row per dataset (pid) for one federation execution. */
+    /**
+     * Latest recorded row per dataset (pid) for one federation execution.
+     *
+     * @return Collection<int, FederationJobRun>
+     */
     public static function latestPerPidForExecution(int $federationId, string $jobUuid): Collection
     {
-        $pids = static::where('federation_id', $federationId)
+        return static::where('federation_id', $federationId)
             ->where('job_uuid', $jobUuid)
-            ->select('pid')->distinct()->pluck('pid');
+            ->whereIn('id', function ($query) use ($federationId, $jobUuid) {
+                $query->selectRaw('MAX(id)')
+                    ->from((new self())->getTable())
+                    ->where('federation_id', $federationId)
+                    ->where('job_uuid', $jobUuid)
+                    ->groupBy('pid');
+            })
+            ->get();
+    }
 
-        return $pids->map(fn (string $pid) => static::where('federation_id', $federationId)
-            ->where('job_uuid', $jobUuid)
-            ->where('pid', $pid)
-            ->latest()
-            ->first());
+    /**
+     * Distinct executions (job_uuid groups) for a federation, most recent first.
+     *
+     * @return LengthAwarePaginator<int, FederationJobRun>
+     */
+    public static function executionsForFederation(int $federationId, int $perPage): LengthAwarePaginator
+    {
+        return static::where('federation_id', $federationId)
+            ->select('job_uuid')
+            ->selectRaw('MIN(created_at) as started_at')
+            ->selectRaw('MAX(created_at) as finished_at')
+            ->groupBy('job_uuid')
+            ->orderByDesc('started_at')
+            ->paginate($perPage, ['*'], 'page');
     }
 
     /**

--- a/app/Models/FederationJobRun.php
+++ b/app/Models/FederationJobRun.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
 
 class FederationJobRun extends Model
 {
@@ -38,4 +39,54 @@ class FederationJobRun extends Model
     protected $casts = [
         'details' => 'array',
     ];
+
+    /** Latest recorded row per dataset (pid) for one federation execution. */
+    public static function latestPerPidForExecution(int $federationId, string $jobUuid): Collection
+    {
+        $pids = static::where('federation_id', $federationId)
+            ->where('job_uuid', $jobUuid)
+            ->select('pid')->distinct()->pluck('pid');
+
+        return $pids->map(fn (string $pid) => static::where('federation_id', $federationId)
+            ->where('job_uuid', $jobUuid)
+            ->where('pid', $pid)
+            ->latest()
+            ->first());
+    }
+
+    /**
+     * @return array<int, array{schema: ?string, message: string}>
+     */
+    public function errorMessages(): array
+    {
+        $raw = data_get($this, 'details.message', '');
+
+        if (is_string($raw)) {
+            return [['schema' => null, 'message' => $raw]];
+        }
+
+        if (is_array($raw)) {
+            $items = isset($raw['message']) && is_array($raw['message']) ? $raw['message'] : $raw;
+
+            $entries = [];
+            foreach ($items as $item) {
+                if (is_array($item) && isset($item['errors']) && is_array($item['errors'])) {
+                    $schema = ($item['name'] ?? '?') . '/' . ($item['version'] ?? '?');
+                    foreach ($item['errors'] as $error) {
+                        $entries[] = ['schema' => $schema, 'message' => $error['message'] ?? 'Unknown validation error'];
+                    }
+                }
+            }
+
+            if (!empty($entries)) {
+                return $entries;
+            }
+
+            if (isset($raw['traser_message'])) {
+                return [['schema' => null, 'message' => (string) $raw['traser_message']]];
+            }
+        }
+
+        return [['schema' => null, 'message' => 'An error occurred while processing this dataset.']];
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\SSO\CustomAccessToken;
 use App\Models\DataAccessApplication;
 use App\Observers\DataAccessApplicationObserver;
 use Config;
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Passport;
 use Laravel\Pennant\Feature;
@@ -66,5 +67,9 @@ class AppServiceProvider extends ServiceProvider
         DataAccessApplication::observe(DataAccessApplicationObserver::class);
 
         Feature::resolveScopeUsing(fn ($driver) => null);
+
+        Request::macro('jwtUser', function () {
+            return $this->input('jwt_user', []);
+        });
     }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -2768,6 +2768,21 @@ return [
             'federationId' => '[0-9]+',
         ],
     ],
+    [
+        'name' => 'team.federation.history',
+        'method' => 'get',
+        'path' => '/teams/{teamId}/federations/{federationId}/history',
+        'methodController' => 'FederationController@history',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:permissions,integrations.metadata',
+        ],
+        'constraint' => [
+            'teamId' => '[0-9]+',
+            'federationId' => '[0-9]+',
+        ],
+    ],
 
     // cohort_requests
     [

--- a/database/migrations/2026_07_23_090228_add_composite_indexes_to_federation_job_runs_table.php
+++ b/database/migrations/2026_07_23_090228_add_composite_indexes_to_federation_job_runs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('federation_job_runs', function (Blueprint $table) {
+            $table->index(['federation_id', 'job_uuid', 'pid'], 'federation_job_runs_federation_job_pid_index');
+            $table->index(['federation_id', 'job_uuid', 'created_at'], 'federation_job_runs_federation_job_created_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('federation_job_runs', function (Blueprint $table) {
+            $table->dropIndex('federation_job_runs_federation_job_pid_index');
+            $table->dropIndex('federation_job_runs_federation_job_created_index');
+        });
+    }
+};

--- a/tests/Feature/FederationHistoryTest.php
+++ b/tests/Feature/FederationHistoryTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Federation;
+use App\Models\FederationJobRun;
+use App\Models\Team;
+use App\Models\TeamHasFederation;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+class FederationHistoryTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function makeFederation(): array
+    {
+        $team = Team::factory()->create();
+        $federation = Federation::factory()->create([
+            'enabled' => true,
+            'tested' => true,
+            'is_running' => false,
+        ]);
+        TeamHasFederation::create([
+            'team_id' => $team->id,
+            'federation_id' => $federation->id,
+        ]);
+
+        return [$team, $federation];
+    }
+
+    private function makeRun(Team $team, Federation $federation, string $jobUuid, string $pid, ?int $status, $message, string $createdAt): FederationJobRun
+    {
+        $run = FederationJobRun::create([
+            'team_id' => $team->id,
+            'federation_id' => $federation->id,
+            'job_uuid' => $jobUuid,
+            'pid' => $pid,
+            'status' => $status,
+            'details' => ['message' => $message],
+            'job_attempts' => 1,
+        ]);
+
+        FederationJobRun::where('id', $run->id)->update(['created_at' => $createdAt]);
+
+        return $run->fresh();
+    }
+
+    private function historyUrl(int $teamId, int $federationId): string
+    {
+        return "api/v1/teams/{$teamId}/federations/{$federationId}/history";
+    }
+
+    public function test_executions_are_listed_most_recent_first_with_correct_pagination(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $this->makeRun($team, $federation, 'uuid-older', 'pid-1', 1, 'CREATED', now()->subDays(2)->toDateTimeString());
+        $this->makeRun($team, $federation, 'uuid-newer', 'pid-2', 1, 'CREATED', now()->subDay()->toDateTimeString());
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id), $this->header);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'current_page',
+                'data' => [
+                    0 => ['job_uuid', 'started_at', 'finished_at', 'status', 'message', 'failed_datasets'],
+                ],
+                'total',
+            ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertSame(2, $content['total']);
+        $this->assertSame('uuid-newer', $content['data'][0]['job_uuid']);
+        $this->assertSame('success', $content['data'][0]['status']);
+        $this->assertNull($content['data'][0]['message']);
+        $this->assertSame([], $content['data'][0]['failed_datasets']);
+        $this->assertSame('uuid-older', $content['data'][1]['job_uuid']);
+    }
+
+    public function test_single_dataset_failure_surfaces_its_normalized_message(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $this->makeRun(
+            $team,
+            $federation,
+            'uuid-failed',
+            'pid-err',
+            0,
+            'An unexpected error occurred while creating dataset pid-err. Please contact support and reference job: uuid-failed',
+            now()->toDateTimeString()
+        );
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $this->assertSame('failed', $content['data'][0]['status']);
+        $this->assertSame(
+            'An unexpected error occurred while creating dataset pid-err. Please contact support and reference job: uuid-failed',
+            $content['data'][0]['message']
+        );
+        $this->assertCount(1, $content['data'][0]['failed_datasets']);
+        $this->assertSame('pid-err', $content['data'][0]['failed_datasets'][0]['pid']);
+        $this->assertSame(
+            'An unexpected error occurred while creating dataset pid-err. Please contact support and reference job: uuid-failed',
+            $content['data'][0]['failed_datasets'][0]['message']
+        );
+    }
+
+    public function test_multiple_dataset_failures_collapse_summary_but_keep_full_detail(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $this->makeRun($team, $federation, 'uuid-multi', 'pid-1', 0, 'boom 1', now()->toDateTimeString());
+        $this->makeRun($team, $federation, 'uuid-multi', 'pid-2', 0, 'boom 2', now()->toDateTimeString());
+        $this->makeRun($team, $federation, 'uuid-multi', 'pid-3', 1, 'CREATED', now()->toDateTimeString());
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $this->assertSame('failed', $content['data'][0]['status']);
+        $this->assertSame('2 of 3 datasets failed', $content['data'][0]['message']);
+
+        $failedDatasets = $content['data'][0]['failed_datasets'];
+        $this->assertCount(2, $failedDatasets);
+        $pids = array_column($failedDatasets, 'pid');
+        $messages = array_column($failedDatasets, 'message');
+        $this->assertContains('pid-1', $pids);
+        $this->assertContains('pid-2', $pids);
+        $this->assertContains('boom 1', $messages);
+        $this->assertContains('boom 2', $messages);
+    }
+
+    public function test_nested_traser_validation_errors_are_normalized_to_readable_text(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $this->makeRun(
+            $team,
+            $federation,
+            'uuid-traser',
+            'pid-traser',
+            0,
+            [[
+                'name' => 'HDRUK',
+                'version' => '2.0.2',
+                'errors' => [['message' => 'must NOT have additional properties']],
+            ]],
+            now()->toDateTimeString()
+        );
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $this->assertSame('failed', $content['data'][0]['status']);
+        $this->assertStringContainsString('must NOT have additional properties', $content['data'][0]['message']);
+    }
+
+    public function test_only_the_latest_attempt_per_dataset_counts(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $this->makeRun($team, $federation, 'uuid-retry', 'pid-retry', 0, 'first attempt failed', now()->subMinute()->toDateTimeString());
+        $this->makeRun($team, $federation, 'uuid-retry', 'pid-retry', 1, 'CREATED', now()->toDateTimeString());
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $this->assertSame('success', $content['data'][0]['status']);
+        $this->assertNull($content['data'][0]['message']);
+    }
+
+    public function test_a_federation_not_belonging_to_the_requested_team_is_rejected(): void
+    {
+        [, $federation] = $this->makeFederation();
+        $otherTeam = Team::factory()->create();
+
+        $response = $this->get($this->historyUrl($otherTeam->id, $federation->id), $this->header);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_a_non_numeric_per_page_is_rejected_with_a_validation_error(): void
+    {
+        [$team, $federation] = $this->makeFederation();
+
+        $response = $this->get($this->historyUrl($team->id, $federation->id) . '?per_page=abc', $this->header);
+
+        $response->assertStatus(400);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

<img width="831" height="841" alt="image" src="https://github.com/user-attachments/assets/6e641a84-4857-4136-bb1a-48c26fb9ee83" />


## Describe your changes

Adds a read-only API for a federation's past run history, so the
frontend can show execution status and failure detail without
querying federation_job_runs directly. Three commits:

  - Extract the per-execution dataset fetch/parse logic (already used
    by the outcome email) onto FederationJobRun, so the new endpoint
    and the email share one implementation instead of two.
  - Adopt a Request::jwtUser() macro in FederationController, in place
    of the repeated $request->all()['jwt_user'] pattern, scoped to
    this controller as a candidate for wider rollout.
  - Add GET /teams/{teamId}/federations/{federationId}/history: a
    paginated list of past executions with status and per-dataset
    failure detail.
    
 Example response:
 
 ```
 {
    "current_page": 1,
    "data": [
        {
            "job_uuid": "",
            "started_at": "2026-07-15 08:42:59",
            "finished_at": "2026-07-15 08:42:59",
            "status": "failed",
            "message": "GWDM/2.0: must have required property 'gatewayId'",
            "failed_datasets": [
                {
                    "pid": "mock-dataset-bad",
                    "message": "GWDM/2.0: must have required property 'gatewayId'"
                }
            ]
        },
        {
            "job_uuid": "77",
            "started_at": "2026-07-15 08:18:34",
            "finished_at": "2026-07-15 08:18:34",
            "status": "success",
            "message": null,
            "failed_datasets": []
        }
    ],
    "first_page_url": "http://localhost:8000/api/v1/teams/5/federations/4/history?page=1",
    "from": 1,
    "last_page": 1,
    "last_page_url": "http://localhost:8000/api/v1/teams/5/federations/4/history?page=1",
    "links": [
        {
            "url": null,
            "label": "&laquo; Previous",
            "page": null,
            "active": false
        },
        {
            "url": "http://localhost:8000/api/v1/teams/5/federations/4/history?page=1",
            "label": "1",
            "page": 1,
            "active": true
        },
        {
            "url": null,
            "label": "Next &raquo;",
            "page": null,
            "active": false
        }
    ],
    "next_page_url": null,
    "path": "http://localhost:8000/api/v1/teams/5/federations/4/history",
    "per_page": 25,
    "prev_page_url": null,
    "to": 2,
    "total": 2
}
```

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9231

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [x] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
