### PR TITLE
fix(GAT-9247): Fix for programmatically created/run federations

### DIFF
--- a/app/Jobs/TestFederation.php
+++ b/app/Jobs/TestFederation.php
@@ -52,7 +52,12 @@ class TestFederation implements ShouldQueue
 
     public function handle(): array
     {
-        $this->gsms = new GoogleSecretManagerService();
+        // Resolved via the container (not `new`) so it can be mocked in tests
+        // and to match ProcessFederation's identical pattern — real GCP
+        // Application Default Credentials are only ever needed for BEARER/
+        // API_KEY federations, but the client's constructor tries to resolve
+        // them unconditionally, so this must stay mockable even for NO_AUTH.
+        $this->gsms = app(GoogleSecretManagerService::class);
 
         $testCall = $this->pullCatalogueList($this->federation->toArray(), $this->gsms);
         if (is_array($testCall)) {

--- a/app/Traits/GatewayMetadataIngestionTrait.php
+++ b/app/Traits/GatewayMetadataIngestionTrait.php
@@ -21,7 +21,7 @@ trait GatewayMetadataIngestionTrait
 {
     use MetadataVersioning;
 
-    public function pullCatalogueList(Federation|array $federation, GoogleSecretManagerService $gsms): Collection
+    public function pullCatalogueList(Federation|array $federation, GoogleSecretManagerService $gsms): Collection|array
     {
         if (!is_array($federation)) {
             return $this->getCatalogueFromFederationModel($federation, $gsms);

--- a/tests/Feature/TestFederationJobTest.php
+++ b/tests/Feature/TestFederationJobTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\TestFederation;
+use App\Services\GoogleSecretManagerService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+class TestFederationJobTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    private const BASE_URL = 'https://test-federation.example.com';
+    private const DATASETS_PATH = '/api/v1/datasets';
+    private const DATASET_PATH = '/api/v1/datasets/{id}';
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function makeInput(): array
+    {
+        return [
+            'auth_type' => 'NO_AUTH',
+            'auth_secret_key' => null,
+            'endpoint_baseurl' => self::BASE_URL,
+            'endpoint_datasets' => self::DATASETS_PATH,
+            'endpoint_dataset' => self::DATASET_PATH,
+            'run_time_hour' => 11,
+        ];
+    }
+
+    /**
+     * Regression test: pullCatalogueList() was declared to return a strict
+     * Collection, but its array-federation branch (used here, since
+     * TestFederation passes an array not a Federation model) can legitimately
+     * return a plain array describing a failed connection attempt. That
+     * mismatch threw "Return value must be of type Collection, array
+     * returned" any time a federation test hit a non-200 remote response —
+     * exactly the case a user testing a broken/misconfigured federation
+     * would hit.
+     */
+    public function test_handle_returns_failure_array_instead_of_throwing_on_non_200_response(): void
+    {
+        $this->mock(GoogleSecretManagerService::class);
+
+        Http::fake([
+            self::BASE_URL . self::DATASETS_PATH . '*' => Http::response(['error' => 'unauthorized'], 401),
+        ]);
+
+        $result = (new TestFederation($this->makeInput()))->handle();
+
+        $this->assertFalse($result['data']['success']);
+        $this->assertEquals(401, $result['data']['status']);
+        $this->assertEquals('Test Unsuccessful', $result['data']['title']);
+    }
+
+    public function test_handle_returns_success_payload_on_200_response(): void
+    {
+        $this->mock(GoogleSecretManagerService::class);
+
+        Http::fake([
+            self::BASE_URL . self::DATASETS_PATH . '*' => Http::response(['items' => []], 200),
+        ]);
+
+        $result = (new TestFederation($this->makeInput()))->handle();
+
+        $this->assertTrue($result['data']['success']);
+        $this->assertEquals(200, $result['data']['status']);
+        $this->assertEquals('Test Successful', $result['data']['title']);
+    }
+}


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Fixes a small error when attempting to run a federation

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9247

## Environment / Configuration changes (if applicable)
N/A

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
