### PR TITLE
refactor(GAT-9231): Add seeders for federation job runs

### DIFF
--- a/app/Models/FederationJobRun.php
+++ b/app/Models/FederationJobRun.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class FederationJobRun extends Model
 {
+    use HasFactory;
     use SoftDeletes;
     use Prunable;
 

--- a/database/factories/FederationJobRunFactory.php
+++ b/database/factories/FederationJobRunFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\FederationJobRun>
+ */
+class FederationJobRunFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'team_id' => 1,
+            'federation_id' => 1,
+            'pid' => 'mock-dataset-' . str_pad((string) fake()->unique()->numberBetween(1, 999), 3, '0', STR_PAD_LEFT),
+            'job_uuid' => fake()->uuid(),
+            'status' => 1,
+            'details' => ['message' => 'CREATED'],
+            'job_attempts' => 1,
+        ];
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn () => [
+            'status' => 0,
+            'details' => ['message' => fake()->randomElement([
+                'Unable to validate dataset metadata against the expected schema.',
+                'The remote dataset endpoint returned an unexpected response.',
+                'Required field "publisher" was missing from the submitted metadata.',
+                'Timed out while translating the dataset metadata.',
+            ])],
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -47,6 +47,7 @@ class DatabaseSeeder extends Seeder
             TeamUserHasRoleSeeder::class,
             FederationSeeder::class,
             TeamHasFederationSeeder::class,
+            FederationJobRunSeeder::class,
             NamedEntitiesSeeder::class,
             DatasetVersionHasNamedEntitiesSeeder::class,
             CohortRequestSeeder::class,

--- a/database/seeders/FederationJobRunSeeder.php
+++ b/database/seeders/FederationJobRunSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Federation;
+use App\Models\FederationJobRun;
+use App\Models\TeamHasFederation;
+use Illuminate\Database\Seeder;
+
+class FederationJobRunSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Federation::all()->each(function (Federation $federation) {
+            $teamHasFederation = TeamHasFederation::where('federation_id', $federation->id)->first();
+
+            if (!$teamHasFederation) {
+                return;
+            }
+
+            for ($execution = 1; $execution <= 5; $execution++) {
+                $jobUuid = fake()->uuid();
+                $createdAt = now()->subDays(5 - $execution);
+                $datasetCount = fake()->numberBetween(2, 5);
+                $failedIndex = fake()->boolean(30) ? fake()->numberBetween(0, $datasetCount - 1) : null;
+
+                for ($dataset = 0; $dataset < $datasetCount; $dataset++) {
+                    $factory = FederationJobRun::factory();
+
+                    if ($dataset === $failedIndex) {
+                        $factory = $factory->failed();
+                    }
+
+                    $run = $factory->create([
+                        'team_id' => $teamHasFederation->team_id,
+                        'federation_id' => $federation->id,
+                        'job_uuid' => $jobUuid,
+                    ]);
+
+                    FederationJobRun::where('id', $run->id)->update(['created_at' => $createdAt]);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds seeding data for federation job run history.

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
