### PR TITLE
feat(GAT-2905): Add last run at to federations

### DIFF
--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -85,6 +85,7 @@ class FederationController extends Controller
      *                   @OA\Property(property="tested", type="boolean", example="0"),
      *                   @OA\Property(property="is_running", type="boolean", example="0"),
      *                   @OA\Property(property="notifications", type="array", example="[]", @OA\Items()),
+     *                   @OA\Property(property="last_run_at", type="datetime", example="2026-07-25 09:12:04", nullable=true),
      *                ),
      *             ),
      *          @OA\Property(property="first_page_url", type="string", example="http:\/\/localhost:8000\/api\/v1\/teams\/19\/federations?page=1"),
@@ -116,11 +117,15 @@ class FederationController extends Controller
                 $query->where('id', $teamId);
             })->with(['team', 'notifications.userNotification'])->paginate($perPage, ['*'], 'page');
 
-            $federations->getCollection()->transform(function ($federation) {
+            $federationIds = $federations->getCollection()->map(fn ($federation) => $federation->id)->all();
+            $lastRunTimes = $federationIds === [] ? collect() : FederationJobRun::latestRunTimesForFederationIds($federationIds);
+
+            $federations->getCollection()->transform(function ($federation) use ($lastRunTimes) {
                 $federation->setAttribute('auth_secret_key', $this->decryptAuthSecretKey(
                     $federation->auth_secret_key_location,
                     $federation->auth_type
                 ));
+                $federation->setAttribute('last_run_at', $lastRunTimes->get($federation->id));
                 return $federation;
             });
 

--- a/app/Models/FederationJobRun.php
+++ b/app/Models/FederationJobRun.php
@@ -83,6 +83,20 @@ class FederationJobRun extends Model
     }
 
     /**
+     * @param non-empty-array<int, int> $federationIds
+     * @return Collection<int, string> federation_id => last_run_at
+     */
+    public static function latestRunTimesForFederationIds(array $federationIds): Collection
+    {
+        return static::select('federation_id')
+            ->selectRaw('MAX(created_at) as last_run_at')
+            ->whereIn('federation_id', $federationIds)
+            ->groupBy('federation_id')
+            ->get()
+            ->pluck('last_run_at', 'federation_id');
+    }
+
+    /**
      * @return array<int, array{schema: ?string, message: string}>
      */
     public function errorMessages(): array

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,8 @@ parameters:
     # Level 9 is the highest level
     level: 3
 
+    checkModelProperties: true
+
     ignoreErrors:
         - '#Call to an undefined method Laravel\\Socialite\\Contracts\\Provider::with\(\)#'
 

--- a/tests/Feature/FederationIndexLastRunTest.php
+++ b/tests/Feature/FederationIndexLastRunTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Federation;
+use App\Models\FederationJobRun;
+use App\Models\Team;
+use App\Models\TeamHasFederation;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+class FederationIndexLastRunTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    private function makeFederation(Team $team): Federation
+    {
+        $federation = Federation::factory()->create([
+            'enabled' => true,
+            'tested' => true,
+            'is_running' => false,
+        ]);
+        TeamHasFederation::create([
+            'team_id' => $team->id,
+            'federation_id' => $federation->id,
+        ]);
+
+        return $federation;
+    }
+
+    private function makeRun(Team $team, Federation $federation, string $jobUuid, string $pid, ?int $status, string $createdAt): FederationJobRun
+    {
+        $run = FederationJobRun::create([
+            'team_id' => $team->id,
+            'federation_id' => $federation->id,
+            'job_uuid' => $jobUuid,
+            'pid' => $pid,
+            'status' => $status,
+            'details' => ['message' => 'CREATED'],
+            'job_attempts' => 1,
+        ]);
+
+        FederationJobRun::where('id', $run->id)->update(['created_at' => $createdAt]);
+
+        return $run->fresh();
+    }
+
+    private function indexUrl(int $teamId): string
+    {
+        return "api/v1/teams/{$teamId}/federations";
+    }
+
+    private function findFederationInResponse($content, int $federationId): array
+    {
+        foreach ($content['data'] as $item) {
+            if ($item['id'] === $federationId) {
+                return $item;
+            }
+        }
+
+        $this->fail("Federation {$federationId} not found in response data");
+    }
+
+    public function test_federation_with_no_runs_has_null_last_run_at(): void
+    {
+        $team = Team::factory()->create();
+        $federation = $this->makeFederation($team);
+
+        $response = $this->get($this->indexUrl($team->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $item = $this->findFederationInResponse($content, $federation->id);
+        $this->assertNull($item['last_run_at']);
+    }
+
+    public function test_federation_with_a_single_run_reports_its_timestamp(): void
+    {
+        $team = Team::factory()->create();
+        $federation = $this->makeFederation($team);
+
+        $createdAt = now()->subHour()->toDateTimeString();
+        $this->makeRun($team, $federation, 'uuid-1', 'pid-1', 1, $createdAt);
+
+        $response = $this->get($this->indexUrl($team->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $item = $this->findFederationInResponse($content, $federation->id);
+        $this->assertSame($createdAt, $item['last_run_at']);
+    }
+
+    public function test_last_run_at_reflects_the_most_recent_execution_only(): void
+    {
+        $team = Team::factory()->create();
+        $federation = $this->makeFederation($team);
+
+        $older = now()->subDays(2)->toDateTimeString();
+        $newer = now()->subDay()->toDateTimeString();
+
+        $this->makeRun($team, $federation, 'uuid-older', 'pid-1', 1, $older);
+        $this->makeRun($team, $federation, 'uuid-newer', 'pid-2', 1, $newer);
+
+        $response = $this->get($this->indexUrl($team->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $item = $this->findFederationInResponse($content, $federation->id);
+        $this->assertSame($newer, $item['last_run_at']);
+    }
+
+    public function test_last_run_at_is_correctly_attributed_per_federation(): void
+    {
+        $team = Team::factory()->create();
+        $federationA = $this->makeFederation($team);
+        $federationB = $this->makeFederation($team);
+
+        $aRunAt = now()->subDays(3)->toDateTimeString();
+        $bRunAt = now()->subHour()->toDateTimeString();
+
+        $this->makeRun($team, $federationA, 'uuid-a', 'pid-a', 1, $aRunAt);
+        $this->makeRun($team, $federationB, 'uuid-b', 'pid-b', 1, $bRunAt);
+
+        $response = $this->get($this->indexUrl($team->id), $this->header);
+        $content = $response->decodeResponseJson();
+
+        $itemA = $this->findFederationInResponse($content, $federationA->id);
+        $itemB = $this->findFederationInResponse($content, $federationB->id);
+
+        $this->assertSame($aRunAt, $itemA['last_run_at']);
+        $this->assertSame($bRunAt, $itemB['last_run_at']);
+    }
+
+    public function test_a_team_with_no_federations_returns_an_empty_list(): void
+    {
+        $team = Team::factory()->create();
+
+        $response = $this->get($this->indexUrl($team->id), $this->header);
+
+        $response->assertStatus(200);
+        $content = $response->decodeResponseJson();
+        $this->assertSame([], $content['data']);
+    }
+}

--- a/tests/Feature/FederationTest.php
+++ b/tests/Feature/FederationTest.php
@@ -141,6 +141,7 @@ class FederationTest extends TestCase
                     'deleted_at',
                     'tested',
                     'notifications',
+                    'last_run_at',
                 ],
             ],
             'first_page_url',


### PR DESCRIPTION
## Describe your changes

1. Turns on phpstan checkModelProperties so we get better types for models

2. Adds last_run_at timestamp to federations response on the API. This is required for some FE work but is also just useful information to have.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-2905

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
