### PR TITLE
fix(GAT-9337): datasetLinkage must be null (not []) when a version has no dataset links

### DIFF
--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -316,7 +316,11 @@ class Gwdm2xHandler extends GwdmMetadataHandler
 
         return [
             'linkage' => [
-                'datasetLinkage' => $datasetLinkage,
+                // GWDM schema requires datasetLinkage to be an object or null.
+                // An empty PHP array JSON-encodes to `[]`, which fails validation,
+                // so collapse the no-linkages case to null. A populated linkage has
+                // string keys (linkage_type) and correctly encodes to an object.
+                'datasetLinkage' => empty($datasetLinkage) ? null : $datasetLinkage,
                 'publicationAboutDataset' => $aboutDataset,
                 'publicationUsingDataset' => $usingDataset,
             ],

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Publication;
+use App\Models\PublicationHasDatasetVersion;
 use App\Models\Team;
 use App\Models\User;
 use App\Services\DatasetService;
@@ -286,5 +288,37 @@ class DatasetVersionLinkageTest extends TestCase
         [, $sourceVersionId] = $this->createDataset($this->getMetadataV2p0());
 
         $this->assertSame([], $this->handler()->afterRead(DatasetVersion::find($sourceVersionId)));
+    }
+
+    /**
+     * A version with a publication linkage but NO dataset linkage must emit
+     * datasetLinkage as null, not []. An empty PHP array encodes to `[]`, which
+     * fails GWDM validation ("datasetLinkage must be object or null") — this is the
+     * regression behind the failed reconstruction of publication-only datasets.
+     */
+    public function test_after_read_emits_null_dataset_linkage_when_only_publication_linked(): void
+    {
+        $this->disableObservers();
+
+        [, $sourceVersionId] = $this->createDataset($this->getMetadataV2p0());
+
+        // A publication link (but deliberately no dataset-to-dataset linkage rows).
+        $publication = Publication::factory()->create(['paper_doi' => '10.1371/journal.pone.0338652']);
+        PublicationHasDatasetVersion::create([
+            'publication_id' => $publication->id,
+            'dataset_version_id' => $sourceVersionId,
+            'link_type' => 'USING',
+            'description' => Gwdm2xHandler::LINKAGE_DESCRIPTION,
+        ]);
+
+        $linkage = $this->handler()->afterRead(DatasetVersion::find($sourceVersionId))['linkage'];
+
+        // Publication link present, so afterRead does NOT fall through to [].
+        $this->assertSame(['10.1371/journal.pone.0338652'], $linkage['publicationUsingDataset']);
+        // The key fix: no dataset links → null, never an empty array.
+        $this->assertNull($linkage['datasetLinkage']);
+
+        // And the encoded shape is a JSON null (object-or-null), not a `[]` array.
+        $this->assertStringContainsString('"datasetLinkage":null', json_encode($linkage));
     }
 }


### PR DESCRIPTION
## Describe your changes

`Gwdm2xHandler::afterRead()` reconstructed the GWDM `linkage` block from SQL junction tables. When a version had **publication** links but **no dataset-to-dataset** links, `datasetLinkage` was left as an empty PHP array. An empty array JSON-encodes to `[]`, but the GWDM schema requires `datasetLinkage` to be an **object or null** — so TRASER read-validation failed with `must be object` / `must be null`, breaking reconstruction (and the `show` endpoint) for publication-only datasets (e.g. dataset 355).

Fix: collapse the no-dataset-links case to `null` (the canonical representation used across the fixtures). A populated linkage still has string keys and correctly encodes to an object.

```php
'datasetLinkage' => empty($datasetLinkage) ? null : $datasetLinkage,
```

Adds a regression test (`test_after_read_emits_null_dataset_linkage_when_only_publication_linked`) reproducing the publication-only case.

## Issue ticket link
[GAT-9337](https://hdruk.atlassian.net/browse/GAT-9337)

## Environment / Configuration changes
None.

## Requires migrations being run?
No.

## Checklist
- [x] Self-review
- [x] Unit test added (regression)
- [ ] Behat — N/A (covered by feature test)
- [ ] Swagger — N/A (no endpoint change)
- [ ] Audit logs — N/A
- [ ] `.env.example` / terraform — N/A

Tests: `DatasetVersionLinkageTest` 7/7 pass; Pint + PHPStan clean.

> The logging / validation-disable work is split into a separate PR (`feat/GAT-9337-logging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GAT-9337]: https://hdruk.atlassian.net/browse/GAT-9337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ