### PR TITLE
feat(GAT-9337): log TRASER translation failures with payload; allow disabling read validation

### DIFF
--- a/app/Http/Controllers/Api/V2/DatasetController.php
+++ b/app/Http/Controllers/Api/V2/DatasetController.php
@@ -158,6 +158,12 @@ class DatasetController extends Controller
      *       description="Alternative output schema version.",
      *       @OA\Schema(type="string")
      *    ),
+     *    @OA\Parameter(
+     *       name="validate_output",
+     *       in="query",
+     *       description="Set to false to skip TRASER output validation of the reconstructed metadata (debugging escape hatch).",
+     *       @OA\Schema(type="boolean", default=true)
+     *    ),
      *    @OA\Response(
      *       response="200",
      *       description="Success response",
@@ -191,6 +197,7 @@ class DatasetController extends Controller
                 $dataset,
                 $request->query('schema_model') ?? $this->outputSchemaContext->schemaModel(),
                 $request->query('schema_version') ?? $this->outputSchemaContext->schemaVersion(),
+                validateOutput: $request->boolean('validate_output', true),
             );
 
             Auditor::log([

--- a/app/MetadataManagementController/MetadataManagementController.php
+++ b/app/MetadataManagementController/MetadataManagementController.php
@@ -124,9 +124,9 @@ class MetadataManagementController
      * @param string $input_schema The schema to validate against
      * @param string $input_version The schema version to validate against
      *
-     * @return bool
+     * @return array|null The TRASER error body when invalid; null when valid
      */
-    public function validateDataModelType(string &$dataset, string $input_schema, string $input_version): bool
+    public function validateDataModelType(string &$dataset, string $input_schema, string $input_version): ?array
     {
         $loggingContext = $this->getLoggingContext(\request());
         $loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;
@@ -157,14 +157,18 @@ class MetadataManagementController
                 'application/json'
             )->post($urlString);
 
-            if ($response->status() !== 200) {
-                \Log::warning('GWDM validation rejected by TRASER', array_merge($loggingContext, [
-                    'status'   => $response->status(),
-                    'response' => $response->body(),
-                ]));
+            if ($response->status() === 200) {
+                return null;
             }
 
-            return ($response->status() === 200);
+            \Log::warning('GWDM validation rejected by TRASER', array_merge($loggingContext, [
+                'status'   => $response->status(),
+                'response' => $response->body(),
+            ]));
+
+            $body = $response->json();
+
+            return is_array($body) ? $body : ['error' => $response->body()];
         } catch (Exception $e) {
             \Log::info($e->getMessage(), $loggingContext);
             throw new MMCException($e->getMessage());

--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -107,6 +107,7 @@ class DatasetService
         Dataset $dataset,
         ?string $outputSchemaModel = null,
         ?string $outputSchemaVersion = null,
+        bool $validateOutput = true,
     ): Dataset|string {
         $dataset->loadMissing('team');
 
@@ -180,7 +181,7 @@ class DatasetService
             $envelope = $this->getReconstructedMetadataEnvelope(
                 $dataset->id,
                 $withLinks->version,
-                validate: $translateRequested,
+                validate: $translateRequested && $validateOutput,
                 prefetched: $withLinks,
             );
 
@@ -194,10 +195,16 @@ class DatasetService
                 );
 
                 if (! $translated['wasTranslated']) {
-                    $traserError = is_array($translated['traser_message'])
-                        ? json_encode($translated['traser_message'])
-                        : ($translated['traser_message'] ?? 'unknown error');
-                    throw new \RuntimeException($traserError);
+                    $this->logTranslationFailure('prepareForShow', $translated, json_encode($envelope), [
+                        'dataset_id' => $dataset->id,
+                        'dataset_pid' => $dataset->pid,
+                        'version' => $withLinks->version,
+                        'output_schema_model' => $outputSchemaModel,
+                        'output_schema_version' => $outputSchemaVersion,
+                        'gwdm_version' => $envelope['gwdmVersion'],
+                    ]);
+
+                    throw new \RuntimeException($this->formatTraserError($translated));
                 }
 
                 $withLinks->metadata = ['metadata' => $translated['metadata']];
@@ -312,6 +319,15 @@ class DatasetService
         );
 
         if (! $traserResponse['wasTranslated']) {
+            $this->logTranslationFailure('create', $traserResponse, json_encode($payload), [
+                'team_id' => $team->id,
+                'team_pid' => $team->pid,
+                'status' => $input['status'] ?? null,
+                'input_schema' => $inputSchema,
+                'input_version' => $inputVersion,
+                'target_gwdm_version' => $targetGwdmVersion,
+            ]);
+
             return ['translated' => false, 'response' => $traserResponse];
         }
 
@@ -433,7 +449,17 @@ class DatasetService
         );
 
         if (! $traserResponse['wasTranslated']) {
-            throw new \RuntimeException('metadata is in an unknown format and cannot be processed');
+            $this->logTranslationFailure('update', $traserResponse, json_encode($payload), [
+                'dataset_id' => $dataset->id,
+                'dataset_pid' => $dataset->pid,
+                'team_id' => $teamId,
+                'status' => $input['status'] ?? null,
+                'input_schema' => $inputSchema,
+                'input_version' => $inputVersion,
+                'target_gwdm_version' => $targetGwdmVersion,
+            ]);
+
+            throw new \RuntimeException('metadata is in an unknown format and cannot be processed: '.$this->formatTraserError($traserResponse));
         }
 
         $versionNumber = $dataset->lastMetadataVersionNumber()->version;
@@ -518,7 +544,17 @@ class DatasetService
         );
 
         if (! $traserResponse['wasTranslated']) {
-            throw new \RuntimeException('metadata is in an unknown format and cannot be processed');
+            $this->logTranslationFailure('updateV2', $traserResponse, json_encode($payload), [
+                'dataset_id' => $dataset->id,
+                'dataset_pid' => $dataset->pid,
+                'team_id' => $teamId,
+                'status' => $input['status'] ?? null,
+                'input_schema' => $inputSchema,
+                'input_version' => $inputVersion,
+                'target_gwdm_version' => $targetGwdmVersion,
+            ]);
+
+            throw new \RuntimeException('metadata is in an unknown format and cannot be processed: '.$this->formatTraserError($traserResponse));
         }
 
         $versionNumber = $dataset->lastMetadataVersionNumber()->version;
@@ -737,14 +773,20 @@ class DatasetService
         // TRASER a hard dependency for all dataset show requests.
         if ($validate) {
             $metadataJson = json_encode(['metadata' => $gwdm]);
-            $isValid = MMC::validateDataModelType($metadataJson, Config::get('metadata.GWDM.name'), $storedVersion);
-            if (! $isValid) {
+            $validationErrors = MMC::validateDataModelType($metadataJson, Config::get('metadata.GWDM.name'), $storedVersion);
+            if ($validationErrors !== null) {
                 \Log::warning('GWDM read validation failed', [
                     'dataset_id' => $datasetId,
+                    'dataset_version_id' => $row->id ?? null,
                     'version' => $targetVersion,
                     'gwdm_version' => $storedVersion,
+                    'validation_errors' => $validationErrors,
+                    'payload' => $metadataJson,
                 ]);
-                throw new \RuntimeException("Reconstructed GWDM for version {$storedVersion} failed schema validation.");
+
+                throw new \RuntimeException(
+                    "Reconstructed GWDM for version {$storedVersion} failed schema validation: ".json_encode($validationErrors)
+                );
             }
         }
 
@@ -917,6 +959,40 @@ class DatasetService
                 Config::get('ted.use_partial')
             );
         }
+    }
+
+    /**
+     * Flatten a TRASER response's error detail into a loggable/throwable string.
+     *
+     * On a failed translation MMC::translateDataModelType returns the TRASER error
+     * body under 'traser_message' — an array (decoded JSON) or a string. Falls back
+     * to 'unknown error' when neither is present.
+     */
+    private function formatTraserError(array $traserResponse): string
+    {
+        $message = $traserResponse['traser_message'] ?? null;
+
+        if (is_array($message)) {
+            return json_encode($message);
+        }
+
+        return $message ?? 'unknown error';
+    }
+
+    /**
+     * Emit a structured warning when TRASER translation fails, capturing the real
+     * error body and status, the exact payload that was sent for translation, and
+     * caller-supplied context. Without this the cause of a failed translate — and
+     * the data that triggered it — is invisible in the logs.
+     */
+    private function logTranslationFailure(string $method, array $traserResponse, ?string $payload = null, array $context = []): void
+    {
+        \Log::warning('GWDM translation failed', array_merge([
+            'method' => $method,
+            'status_code' => $traserResponse['statusCode'] ?? null,
+            'traser_message' => $this->formatTraserError($traserResponse),
+            'payload' => $payload,
+        ], $context));
     }
 
     /**

--- a/tests/Feature/FormHydrationTest.php
+++ b/tests/Feature/FormHydrationTest.php
@@ -161,7 +161,7 @@ class FormHydrationTest extends TestCase
                     "statusCode" => "200",
                 ];
             });
-        MMC::shouldReceive("validateDataModelType")->andReturn(true);
+        MMC::shouldReceive("validateDataModelType")->andReturn(null);
         MMC::makePartial();
 
         // Create the new team

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -488,7 +488,7 @@ class TeamTest extends TestCase
         $this->assertEquals($content['data']['member_of'], 'HUB');
         $this->assertEquals($content['data']['name'], $updateTeamName);
 
-        MMC::shouldReceive("validateDataModelType")->andReturn(true);
+        MMC::shouldReceive("validateDataModelType")->andReturn(null);
 
         $responseGetDataset = $this->json(
             'GET',

--- a/tests/Traits/MockExternalApis.php
+++ b/tests/Traits/MockExternalApis.php
@@ -1152,7 +1152,7 @@ trait MockExternalApis
                    "statusCode" => "200",
                ];
            });
-        MMC::shouldReceive("validateDataModelType")->andReturn(true);
+        MMC::shouldReceive("validateDataModelType")->andReturn(null);
         MMC::makePartial();
 
         $this->dataset_store = [];

--- a/tests/Unit/ValidateDataModelErrorsTest.php
+++ b/tests/Unit/ValidateDataModelErrorsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Http;
+use MetadataManagementController as MMC;
+use Tests\TestCase;
+
+class ValidateDataModelErrorsTest extends TestCase
+{
+    public function test_validate_returns_traser_errors_on_failure(): void
+    {
+        $traserErrorBody = [
+            'error' => 'metadata validation failed',
+            'details' => [
+                ['instancePath' => '/linkage/datasetLinkage', 'message' => 'must be object'],
+            ],
+            'data' => ['metadata' => []],
+        ];
+
+        Http::fake(['*/validate*' => Http::response($traserErrorBody, 400)]);
+
+        $json = json_encode(['metadata' => ['foo' => 'bar']]);
+        $errors = MMC::validateDataModelType($json, 'GWDM', '2.0');
+
+        $this->assertIsArray($errors);
+        $this->assertSame('metadata validation failed', $errors['error']);
+        $this->assertSame('must be object', $errors['details'][0]['message']);
+    }
+
+    public function test_validate_returns_null_on_success(): void
+    {
+        Http::fake(['*/validate*' => Http::response(['details' => 'all ok'], 200)]);
+
+        $json = json_encode(['metadata' => ['foo' => 'bar']]);
+
+        $this->assertNull(MMC::validateDataModelType($json, 'GWDM', '2.0'));
+    }
+}


### PR DESCRIPTION
## Describe your changes

When metadata failed to translate/validate through TRASER it was very hard to tell **why** — `update()`/`updateV2()` threw a generic "unknown format" message and discarded the TRASER error, and `create()` logged nothing.

This PR:

- Adds a structured `Log::warning('GWDM translation failed', …)` capturing the TRASER `status_code`, the real error body (`traser_message`), and the **exact payload** sent for translation, plus dataset/team/schema context. Wired into `create`, `update`, `updateV2`, and `prepareForShow`.
- Makes `update()`/`updateV2()` surface the real TRASER error in their thrown message (so it also reaches the 400 response body) instead of a generic string.
- Adds a per-request escape hatch on the **show** endpoint to skip TRASER output validation of the reconstructed metadata:
  `GET /api/v2/datasets/{id}?validate_output=false` (`prepareForShow` gains a `$validateOutput` flag; default preserves current behaviour).

Note: the write endpoints (create/update) are intentionally **not** given the flag — validation there is unchanged (`!$isDraft`).

## Issue ticket link
GAT-9337

## Environment / Configuration changes
None (no new env vars — the toggle is a query parameter).

## Requires migrations being run?
No.

## Checklist
- [x] Self-review
- [ ] Unit tests / mocks — existing suites pass; no new behaviour beyond logging + opt-out flag
- [ ] Behat — N/A
- [x] Swagger — `validate_output` query param documented on `GET /api/v2/datasets/{id}`
- [ ] Audit logs — N/A
- [ ] `.env.example` / terraform — N/A

Tests: V2 `DatasetTest` + `DatasetVersionTest` pass; Pint + PHPStan clean.

> Complements the linkage fix in #1721 (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)