### PR TITLE
fix(GAT-9337): Hot fix to main for dataset linkages

### DIFF
--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -316,7 +316,11 @@ class Gwdm2xHandler extends GwdmMetadataHandler
 
         return [
             'linkage' => [
-                'datasetLinkage' => $datasetLinkage,
+                // GWDM schema requires datasetLinkage to be an object or null.
+                // An empty PHP array JSON-encodes to `[]`, which fails validation,
+                // so collapse the no-linkages case to null. A populated linkage has
+                // string keys (linkage_type) and correctly encodes to an object.
+                'datasetLinkage' => empty($datasetLinkage) ? null : $datasetLinkage,
                 'publicationAboutDataset' => $aboutDataset,
                 'publicationUsingDataset' => $usingDataset,
             ],

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\DatasetVersionHasDatasetVersion;
+use App\Models\Publication;
+use App\Models\PublicationHasDatasetVersion;
 use App\Models\Team;
 use App\Models\User;
 use App\Services\DatasetService;
@@ -286,5 +288,37 @@ class DatasetVersionLinkageTest extends TestCase
         [, $sourceVersionId] = $this->createDataset($this->getMetadataV2p0());
 
         $this->assertSame([], $this->handler()->afterRead(DatasetVersion::find($sourceVersionId)));
+    }
+
+    /**
+     * A version with a publication linkage but NO dataset linkage must emit
+     * datasetLinkage as null, not []. An empty PHP array encodes to `[]`, which
+     * fails GWDM validation ("datasetLinkage must be object or null") — this is the
+     * regression behind the failed reconstruction of publication-only datasets.
+     */
+    public function test_after_read_emits_null_dataset_linkage_when_only_publication_linked(): void
+    {
+        $this->disableObservers();
+
+        [, $sourceVersionId] = $this->createDataset($this->getMetadataV2p0());
+
+        // A publication link (but deliberately no dataset-to-dataset linkage rows).
+        $publication = Publication::factory()->create(['paper_doi' => '10.1371/journal.pone.0338652']);
+        PublicationHasDatasetVersion::create([
+            'publication_id' => $publication->id,
+            'dataset_version_id' => $sourceVersionId,
+            'link_type' => 'USING',
+            'description' => Gwdm2xHandler::LINKAGE_DESCRIPTION,
+        ]);
+
+        $linkage = $this->handler()->afterRead(DatasetVersion::find($sourceVersionId))['linkage'];
+
+        // Publication link present, so afterRead does NOT fall through to [].
+        $this->assertSame(['10.1371/journal.pone.0338652'], $linkage['publicationUsingDataset']);
+        // The key fix: no dataset links → null, never an empty array.
+        $this->assertNull($linkage['datasetLinkage']);
+
+        // And the encoded shape is a JSON null (object-or-null), not a `[]` array.
+        $this->assertStringContainsString('"datasetLinkage":null', json_encode($linkage));
     }
 }


### PR DESCRIPTION
…set links

Gwdm2xHandler::afterRead() built datasetLinkage as an empty PHP array when a version had publication links but no dataset-to-dataset links. An empty array JSON-encodes to `[]`, which fails GWDM validation (datasetLinkage must be an object or null), breaking reconstruction of publication-only datasets. Collapse the no-linkages case to null (a populated linkage keeps its object shape).

Adds a regression test covering the publication-only case.

## Screenshots (if relevant)

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
