### PR TITLE
fix(GAT-9247): fixes headers not being sent for remote source with au…

### DIFF
--- a/app/Jobs/TestFederation.php
+++ b/app/Jobs/TestFederation.php
@@ -59,7 +59,10 @@ class TestFederation implements ShouldQueue
         // them unconditionally, so this must stay mockable even for NO_AUTH.
         $this->gsms = app(GoogleSecretManagerService::class);
 
-        $testCall = $this->pullCatalogueList($this->federation->toArray(), $this->gsms);
+        $federationArray = $this->federation->toArray();
+        $federationArray['auth_secret_key'] = $this->federation->getAttribute('auth_secret_key');
+
+        $testCall = $this->pullCatalogueList($federationArray, $this->gsms);
         if (is_array($testCall)) {
             // Failure
             return $testCall;

--- a/app/Traits/GatewayMetadataIngestionTrait.php
+++ b/app/Traits/GatewayMetadataIngestionTrait.php
@@ -35,13 +35,10 @@ trait GatewayMetadataIngestionTrait
         $url = $federation->endpoint_baseurl . $federation->endpoint_datasets;
         $this->log('info', "calling REMOTE collection @ {$url}");
 
-        $response = Http::get(
-            $url,
-            [
-                $this->determineAuthType($federation, $gsms),
-                'Accept' => 'application/json',
-            ]
-        );
+        $response = Http::withHeaders(array_merge(
+            $this->determineAuthType($federation, $gsms),
+            ['Accept' => 'application/json'],
+        ))->get($url);
         $this->log('info', "response from REMOTE collection: status={$response->status()}, body=" . json_encode($response->body()));
 
         if ($response->status() === 200) {
@@ -55,10 +52,9 @@ trait GatewayMetadataIngestionTrait
 
     private function getCatalogueFromFederationArray(array $federation, GoogleSecretManagerService $gsms): Collection|array
     {
-        $response = Http::get(
-            $federation['endpoint_baseurl'] . $federation['endpoint_datasets'],
+        $response = Http::withHeaders(
             $this->determineAuthType($federation, $gsms)
-        );
+        )->get($federation['endpoint_baseurl'] . $federation['endpoint_datasets']);
         if ($response->status() === 200) {
             return collect($response->json()['items'])->keyBy('persistentId');
         }


### PR DESCRIPTION
…th layer.

Before this fix, the auth was being sent as part of the query string, and ADDI's auth layer was returning a 401 preventing them from testing a federation. 

## Screenshots (if relevant)
<img width="1707" height="1119" alt="image" src="https://github.com/user-attachments/assets/fe53c06c-cba8-4198-858d-60d7b5cf8b70" />

## Describe your changes

## Issue ticket link

## Environment / Configuration changes (if applicable)
No

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
