### PR TITLE
fix(GAT-9999): Hotfix to stop typesense hot indexing when the feature…

### DIFF
--- a/app/Models/Base/BaseTypesenseModel.php
+++ b/app/Models/Base/BaseTypesenseModel.php
@@ -25,6 +25,31 @@ abstract class BaseTypesenseModel extends Model
         return config('scout.prefix') . $this->getTable();
     }
 
+    // Scout's Searchable trait registers its own ModelObserver that fires on
+    // every saved/deleted event and calls these two methods to sync to Typesense.
+    // That happens unconditionally — regardless of any feature flag — so we gate
+    // here rather than only in the search path. Without this, saving a Collection
+    // on an environment where the flag is off still attempts a Typesense upsert
+    // and surfaces a "forbidden" API-key error to the user.
+
+    public static function queueMakeSearchable($models): void
+    {
+        if (!Feature::active('TypesenseSearch')) {
+            return;
+        }
+
+        parent::queueMakeSearchable($models);
+    }
+
+    public static function queueRemoveFromSearch($models): void
+    {
+        if (!Feature::active('TypesenseSearch')) {
+            return;
+        }
+
+        parent::queueRemoveFromSearch($models);
+    }
+
     abstract public function toSearchableArray(): array;
     abstract public function typesenseCollectionSchema(): array;
     abstract public function typesenseSearchParameters(): array;

--- a/app/Models/Base/BaseTypesenseModel.php
+++ b/app/Models/Base/BaseTypesenseModel.php
@@ -3,6 +3,7 @@
 namespace App\Models\Base;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Pennant\Feature as PennantFeature;
 use Laravel\Scout\Searchable;
 
 /**
@@ -10,16 +11,23 @@ use Laravel\Scout\Searchable;
  */
 abstract class BaseTypesenseModel extends Model
 {
-    use Searchable;
+    use Searchable {
+        // Alias the trait originals so we can call them from our overrides below
+        // while still intercepting before any Typesense connection is attempted.
+        Searchable::queueMakeSearchable as traitQueueMakeSearchable;
+        Searchable::queueRemoveFromSearch as traitQueueRemoveFromSearch;
+    }
 
     public function getScoutKeyName()
     {
         return 'id';
     }
+
     public function getScoutKey()
     {
         return (string) $this->id;
     }
+
     public function searchableAs()
     {
         return config('scout.prefix') . $this->getTable();
@@ -28,26 +36,26 @@ abstract class BaseTypesenseModel extends Model
     // Scout's Searchable trait registers its own ModelObserver that fires on
     // every saved/deleted event and calls these two methods to sync to Typesense.
     // That happens unconditionally — regardless of any feature flag — so we gate
-    // here rather than only in the search path. Without this, saving a Collection
-    // on an environment where the flag is off still attempts a Typesense upsert
-    // and surfaces a "forbidden" API-key error to the user.
+    // here rather than only in the search path. Without this, saving a model on
+    // an environment where the flag is off still attempts a Typesense upsert and
+    // surfaces a "forbidden" API-key error to the user.
 
-    public static function queueMakeSearchable($models): void
+    public function queueMakeSearchable($models): void
     {
-        if (!Feature::active('TypesenseSearch')) {
+        if (!PennantFeature::active('TypesenseSearch')) {
             return;
         }
 
-        parent::queueMakeSearchable($models);
+        $this->traitQueueMakeSearchable($models);
     }
 
-    public static function queueRemoveFromSearch($models): void
+    public function queueRemoveFromSearch($models): void
     {
-        if (!Feature::active('TypesenseSearch')) {
+        if (!PennantFeature::active('TypesenseSearch')) {
             return;
         }
 
-        parent::queueRemoveFromSearch($models);
+        $this->traitQueueRemoveFromSearch($models);
     }
 
     abstract public function toSearchableArray(): array;


### PR DESCRIPTION
… is disabled/not available

## Screenshots (if relevant)

## Describe your changes
Stephen raised that when creating a collection a typesense x-typesense-key error was being displayed. This fixes that by adding a guard against an automatic scout index on model change.

## Issue ticket link

## Environment / Configuration changes (if applicable)
None

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
