### PR TITLE
feat(GAT-8985): Adds a dataset title to federation failure email notification

### DIFF
--- a/app/Jobs/SendEmailCustomIntegration.php
+++ b/app/Jobs/SendEmailCustomIntegration.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\Dataset;
 use App\Models\EmailTemplate;
 use App\Models\Federation;
 use App\Models\FederationJobRun;
@@ -103,15 +104,19 @@ class SendEmailCustomIntegration implements ShouldQueue
     public function getFederationHistory(): array
     {
         $latestAttempts = FederationJobRun::latestPerPidForExecution($this->federationId, $this->jobUuid);
+        $titlesByPid    = Dataset::titlesForPids($latestAttempts->pluck('pid')->all());
 
         $integrationSuccess = '<ul>';
         $integrationErrors  = '<ul>';
         $successCount       = 0;
 
         foreach ($latestAttempts as $latestAttempt) {
+            $title = $titlesByPid[$latestAttempt->pid];
+
             if ($latestAttempt->status === 1) {
-                $details = data_get($latestAttempt, 'details.message', '');
-                $integrationSuccess .= "<li>PID: {$latestAttempt->pid} - {$details}</li>";
+                $details    = data_get($latestAttempt, 'details.message', '');
+                $identifier = $title ? "{$title} (PID: {$latestAttempt->pid})" : "PID: {$latestAttempt->pid}";
+                $integrationSuccess .= "<li>{$identifier} - {$details}</li>";
                 $successCount++;
             }
 
@@ -119,7 +124,8 @@ class SendEmailCustomIntegration implements ShouldQueue
                 $error = collect($latestAttempt->errorMessages())
                     ->map(fn ($entry) => $entry['schema'] ? "{$entry['schema']}  - {$entry['message']}<br>" : $entry['message'])
                     ->implode('');
-                $integrationErrors .= "<li>PID - {$latestAttempt->pid}:<br>{$error}</li>";
+                $identifier = $title ? "{$title} (PID: {$latestAttempt->pid})" : "PID - {$latestAttempt->pid}";
+                $integrationErrors .= "<li>{$identifier}:<br>{$error}</li>";
             }
         }
 

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -296,6 +296,27 @@ class Dataset extends Model
     }
 
     /**
+     * @param array<int, string> $pids
+     * @return array<string, string|null>
+     * 
+     */
+    public static function titlesForPids(array $pids): array
+    {
+        if (empty($pids)) {
+            return [];
+        }
+
+        $found = static::whereIn('pid', $pids)
+            ->with(['latestMetadata' => fn ($q) => $q->selectRaw('dataset_versions.id, dataset_versions.dataset_id, dataset_versions.title')])
+            ->get(['id', 'pid'])
+            ->mapWithKeys(fn ($dataset) => [
+                $dataset->pid => filled($dataset->latestMetadata?->title) ? $dataset->latestMetadata->title : null,
+            ]);
+
+        return collect($pids)->mapWithKeys(fn ($pid) => [$pid => $found[$pid] ?? null])->all();
+    }
+
+    /**
      * Helper function to grab dataset title from latest metadata.
      */
     public function getTitle(): string

--- a/tests/Unit/Models/DatasetTest.php
+++ b/tests/Unit/Models/DatasetTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use App\Models\Team;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+
+class DatasetTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Dataset::flushEventListeners();
+        DatasetVersion::flushEventListeners();
+        Team::flushEventListeners();
+    }
+
+    private function makeVersion(Dataset $dataset, int $version, ?string $title): DatasetVersion
+    {
+        return DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => $version,
+            'patch'       => null,
+            'metadata'    => ['gwdmVersion' => config('metadata.GWDM.version'), 'metadata' => []],
+            'title'       => $title,
+            'short_title' => $title,
+        ]);
+    }
+
+    public function test_titlesForPids_returns_empty_array_for_empty_input(): void
+    {
+        $this->assertSame([], Dataset::titlesForPids([]));
+    }
+
+    public function test_titlesForPids_returns_title_for_a_known_pid(): void
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create([
+            'status' => Dataset::STATUS_ACTIVE,
+            'pid'    => 'PID-KNOWN',
+        ]);
+        $this->makeVersion($dataset, 1, 'My Dataset Title');
+
+        $result = Dataset::titlesForPids(['PID-KNOWN']);
+
+        $this->assertSame(['PID-KNOWN' => 'My Dataset Title'], $result);
+    }
+
+    public function test_titlesForPids_returns_null_for_pid_with_no_dataset(): void
+    {
+        $result = Dataset::titlesForPids(['PID-DOES-NOT-EXIST']);
+
+        $this->assertArrayHasKey('PID-DOES-NOT-EXIST', $result);
+        $this->assertNull($result['PID-DOES-NOT-EXIST']);
+    }
+
+    public function test_titlesForPids_uses_the_latest_version_title_when_several_exist(): void
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create([
+            'status' => Dataset::STATUS_ACTIVE,
+            'pid'    => 'PID-MULTI-VERSION',
+        ]);
+        $this->makeVersion($dataset, 1, 'Old Title');
+        $this->makeVersion($dataset, 2, 'New Title');
+
+        $result = Dataset::titlesForPids(['PID-MULTI-VERSION']);
+
+        $this->assertSame('New Title', $result['PID-MULTI-VERSION']);
+    }
+
+    public function test_titlesForPids_returns_null_when_dataset_has_no_version_rows(): void
+    {
+        $team = Team::factory()->create();
+        Dataset::factory()->for($team)->create([
+            'status' => Dataset::STATUS_ACTIVE,
+            'pid'    => 'PID-NO-VERSION',
+        ]);
+
+        $result = Dataset::titlesForPids(['PID-NO-VERSION']);
+
+        $this->assertArrayHasKey('PID-NO-VERSION', $result);
+        $this->assertNull($result['PID-NO-VERSION']);
+    }
+
+    public function test_titlesForPids_returns_exactly_one_entry_per_input_pid(): void
+    {
+        $team    = Team::factory()->create();
+        $dataset = Dataset::factory()->for($team)->create([
+            'status' => Dataset::STATUS_ACTIVE,
+            'pid'    => 'PID-FOUND',
+        ]);
+        $this->makeVersion($dataset, 1, 'Found Title');
+
+        $result = Dataset::titlesForPids(['PID-FOUND', 'PID-MISSING']);
+
+        $this->assertSame(['PID-FOUND', 'PID-MISSING'], array_keys($result));
+        $this->assertSame('Found Title', $result['PID-FOUND']);
+        $this->assertNull($result['PID-MISSING']);
+    }
+}

--- a/tests/Unit/SendEmailCustomIntegrationTest.php
+++ b/tests/Unit/SendEmailCustomIntegrationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use App\Jobs\SendEmailCustomIntegration;
 use App\Jobs\SendEmailJob;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
 use App\Models\EmailTemplate;
 use App\Models\FederationJobRun;
 use Illuminate\Support\Facades\Queue;
@@ -472,5 +474,83 @@ class SendEmailCustomIntegrationTest extends TestCase
 
         $this->assertSame(0, $result['success_count']);
         $this->assertStringNotContainsString('ZZZ', $result['integration_success']);
+    }
+    
+    private function makeDatasetWithTitle(string $pid, string $title): Dataset
+    {
+        $dataset = Dataset::factory()->create([
+            'pid'    => $pid,
+            'status' => Dataset::STATUS_ACTIVE,
+        ]);
+
+        DatasetVersion::create([
+            'dataset_id'  => $dataset->id,
+            'version'     => 1,
+            'patch'       => null,
+            'metadata'    => ['gwdmVersion' => config('metadata.GWDM.version'), 'metadata' => []],
+            'title'       => $title,
+            'short_title' => $title,
+        ]);
+
+        return $dataset;
+    }
+
+    public function test_history_includes_dataset_title_for_successful_pid_when_available(): void
+    {
+        $this->makeDatasetWithTitle('TITLED-OK', 'My Dataset Title');
+
+        FederationJobRun::create([
+            'team_id'       => self::TEAM_ID,
+            'federation_id' => self::FEDERATION_ID,
+            'job_uuid'      => self::JOB_UUID,
+            'pid'           => 'TITLED-OK',
+            'status'        => 1,
+            'details'       => ['message' => 'Synced OK'],
+            'job_attempts'  => 1,
+        ]);
+
+        $job    = new SendEmailCustomIntegration(self::FEDERATION_ID, self::JOB_UUID, 'success');
+        $result = $job->getFederationHistory();
+
+        $this->assertStringContainsString('My Dataset Title (PID: TITLED-OK)', $result['integration_success']);
+    }
+
+    public function test_history_includes_dataset_title_for_failed_pid_when_dataset_already_exists(): void
+    {
+        $this->makeDatasetWithTitle('TITLED-ERR', 'Existing Dataset');
+
+        FederationJobRun::create([
+            'team_id'       => self::TEAM_ID,
+            'federation_id' => self::FEDERATION_ID,
+            'job_uuid'      => self::JOB_UUID,
+            'pid'           => 'TITLED-ERR',
+            'status'        => 0,
+            'details'       => ['message' => 'update failed validation'],
+            'job_attempts'  => 1,
+        ]);
+
+        $job    = new SendEmailCustomIntegration(self::FEDERATION_ID, self::JOB_UUID, 'failure');
+        $result = $job->getFederationHistory();
+
+        $this->assertStringContainsString('Existing Dataset (PID: TITLED-ERR)', $result['integration_errors']);
+    }
+
+    public function test_history_falls_back_to_pid_only_when_no_dataset_exists_for_failed_pid(): void
+    {
+        FederationJobRun::create([
+            'team_id'       => self::TEAM_ID,
+            'federation_id' => self::FEDERATION_ID,
+            'job_uuid'      => self::JOB_UUID,
+            'pid'           => 'NEW-PID-NO-DATASET',
+            'status'        => 0,
+            'details'       => ['message' => 'translation failed'],
+            'job_attempts'  => 1,
+        ]);
+
+        $job    = new SendEmailCustomIntegration(self::FEDERATION_ID, self::JOB_UUID, 'failure');
+        $result = $job->getFederationHistory();
+
+        $this->assertStringContainsString('PID - NEW-PID-NO-DATASET', $result['integration_errors']);
+        $this->assertStringNotContainsString('(PID:', $result['integration_errors']);
     }
 }


### PR DESCRIPTION
## Describe your changes

Adds a dataset title to federation failure email notification

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
