### PR TITLE
feat(GAT-9236): Forward partner context to search service

### DIFF
--- a/app/Http/Controllers/Api/V1/SearchController.php
+++ b/app/Http/Controllers/Api/V1/SearchController.php
@@ -16,7 +16,6 @@ use App\Http\Requests\Search\PublicationSearch;
 use App\Http\Requests\Search\Search;
 use App\Http\Traits\LoggingContext;
 use App\Http\Traits\PaginateFromArray;
-use App\Models\Dataset;
 use App\Models\Dur;
 use App\Models\License;
 use Auditor;
@@ -154,6 +153,10 @@ class SearchController extends Controller
         try {
             $input['aggs'] = FilterCache::get('dataset', enabledOnly: true);
 
+            $partner = $this->partnerContext->getPartner();
+            $shouldScope = $partner !== 'HDRUK' || !config('partners.allow_cross_context_read', true);
+            $input['partnerContext'] = $shouldScope ? $partner : null;
+
             $urlString = config('gateway.search_service_url') . '/search/datasets';
             $response = Http::withHeaders($loggingContext)->post($urlString, $input);
 
@@ -174,10 +177,7 @@ class SearchController extends Controller
                 ], 404);
             }
 
-            $datasetsArray = $this->filterDatasetHitsForPartner(
-                $response['hits']['hits'],
-                $this->partnerContext->getPartner(),
-            );
+            $datasetsArray = $response['hits']['hits'];
             $totalResults = count($datasetsArray);
             $matchedIds = array_column($datasetsArray, '_id');
 
@@ -1479,38 +1479,6 @@ class SearchController extends Controller
         }
 
         return $resultArray;
-    }
-
-    /**
-     * Keep only Elasticsearch hits whose dataset is visible in the active partner context.
-     * Only ACTIVE datasets are indexed in search, so we align with that here.
-     *
-     * @param  array<int, array<string, mixed>>  $hits
-     * @return array<int, array<string, mixed>>
-     */
-    private function filterDatasetHitsForPartner(array $hits, string $partnerContext): array
-    {
-        if ($hits === []) {
-            return $hits;
-        }
-
-        $shouldFilter = $partnerContext !== 'HDRUK'
-            || !config('partners.allow_cross_context_read', true);
-
-        if (!$shouldFilter) {
-            return $hits;
-        }
-
-        $allowedIds = Dataset::query()
-            ->forPartnerContext($partnerContext)
-            ->where('status', Dataset::STATUS_ACTIVE)
-            ->pluck('id')
-            ->flip();
-
-        return array_values(array_filter(
-            $hits,
-            fn (array $hit) => isset($allowedIds[(int) $hit['_id']])
-        ));
     }
 
     private function isDoi(string $query): bool

--- a/app/Http/Traits/IndexElastic.php
+++ b/app/Http/Traits/IndexElastic.php
@@ -192,6 +192,7 @@ trait IndexElastic
                 'geographicLocation' => array_map(fn ($spatialCoverage) => $spatialCoverage['region'], $datasetMatch->allSpatialCoverages),
                 'dataProviderColl' => DataProviderColl::whereIn('id', DataProviderCollHasTeam::where('team_id', $datasetMatch->team_id)->pluck('data_provider_coll_id'))->pluck('name')->all(),
                 'isCohortDiscovery' => $datasetMatch->is_cohort_discovery,
+                'partnerContext' => $datasetMatch->partner_context,
                 // Project grants (for search & filtering)
                 'projectGrants' => $projectGrants,
                 'projectGrantNames' => array_values(array_unique(array_filter(array_map(

--- a/app/Providers/SearchServiceProvider.php
+++ b/app/Providers/SearchServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Context\PartnerContext;
 use App\Services\SearchAggregator;
 use App\SearchProviders\HDRUK;
 use App\SearchProviders\ARDC;
@@ -11,9 +12,9 @@ class SearchServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->bind(SearchAggregator::class, function () {
+        $this->app->bind(SearchAggregator::class, function ($app) {
             return new SearchAggregator([
-                new HDRUK(),
+                new HDRUK($app->make(PartnerContext::class)),
                 new ARDC(),
             ]);
         });

--- a/app/SearchProviders/HDRUK.php
+++ b/app/SearchProviders/HDRUK.php
@@ -4,6 +4,7 @@ namespace App\SearchProviders;
 
 use Auditor;
 use Http;
+use App\Context\PartnerContext;
 use App\Contracts\SearchProvider;
 use App\Services\Search\FilterCache;
 use App\Services\Search\CollectionHydrator;
@@ -13,7 +14,6 @@ use App\Services\Search\DatasetHydrator;
 use App\Services\Search\DataUseHydrator;
 use App\Services\Search\PublicationHydrator;
 use App\Services\Search\ToolHydrator;
-use App\Context\PartnerContext;
 use Laravel\Pennant\Feature;
 
 class HDRUK implements SearchProvider
@@ -64,6 +64,15 @@ class HDRUK implements SearchProvider
         'data_custodian_networks' => \App\Models\DataProviderColl::class,
         'data_custodians'         => \App\Models\Team::class,
     ];
+
+    public function __construct(private readonly ?PartnerContext $partnerContext = null)
+    {
+    }
+
+    private function resolvePartnerContext(): PartnerContext
+    {
+        return $this->partnerContext ?? app(PartnerContext::class);
+    }
 
     public function isDeferred(): bool
     {
@@ -338,6 +347,12 @@ class HDRUK implements SearchProvider
 
         if ($query !== '') {
             $input['query'] = $query;
+        }
+
+        if ($filterConfig['type'] === 'dataset') {
+            $partner = $this->resolvePartnerContext()->getPartner();
+            $shouldScope = $partner !== 'HDRUK' || !config('partners.allow_cross_context_read', true);
+            $input['partnerContext'] = $shouldScope ? $partner : null;
         }
 
         $response = Http::post($this->getSearchURI($type), $input);

--- a/tests/Feature/IndexElasticGwdmGatingTest.php
+++ b/tests/Feature/IndexElasticGwdmGatingTest.php
@@ -104,4 +104,34 @@ class IndexElasticGwdmGatingTest extends TestCase
         $this->assertIsArray($params, 'an indexable version (real GWDM 2.0 today) must still build an ES document');
         $this->assertSame((int) $datasetId, $params['id']);
     }
+
+    public function test_reindex_elastic_includes_the_dataset_partner_context(): void
+    {
+        $team = Team::first();
+        $user = User::first();
+        $metadata = $this->getMetadataV2p0();
+
+        request()->headers->set('x-gwdm-version', '2.0');
+        $created = app(DatasetService::class)->create(
+            [
+                'metadata' => $metadata,
+                'status' => Dataset::STATUS_ACTIVE,
+                'user_id' => $user->id,
+                'team_id' => $team->id,
+                'create_origin' => Dataset::ORIGIN_MANUAL,
+            ],
+            $team,
+            null,
+            null,
+            false,
+        );
+        $datasetId = $created['dataset_id'];
+
+        Dataset::where('id', $datasetId)->update(['partner_context' => 'CRUK']);
+
+        $job = new IndexDataset((string) $datasetId);
+        $params = $job->reindexElastic((string) $datasetId, true);
+
+        $this->assertSame('CRUK', $params['body']['partnerContext']);
+    }
 }

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -8,6 +8,7 @@ use Tests\TestCase;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\Dataset;
+use Illuminate\Support\Facades\Http;
 use Tests\Traits\Authorization;
 use Tests\Traits\MockExternalApis;
 use MetadataManagementController as MMC;
@@ -35,6 +36,60 @@ class SearchTest extends TestCase
 
         $this->metadata = $this->getMetadata();
     }
+
+    public function test_dataset_search_sends_partner_context_when_scoping_applies(): void
+    {
+        $response = $this->json(
+            'POST',
+            self::TEST_URL_SEARCH . '/datasets',
+            ['query' => 'asthma'],
+            ['Accept' => 'application/json', 'x-partner-context' => 'CRUK'],
+        );
+        $response->assertStatus(200);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && $request['partnerContext'] === 'CRUK';
+        });
+    }
+
+    public function test_dataset_search_omits_partner_context_for_hdruk_with_cross_context_read(): void
+    {
+        Config::set('partners.allow_cross_context_read', true);
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL_SEARCH . '/datasets',
+            ['query' => 'asthma'],
+            ['Accept' => 'application/json', 'x-partner-context' => 'HDRUK'],
+        );
+        $response->assertStatus(200);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && array_key_exists('partnerContext', $request->data())
+                && $request['partnerContext'] === null;
+        });
+    }
+
+    public function test_dataset_search_scopes_partner_context_for_hdruk_when_cross_context_read_disabled(): void
+    {
+        Config::set('partners.allow_cross_context_read', false);
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL_SEARCH . '/datasets',
+            ['query' => 'asthma'],
+            ['Accept' => 'application/json', 'x-partner-context' => 'HDRUK'],
+        );
+        $response->assertStatus(200);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && $request['partnerContext'] === 'HDRUK';
+        });
+    }
+
 
     /**
      * Search using a query with success

--- a/tests/Feature/V2/PartnerContextTest.php
+++ b/tests/Feature/V2/PartnerContextTest.php
@@ -9,7 +9,6 @@ use App\Models\DatasetVersion;
 use App\Http\Enums\TeamMemberOf;
 use Tests\Traits\Authorization;
 use Tests\Traits\MockExternalApis;
-use Illuminate\Support\Facades\Http;
 
 /**
  * Tests for partner_context isolation (GAT-8924).
@@ -31,7 +30,6 @@ class PartnerContextTest extends TestCase
     }
 
     public const DATASETS_URL      = '/api/v2/datasets';
-    public const SEARCH_DATASETS_URL = '/api/v1/search/datasets';
     public const TEAMS_URL         = '/api/v1/teams';
     public const NOTIFICATIONS_URL = '/api/v1/notifications';
     public const USERS_URL         = '/api/v1/users';
@@ -206,53 +204,6 @@ class PartnerContextTest extends TestCase
         $this->assertCount($initialCrukCount + 2, $response->json('data'));
     }
 
-    public function test_cruk_context_search_returns_only_cruk_datasets(): void
-    {
-        [$teamId, $userId] = $this->createTeamAndUser();
-
-        $hdrukDatasetId = $this->createDataset($teamId, $userId, 'HDRUK');
-        $crukDatasetId = $this->createDataset($teamId, $userId, 'CRUK');
-
-        $this->mockSearchHitsForDatasetIds([$hdrukDatasetId, $crukDatasetId]);
-
-        $response = $this->json(
-            'POST',
-            self::SEARCH_DATASETS_URL,
-            ['query' => null],
-            array_merge($this->header, ['x-partner-context' => 'CRUK']),
-        );
-
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
-
-        $returnedIds = array_map('intval', array_column($response->json('data'), '_id'));
-        $this->assertSame([$crukDatasetId], $returnedIds);
-        $this->assertSame(1, $response->json('total'));
-        $this->assertSame(1, $response->json('elastic_total'));
-    }
-
-    public function test_hdruk_context_search_returns_all_partner_datasets(): void
-    {
-        [$teamId, $userId] = $this->createTeamAndUser();
-
-        $hdrukDatasetId = $this->createDataset($teamId, $userId, 'HDRUK');
-        $crukDatasetId = $this->createDataset($teamId, $userId, 'CRUK');
-
-        $this->mockSearchHitsForDatasetIds([$hdrukDatasetId, $crukDatasetId]);
-
-        $response = $this->json(
-            'POST',
-            self::SEARCH_DATASETS_URL,
-            ['query' => null],
-            $this->header,
-        );
-
-        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
-
-        $returnedIds = array_map('intval', array_column($response->json('data'), '_id'));
-        $this->assertEqualsCanonicalizing([$hdrukDatasetId, $crukDatasetId], $returnedIds);
-        $this->assertSame(2, $response->json('total'));
-    }
-
     // -------------------------------------------------------------------------
     // Read path — single-dataset show isolation
     // -------------------------------------------------------------------------
@@ -357,55 +308,6 @@ class PartnerContextTest extends TestCase
         $response->assertStatus(Config::get('statuscodes.STATUS_CREATED.code'));
 
         return $response->json('data');
-    }
-
-    /**
-     * Stub the external search service to return hits for the given dataset IDs.
-     *
-     * @param  array<int>  $datasetIds
-     */
-    private function mockSearchHitsForDatasetIds(array $datasetIds): void
-    {
-        $hits = array_map(fn (int $id) => [
-            '_id' => (string) $id,
-            '_source' => [
-                'abstract' => '',
-                'description' => '',
-                'keywords' => '',
-                'named_entities' => [],
-                'publisherName' => '',
-                'shortTitle' => 'Dataset ' . $id,
-                'title' => 'Dataset ' . $id,
-                'dataUseTitles' => [],
-                'populationSize' => 1000,
-            ],
-            'highlight' => [
-                'abstract' => [],
-                'description' => [],
-            ],
-        ], $datasetIds);
-
-        $searchUrl = config('gateway.search_service_url') . '/search/datasets*';
-
-        // Replace setUp search stubs so this test controls returned hit IDs.
-        $factory = Http::getFacadeRoot();
-        $reflection = new \ReflectionClass($factory);
-        $property = $reflection->getProperty('stubCallbacks');
-        $property->setAccessible(true);
-        $property->setValue($factory, collect());
-
-        Http::fake([
-            $searchUrl => Http::response([
-                'took' => 1,
-                'timed_out' => false,
-                '_shards' => [],
-                'hits' => [
-                    'total' => ['value' => count($hits)],
-                    'hits' => $hits,
-                ],
-                'aggregations' => [],
-            ], 200),
-        ]);
     }
 
     /**

--- a/tests/Unit/SearchProviders/HDRUKTest.php
+++ b/tests/Unit/SearchProviders/HDRUKTest.php
@@ -2,13 +2,16 @@
 
 namespace Tests\Unit\SearchProviders;
 
+use Config;
 use Mockery;
 use Tests\TestCase;
+use App\Context\PartnerContext;
 use App\SearchProviders\HDRUK;
 use App\Models\DatasetVersion;
 use App\Models\Tool;
 use App\Models\DataProviderColl;
 use App\Services\TypesenseService;
+use Illuminate\Support\Facades\Http;
 use Laravel\Pennant\Feature;
 
 class HDRUKTest extends TestCase
@@ -595,5 +598,80 @@ class HDRUKTest extends TestCase
             ['PIONEER: HDR UK Health Da...' => 16, 'SAIL' => 7, 'Tissue directory' => 2],
             collect($result['aggregations']['publisherName']['buckets'])->pluck('doc_count', 'key')->all()
         );
+    }
+
+    private function fakeSearchServiceDatasetsEndpoint(): void
+    {
+        Http::fake([
+            config('gateway.search_service_url', 'http://localhost:8003') . '/search/datasets*' => Http::response([
+                'hits' => ['total' => ['value' => 0], 'hits' => []],
+                'aggregations' => [],
+            ], 200),
+            config('gateway.search_service_url', 'http://localhost:8003') . '/search/tools*' => Http::response([
+                'hits' => ['total' => ['value' => 0], 'hits' => []],
+                'aggregations' => [],
+            ], 200),
+        ]);
+    }
+
+    public function test_search_via_elastic_sends_partner_context_for_datasets(): void
+    {
+        $this->fakeSearchServiceDatasetsEndpoint();
+
+        $partnerContext = Mockery::mock(PartnerContext::class);
+        $partnerContext->shouldReceive('getPartner')->andReturn('PRUK');
+
+        (new HDRUK($partnerContext))->search('asthma', 'datasets', []);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && $request['partnerContext'] === 'PRUK';
+        });
+    }
+
+    public function test_search_via_elastic_omits_partner_context_for_non_dataset_types(): void
+    {
+        $this->fakeSearchServiceDatasetsEndpoint();
+
+        $partnerContext = Mockery::mock(PartnerContext::class);
+        $partnerContext->shouldReceive('getPartner')->andReturn('PRUK');
+
+        (new HDRUK($partnerContext))->search('nlp', 'tools', []);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/tools')
+                && !array_key_exists('partnerContext', $request->data());
+        });
+    }
+
+    public function test_search_via_elastic_respects_hdruk_cross_context_read_default(): void
+    {
+        $this->fakeSearchServiceDatasetsEndpoint();
+        Config::set('partners.allow_cross_context_read', true);
+
+        $partnerContext = Mockery::mock(PartnerContext::class);
+        $partnerContext->shouldReceive('getPartner')->andReturn('HDRUK');
+
+        (new HDRUK($partnerContext))->search('asthma', 'datasets', []);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && array_key_exists('partnerContext', $request->data())
+                && $request['partnerContext'] === null;
+        });
+    }
+
+    public function test_hdruk_defaults_partner_context_when_constructed_without_argument(): void
+    {
+        $this->fakeSearchServiceDatasetsEndpoint();
+
+        request()->headers->set('x-partner-context', 'CRUK');
+
+        (new HDRUK())->search('asthma', 'datasets', []);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/search/datasets')
+                && $request['partnerContext'] === 'CRUK';
+        });
     }
 }


### PR DESCRIPTION
## Describe your changes

Forward partner context to the search service, to replace the behaviour which does post processing on the query results.

Also adds a feature flag 'ParnerScopedSearch'. 

## Issue ticket link

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [x] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
