### PR TITLE
fix!(GAT-9374): turn off traser validation

### DIFF
--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -177,10 +177,12 @@ class DatasetService
             // storage strategy: 2.x reads from the JSON blob; 3.0 reads from SQL tables.
             // Validation runs only when TRASER translation is requested so that TRASER
             // is not a hard dependency for every read.
+
+            // TODO: Validation set to false because otherwise we force everything through TRASER validation.
             $envelope = $this->getReconstructedMetadataEnvelope(
                 $dataset->id,
                 $withLinks->version,
-                validate: $translateRequested,
+                validate: false,
                 prefetched: $withLinks,
             );
 


### PR DESCRIPTION

## Describe your changes

Stops forcing every dataset retrieval through TRASER validation.

Default schema is set to HDRUK 4.0, meaning each time a dataset is retrieved it tries to validate against it. The reference case (https://healthdatagateway.org/dataset/1378) is not valid against HDRUK 4.0, therefore TRASER fails.

The fix here turns off the validation until we can discuss and find a better solution.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9374

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
