### PR TITLE
fix!(GAT-9374): Adjust prior hotfix to make sure translation on retrieval is always false

### DIFF
--- a/app/Services/DatasetService.php
+++ b/app/Services/DatasetService.php
@@ -162,7 +162,8 @@ class DatasetService
             throw new \InvalidArgumentException('schema_version provided without schema_model');
         }
 
-        $translateRequested = $outputSchemaModel && $outputSchemaVersion;
+        // TODO: Turn off translation
+        $translateRequested = false;
 
         // Reduced relation set is sufficient for the TRASER path (metadata is replaced
         // entirely by the translation result). No-translation path needs the full graph.
@@ -182,7 +183,7 @@ class DatasetService
             $envelope = $this->getReconstructedMetadataEnvelope(
                 $dataset->id,
                 $withLinks->version,
-                validate: false,
+                validate: $translateRequested,
                 prefetched: $withLinks,
             );
 


### PR DESCRIPTION
## Describe your changes

Prior hotfix only turned off translation on `getReconstructedMetadataEnvelope` - not realising it was also called further down before calling `MMC::translateDataModelType`

I have checked and this now means no calls will be made to traser when trying to return a specific dataset. 

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9374

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
