### PR TITLE
feat(GAT-9424):  Implements a nightly dataset link scanner to expose issues with dataset rendering on the frontend

### DIFF
--- a/app/Console/Commands/NightlyDatasetTestCommand.php
+++ b/app/Console/Commands/NightlyDatasetTestCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\NightlyDatasetTestJob;
+use Illuminate\Console\Command;
+
+class NightlyDatasetTestCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:nightly-dataset-test';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Nightly process to check every active dataset\'s page is reachable and record the result.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        NightlyDatasetTestJob::dispatch();
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -28,6 +28,9 @@ class Kernel extends ConsoleKernel
 
         // // update hubspot contacts information
         // $schedule->command('app:sync-hubspot-contacts')->dailyAt('04:00');
+
+        // nightly check that active dataset pages are reachable
+        $schedule->command('app:nightly-dataset-test')->dailyAt('03:00');
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,7 +30,7 @@ class Kernel extends ConsoleKernel
         // $schedule->command('app:sync-hubspot-contacts')->dailyAt('04:00');
 
         // nightly check that active dataset pages are reachable
-        $schedule->command('app:nightly-dataset-test')->dailyAt('03:00');
+        // $schedule->command('app:nightly-dataset-test')->dailyAt('03:00');
     }
 
     /**

--- a/app/Http/Controllers/Api/V2/NightlyDatasetTestController.php
+++ b/app/Http/Controllers/Api/V2/NightlyDatasetTestController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api\V2;
+
+use Auditor;
+use Config;
+use Exception;
+use App\Http\Controllers\Controller;
+use App\Models\NightlyDatasetTest;
+use Illuminate\Http\JsonResponse;
+
+class NightlyDatasetTestController extends Controller
+{
+    /**
+     * @OA\Get(
+     *    path="/api/v2/nightly_dataset_tests",
+     *    operationId="fetch_nightly_dataset_tests_v2",
+     *    tags={"NightlyDatasetTests"},
+     *    summary="NightlyDatasetTestController@index",
+     *    description="Get the results of the nightly dataset reachability check, with a summary and a list of failures",
+     *    @OA\Response(
+     *       response="200",
+     *       description="Success response",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="success"),
+     *          @OA\Property(
+     *             property="data",
+     *             type="array",
+     *             example="[]",
+     *             @OA\Items(
+     *                type="array",
+     *                @OA\Items()
+     *             )
+     *          ),
+     *       ),
+     *    ),
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        try {
+            $results = NightlyDatasetTest::all();
+
+            $totalChecked = $results->count();
+            $successful = $results->filter(fn ($result) => $result->isSuccessful());
+            $failed = $results->reject(fn ($result) => $result->isSuccessful());
+
+            $failedDatasets = $failed->map(function ($result) {
+                return [
+                    'datasetId' => $result->dataset_id,
+                    'statusCode' => $result->status_code,
+                    'checkedAt' => $result->updated_at,
+                ];
+            })->values();
+
+            $data = [
+                'summary' => [
+                    'totalChecked' => $totalChecked,
+                    'totalSuccessful' => $successful->count(),
+                    'totalFailed' => $failed->count(),
+                ],
+                'failedDatasets' => $failedDatasets,
+            ];
+
+            return response()->json([
+                'message' => Config::get('statuscodes.STATUS_OK.message'),
+                'data' => $data,
+            ], Config::get('statuscodes.STATUS_OK.code'));
+
+        } catch (Exception $e) {
+            Auditor::log([
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@' . __FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V2/NightlyDatasetTestController.php
+++ b/app/Http/Controllers/Api/V2/NightlyDatasetTestController.php
@@ -39,7 +39,10 @@ class NightlyDatasetTestController extends Controller
     public function index(): JsonResponse
     {
         try {
-            $results = NightlyDatasetTest::all();
+            // Null status_code means the request never got a response (e.g. a local
+            // connection blip) rather than the dataset page actually erroring, so we
+            // exclude those from the metrics entirely and only count real HTTP errors.
+            $results = NightlyDatasetTest::whereNotNull('status_code')->get();
 
             $totalChecked = $results->count();
             $successful = $results->filter(fn ($result) => $result->isSuccessful());
@@ -53,11 +56,16 @@ class NightlyDatasetTestController extends Controller
                 ];
             })->values();
 
+            $totalFailed = $failed->count();
+
             $data = [
                 'summary' => [
                     'totalChecked' => $totalChecked,
                     'totalSuccessful' => $successful->count(),
-                    'totalFailed' => $failed->count(),
+                    'totalFailed' => $totalFailed,
+                    'percentageFailed' => $totalChecked > 0
+                        ? round(($totalFailed / $totalChecked) * 100, 1)
+                        : 0,
                 ],
                 'failedDatasets' => $failedDatasets,
             ];

--- a/app/Jobs/NightlyDatasetTestJob.php
+++ b/app/Jobs/NightlyDatasetTestJob.php
@@ -39,7 +39,6 @@ class NightlyDatasetTestJob implements ShouldQueue, Silenced
                 $responses = Http::pool(fn (Pool $pool) => $ids->map(
                     fn ($id) => $pool->as($id)
                         ->timeout(30)
-                        ->withOptions(['stream' => true])
                         ->get($this->datasetUrl($id))
                 ));
 

--- a/app/Jobs/NightlyDatasetTestJob.php
+++ b/app/Jobs/NightlyDatasetTestJob.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Dataset;
+use App\Models\NightlyDatasetTest;
+use Http;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Horizon\Contracts\Silenced;
+use Throwable;
+
+class NightlyDatasetTestJob implements ShouldQueue, Silenced
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public $tries = 1;
+
+    public function handle(): void
+    {
+        // We run a single rolling window of results here, every night. Will only have
+        // as many rows as we have ACTIVE datasets.
+        Dataset::where('status', Dataset::STATUS_ACTIVE)
+            ->select('id')
+            ->chunkById(100, function ($datasets) {
+                foreach ($datasets as $dataset) {
+                    $statusCode = $this->checkDataset($dataset->id);
+
+                    NightlyDatasetTest::updateOrCreate(
+                        ['dataset_id' => $dataset->id],
+                        ['status_code' => $statusCode],
+                    );
+                }
+            });
+    }
+
+    private function checkDataset(int $datasetId): ?int
+    {
+        $url = rtrim(config('app.url'), '/') . '/en/datasets/' . $datasetId;
+
+        try {
+            $response = Http::timeout(30)->get($url);
+
+            return $response->status();
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    public function tags(): array
+    {
+        return ['nightly_dataset_tests'];
+    }
+}

--- a/app/Jobs/NightlyDatasetTestJob.php
+++ b/app/Jobs/NightlyDatasetTestJob.php
@@ -8,10 +8,11 @@ use Http;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Laravel\Horizon\Contracts\Silenced;
-use Throwable;
 
 class NightlyDatasetTestJob implements ShouldQueue, Silenced
 {
@@ -26,31 +27,36 @@ class NightlyDatasetTestJob implements ShouldQueue, Silenced
     {
         // We run a single rolling window of results here, every night. Will only have
         // as many rows as we have ACTIVE datasets.
+        NightlyDatasetTest::truncate();
+
+        $concurrency = (int) config('gateway.nightly_dataset_test_concurrency');
+
         Dataset::where('status', Dataset::STATUS_ACTIVE)
             ->select('id')
-            ->chunkById(100, function ($datasets) {
-                foreach ($datasets as $dataset) {
-                    $statusCode = $this->checkDataset($dataset->id);
+            ->chunkById($concurrency, function ($datasets) {
+                $ids = $datasets->pluck('id');
 
-                    NightlyDatasetTest::updateOrCreate(
-                        ['dataset_id' => $dataset->id],
-                        ['status_code' => $statusCode],
-                    );
+                $responses = Http::pool(fn (Pool $pool) => $ids->map(
+                    fn ($id) => $pool->as($id)
+                        ->timeout(30)
+                        ->withOptions(['stream' => true])
+                        ->get($this->datasetUrl($id))
+                ));
+
+                foreach ($ids as $id) {
+                    $response = $responses[$id];
+
+                    NightlyDatasetTest::create([
+                        'dataset_id' => $id,
+                        'status_code' => $response instanceof Response ? $response->status() : null,
+                    ]);
                 }
             });
     }
 
-    private function checkDataset(int $datasetId): ?int
+    private function datasetUrl(int $datasetId): string
     {
-        $url = rtrim(config('app.url'), '/') . '/en/datasets/' . $datasetId;
-
-        try {
-            $response = Http::timeout(30)->get($url);
-
-            return $response->status();
-        } catch (Throwable $e) {
-            return null;
-        }
+        return rtrim(config('gateway.gateway_url'), '/') . '/en/dataset/' . $datasetId;
     }
 
     public function tags(): array

--- a/app/Models/NightlyDatasetTest.php
+++ b/app/Models/NightlyDatasetTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NightlyDatasetTest extends Model
+{
+    protected $table = 'nightly_dataset_tests';
+
+    protected $fillable = [
+        'dataset_id',
+        'status_code',
+    ];
+
+    public function dataset(): BelongsTo
+    {
+        return $this->belongsTo(Dataset::class);
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->status_code !== null && $this->status_code >= 200 && $this->status_code < 400;
+    }
+}

--- a/config/gateway.php
+++ b/config/gateway.php
@@ -8,6 +8,7 @@ return [
     "gateway_url" => env("GATEWAY_URL", "http://localhost"),
     "google_secrets_gmi_prepend_name" => env("GOOGLE_SECRETS_GMI_PREPEND_NAME", ""),
     "media_url" => env("MEDIA_URL", ""),
+    "nightly_dataset_test_concurrency" => env("NIGHTLY_DATASET_TEST_CONCURRENCY", 5),
     "omop_seeding_nchunks" => env("OMOP_SEEDING_NCHUNKS", 500),
     "omop_seeding_use_infile" => env("OMOP_SEEDING_USE_INFILE", true),
     "rate_limit" => env("RATE_LIMIT", 2000),

--- a/config/routes_v2.php
+++ b/config/routes_v2.php
@@ -1240,6 +1240,20 @@ return [
         'constraint' => [],
     ],
 
+    // nightly dataset tests
+    [
+        'name' => 'nightly_dataset_tests.get',
+        'method' => 'get',
+        'path' => '/nightly_dataset_tests',
+        'methodController' => 'NightlyDatasetTestController@index',
+        'namespaceController' => 'App\Http\Controllers\Api\V2',
+        'middleware' => [
+            'jwt.verify',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
+
     // SearchAggregator
     [
         'name' => 'search_agg.post',

--- a/database/migrations/2026_08_05_000000_create_nightly_dataset_tests_table.php
+++ b/database/migrations/2026_08_05_000000_create_nightly_dataset_tests_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('nightly_dataset_tests', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('dataset_id')->unique();
+            $table->foreign('dataset_id')->references('id')->on('datasets')->onDelete('cascade');
+            $table->unsignedSmallInteger('status_code')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('nightly_dataset_tests');
+    }
+};

--- a/routes/api.scheduler.php
+++ b/routes/api.scheduler.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Jobs\AliasReplyScannerJob;
+use App\Jobs\NightlyDatasetTestJob;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/cohort_user_expiry', function (Request $reqest) {
@@ -44,6 +45,14 @@ Route::get('/gateway_metadata_ingestion', function (Request $request) {
     ], 200);
 });
 
+Route::get('/nightly_dataset_test', function (Request $request) {
+    NightlyDatasetTestJob::dispatch();
+
+    return response()->json([
+        'message' => 'ok',
+    ], 200);
+});
+
 Route::any('{path}', function () {
     $response = [
         'message' => 'Resource not found',
@@ -51,3 +60,5 @@ Route::any('{path}', function () {
 
     return response()->json($response, 404);
 });
+
+


### PR DESCRIPTION
## Screenshots (if relevant)
<img width="1616" height="930" alt="image" src="https://github.com/user-attachments/assets/79b9c6b3-6429-4a8f-a34a-76ca4af76d15" />

## Describe your changes
Adds nightly runnable job (via GCP scheduler) to collect and attempt to load all active datasets within Gateway, to catch any errors in rendering.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9424

## Environment / Configuration changes (if applicable)
New env var configured for: `NIGHTLY_DATASET_TEST_CONCURRENCY` - defaults to 5. Can be tweaked for production builds that have more oompf and can process more concurrently.

## Requires migrations being run?
Yes. 

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [x] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
