### PR TITLE
fix(GAT-9245): Saving unresolvable linkages

### DIFF
--- a/app/Console/Commands/ReconcileLinkages.php
+++ b/app/Console/Commands/ReconcileLinkages.php
@@ -7,6 +7,7 @@ use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Services\Gwdm\GwdmHandlerFactory;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 /**
  * Reconcile the linkage junction tables against the stored GWDM blob (GAT-9018).
@@ -70,16 +71,24 @@ class ReconcileLinkages extends Command
 
         $versionsProcessed = 0;
         $failures = 0;
+        $driftRows = [];
 
-        $query->chunkById($chunk, function ($datasets) use ($allVersions, $sync, $dryRun, &$versionsProcessed, &$failures) {
+        $query->chunkById($chunk, function ($datasets) use ($allVersions, $sync, $dryRun, &$versionsProcessed, &$failures, &$driftRows) {
             foreach ($datasets as $dataset) {
-                $versions = $this->versionsFor($dataset, $allVersions);
-
-                foreach ($versions as $version) {
+                foreach ($this->versionsFor($dataset, $allVersions) as $version) {
                     $versionsProcessed++;
 
                     if ($dryRun) {
-                        $this->line("  would reconcile dataset {$dataset->id} version {$version->id} (v{$version->version}, gwdm {$version->gwdm_version})");
+                        foreach ($this->driftFor($version) as $d) {
+                            $driftRows[] = [
+                                $dataset->id,
+                                $version->version,
+                                $d['kind'],
+                                $d['linkage_type'],
+                                Str::limit($d['reference'], 60),
+                                $d['reason'],
+                            ];
+                        }
 
                         continue;
                     }
@@ -102,10 +111,64 @@ class ReconcileLinkages extends Command
             }
         });
 
-        $verb = $dryRun ? 'would process' : ($sync ? 'processed' : 'dispatched');
+        if ($dryRun) {
+            return $this->renderDriftReport($driftRows, $versionsProcessed);
+        }
+
+        $verb = $sync ? 'processed' : 'dispatched';
         $this->info("Done. {$verb} {$versionsProcessed} version(s)".($failures ? " with {$failures} failure(s)." : '.'));
 
         return $failures > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Drift rows for a version via its GWDM handler. Only 2.x+ handlers expose
+     * diagnoseLinkageDrift(); others (1.x) have no SQL linkage tables, so report nothing.
+     *
+     * @return array<int, array{kind: string, linkage_type: string, reference: string, reason: string}>
+     */
+    private function driftFor($version): array
+    {
+        $full = DatasetVersion::findOrFail($version->id);
+        $gwdmVersion = $full->gwdm_version ?? ($full->metadata['gwdmVersion'] ?? '2.0');
+        $handler = app(GwdmHandlerFactory::class)->resolve($gwdmVersion);
+
+        return method_exists($handler, 'diagnoseLinkageDrift')
+            ? $handler->diagnoseLinkageDrift($full)
+            : [];
+    }
+
+    /**
+     * Print the dry-run drift table + a per-reason summary (what is in the blob but not
+     * in the SQL junction tables, and why).
+     */
+    private function renderDriftReport(array $driftRows, int $versionsProcessed): int
+    {
+        if (empty($driftRows)) {
+            $this->info("Scanned {$versionsProcessed} version(s): no linkage drift — SQL matches the blob.");
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Dataset', 'Version', 'Kind', 'Linkage', 'Reference', 'Reason'],
+            $driftRows,
+        );
+
+        $byReason = [];
+        foreach ($driftRows as $row) {
+            $byReason[$row[5]] = ($byReason[$row[5]] ?? 0) + 1;
+        }
+
+        $this->newLine();
+        $this->warn(count($driftRows).' out-of-sync reference(s) across '.$versionsProcessed.' version(s):');
+        foreach ($byReason as $reason => $count) {
+            $this->line(sprintf('  %4d  %s', $count, $reason));
+        }
+        $this->newLine();
+        $this->line('Run without --dry-run to backfill these into the junction tables.');
+
+        return self::SUCCESS;
     }
 
     /**

--- a/app/Console/Commands/ReconcileLinkages.php
+++ b/app/Console/Commands/ReconcileLinkages.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\LinkageExtraction;
+use App\Models\Dataset;
+use App\Models\DatasetVersion;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Illuminate\Console\Command;
+
+/**
+ * Reconcile the linkage junction tables against the stored GWDM blob (GAT-9018).
+ *
+ * Since the junction tables became the source of truth for 2.x linkages, any
+ * reference LinkageExtraction could not resolve at write time (a free-text dataset
+ * title, or a DOI with no matching publications row) is preserved as a junction row
+ * with a NULL target FK and the raw value in raw_url/raw_pid/raw_title/raw_doi
+ * (see the 2026_06_18 migration + Gwdm2xHandler).
+ *
+ * Rows extracted BEFORE that change simply dropped those unresolved references, so
+ * they now live only in the JSON blob and are invisible to afterRead(). Re-running
+ * extraction rebuilds each version's junction rows from the reconstructed blob
+ * (delete-then-insert per version — idempotent), backfilling the unresolved refs.
+ *
+ * This is a manual ops tool: nothing dispatches it automatically. Start with
+ * --dry-run to see the scope, then run for real (optionally --sync for small runs).
+ */
+class ReconcileLinkages extends Command
+{
+    protected $signature = 'app:reconcile-linkages
+        {--dataset= : Limit to a single dataset id}
+        {--all-versions : Process every version of each dataset (default: latest version only)}
+        {--sync : Run extraction inline instead of dispatching to the enrichment queue}
+        {--dry-run : Report what would be processed without changing anything}
+        {--chunk=100 : Dataset chunk size when iterating}
+        {--force : Skip the confirmation prompt}';
+
+    protected $description = 'Re-run linkage extraction to backfill unresolved (free-text / unknown-DOI) linkages into the junction tables from the GWDM blob (GAT-9018).';
+
+    public function handle(): int
+    {
+        $datasetId = $this->option('dataset');
+        $allVersions = (bool) $this->option('all-versions');
+        $sync = (bool) $this->option('sync');
+        $dryRun = (bool) $this->option('dry-run');
+        $chunk = max(1, (int) $this->option('chunk'));
+
+        $query = Dataset::query()->select(['id']);
+        if ($datasetId !== null) {
+            $query->where('id', (int) $datasetId);
+        }
+
+        $datasetCount = (clone $query)->count();
+        if ($datasetCount === 0) {
+            $this->warn('No datasets matched — nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $mode = $dryRun ? 'DRY RUN (no changes)' : ($sync ? 'SYNC (inline)' : 'QUEUED (enrichment)');
+        $scope = $allVersions ? 'all versions' : 'latest version only';
+        $this->info("Reconciling linkages for {$datasetCount} dataset(s) — {$scope} — mode: {$mode}.");
+
+        if (! $dryRun && ! $this->option('force')
+            && ! $this->confirm("Re-run linkage extraction for {$datasetCount} dataset(s)? Existing junction rows are rebuilt from the GWDM blob.")) {
+            $this->warn('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $versionsProcessed = 0;
+        $failures = 0;
+
+        $query->chunkById($chunk, function ($datasets) use ($allVersions, $sync, $dryRun, &$versionsProcessed, &$failures) {
+            foreach ($datasets as $dataset) {
+                $versions = $this->versionsFor($dataset, $allVersions);
+
+                foreach ($versions as $version) {
+                    $versionsProcessed++;
+
+                    if ($dryRun) {
+                        $this->line("  would reconcile dataset {$dataset->id} version {$version->id} (v{$version->version}, gwdm {$version->gwdm_version})");
+
+                        continue;
+                    }
+
+                    try {
+                        if ($sync) {
+                            // Run extraction inline via the handler (bypasses the queue
+                            // entirely) — mirrors what LinkageExtraction::handle() does.
+                            $full = DatasetVersion::findOrFail($version->id);
+                            $gwdmVersion = $full->gwdm_version ?? ($full->metadata['gwdmVersion'] ?? '2.0');
+                            app(GwdmHandlerFactory::class)->resolve($gwdmVersion)->extractLinkages($full);
+                        } else {
+                            LinkageExtraction::dispatch((string) $dataset->id, (string) $version->id);
+                        }
+                    } catch (\Throwable $e) {
+                        $failures++;
+                        $this->error("  failed dataset {$dataset->id} version {$version->id}: {$e->getMessage()}");
+                    }
+                }
+            }
+        });
+
+        $verb = $dryRun ? 'would process' : ($sync ? 'processed' : 'dispatched');
+        $this->info("Done. {$verb} {$versionsProcessed} version(s)".($failures ? " with {$failures} failure(s)." : '.'));
+
+        return $failures > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * The dataset versions to reconcile: the latest only, or every version.
+     *
+     * @return iterable<DatasetVersion>
+     */
+    private function versionsFor(Dataset $dataset, bool $allVersions): iterable
+    {
+        if ($allVersions) {
+            return DatasetVersion::where('dataset_id', $dataset->id)
+                ->select(['id', 'version', 'gwdm_version'])
+                ->orderBy('version')
+                ->get();
+        }
+
+        $latest = $dataset->latestVersion(['id', 'version', 'gwdm_version', 'dataset_id']);
+
+        return $latest ? [$latest] : [];
+    }
+}

--- a/app/Models/DatasetVersionHasDatasetVersion.php
+++ b/app/Models/DatasetVersionHasDatasetVersion.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property string|null $short_title
@@ -18,8 +18,11 @@ class DatasetVersionHasDatasetVersion extends Model
     use HasFactory;
 
     public const LINKAGE_TYPE_DATASETS = 'linkedDatasets';
+
     public const LINKAGE_TYPE_DERIVED_FROM = 'isDerivedFrom';
+
     public const LINKAGE_TYPE_PART_OF = 'isPartOf';
+
     public const LINKAGE_TYPE_MEMBER_OF = 'isMemberOf';
 
     protected $fillable = [
@@ -28,6 +31,9 @@ class DatasetVersionHasDatasetVersion extends Model
         'linkage_type',
         'direct_linkage',
         'description',
+        'raw_url',
+        'raw_pid',
+        'raw_title',
     ];
 
     /**
@@ -55,7 +61,6 @@ class DatasetVersionHasDatasetVersion extends Model
     /**
      * Get the second dataset linked by this linkage.
      */
-
     public function dataset2()
     {
         return $this->belongsTo(Dataset::class, 'dataset_version_target_id');

--- a/app/Models/PublicationHasDatasetVersion.php
+++ b/app/Models/PublicationHasDatasetVersion.php
@@ -2,16 +2,17 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Observers\PublicationHasDatasetVersionObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Notifications\Notifiable;
 
 /**
  * Populated by the join select in Gwdm2xHandler::afterRead() (publications.paper_doi):
+ *
  * @property-read string|null $paper_doi
  */
 #[ObservedBy([PublicationHasDatasetVersionObserver::class])]
@@ -19,8 +20,8 @@ class PublicationHasDatasetVersion extends Model
 {
     use HasFactory;
     use Notifiable;
-    use SoftDeletes;
     use Prunable;
+    use SoftDeletes;
 
     public $timestamps = false;
 
@@ -29,6 +30,7 @@ class PublicationHasDatasetVersion extends Model
         'dataset_version_id',
         'link_type',
         'description',
+        'raw_doi',
     ];
 
     protected $dates = ['deleted_at'];
@@ -39,5 +41,4 @@ class PublicationHasDatasetVersion extends Model
      * @var string
      */
     protected $table = 'publication_has_dataset_version';
-
 }

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -181,15 +181,17 @@ class Gwdm2xHandler extends GwdmMetadataHandler
 
                 if (! $targetVersionId) {
                     // Store unresolved reference so afterRead() can reconstruct it from SQL.
+                    // Coerce blanks to NULL: the GWDM schema allows null url/pid/title but a
+                    // string must satisfy minLength/uri format, so '' would fail validation.
                     DatasetVersionHasDatasetVersion::create([
                         'dataset_version_source_id' => $sourceVersionId,
                         'dataset_version_target_id' => null,
                         'linkage_type' => $key,
                         'direct_linkage' => 1,
                         'description' => self::LINKAGE_DESCRIPTION,
-                        'raw_url' => $d['url'] ?? null,
-                        'raw_pid' => $d['pid'] ?? null,
-                        'raw_title' => $d['title'] ?? null,
+                        'raw_url' => $this->blankToNull($d['url'] ?? null),
+                        'raw_pid' => $this->blankToNull($d['pid'] ?? null),
+                        'raw_title' => $this->blankToNull($d['title'] ?? null),
                     ]);
 
                     continue;
@@ -312,6 +314,44 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         return $doi !== '' ? $doi : null;
     }
 
+    /**
+     * Normalise a raw linkage string for storage/output: trim and treat an empty
+     * string as NULL. The GWDM schema allows null url/pid/title but requires any
+     * string to satisfy minLength/uri constraints, so '' would fail validation.
+     */
+    protected function blankToNull(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * Unresolved (free-text) dataset linkage rows for a version — junction rows with
+     * dataset_version_target_id = NULL that carry the raw url/pid/title captured at
+     * extraction time. resolveDatasetLinkages() excludes these (it requires an ACTIVE
+     * target), so afterRead()/getLinkages() read them here to keep SQL the complete
+     * source of truth.
+     *
+     * @return array<int, object{linkage_type: string, raw_url: ?string, raw_pid: ?string, raw_title: ?string}>
+     */
+    protected function resolveUnresolvedDatasetLinkages(int $sourceVersionId): array
+    {
+        return DB::select(
+            'SELECT linkage_type, raw_url, raw_pid, raw_title
+            FROM dataset_version_has_dataset_version
+            WHERE dataset_version_source_id = ?
+              AND direct_linkage = ?
+              AND description = ?
+              AND dataset_version_target_id IS NULL',
+            [$sourceVersionId, 1, self::LINKAGE_DESCRIPTION]
+        );
+    }
+
     // ── Read path ─────────────────────────────────────────────────────────────
 
     /**
@@ -329,16 +369,11 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         // Unresolved rows (target_id = NULL) carry the raw free-text reference captured
         // at extraction time. resolveDatasetLinkages() intentionally excludes them (it
         // requires an ACTIVE target dataset), so read them separately to preserve them.
-        $unresolvedDatasets = DatasetVersionHasDatasetVersion::query()
-            ->where('dataset_version_source_id', $dv->id)
-            ->where('direct_linkage', 1)
-            ->where('description', self::LINKAGE_DESCRIPTION)
-            ->whereNull('dataset_version_target_id')
-            ->get();
+        $unresolvedDatasets = $this->resolveUnresolvedDatasetLinkages($dv->id);
 
         $publications = $this->resolvePublicationLinkages($dv->id);
 
-        if (empty($resolvedDatasets) && $unresolvedDatasets->isEmpty() && empty($publications)) {
+        if (empty($resolvedDatasets) && empty($unresolvedDatasets) && empty($publications)) {
             return [];
         }
 
@@ -351,10 +386,11 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             ];
         }
         foreach ($unresolvedDatasets as $row) {
+            // blankToNull: GWDM allows null url/pid/title, but '' fails minLength/uri.
             $datasetLinkage[$row->linkage_type][] = [
-                'url' => $row->raw_url,
-                'pid' => $row->raw_pid,
-                'title' => $row->raw_title,
+                'url' => $this->blankToNull($row->raw_url),
+                'pid' => $this->blankToNull($row->raw_pid),
+                'title' => $this->blankToNull($row->raw_title),
             ];
         }
 
@@ -493,21 +529,190 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             $this->resolveDatasetLinkages($datasetVersionId, useLatestTitle: true)
         );
 
-        $unresolved = DatasetVersionHasDatasetVersion::query()
-            ->where('dataset_version_source_id', $datasetVersionId)
-            ->where('direct_linkage', 1)
-            ->where('description', self::LINKAGE_DESCRIPTION)
-            ->whereNull('dataset_version_target_id')
-            ->get()
-            ->map(fn ($row) => [
-                'title' => $row->raw_title,
-                'url' => $row->raw_url,
+        $unresolved = array_map(
+            fn ($row) => [
+                'title' => $this->blankToNull($row->raw_title),
+                'url' => $this->blankToNull($row->raw_url),
                 'dataset_id' => null,
                 'linkage_type' => $row->linkage_type,
-            ])
-            ->all();
+            ],
+            $this->resolveUnresolvedDatasetLinkages($datasetVersionId)
+        );
 
         return array_merge($resolved, $unresolved);
+    }
+
+    /**
+     * DRY-RUN diagnostics (read-only): which references in the reconstructed GWDM blob
+     * are NOT represented by a live junction row, and why. Powers
+     * `app:reconcile-linkages --dry-run`. A non-empty result means SQL is out of sync
+     * with the blob; a reconcile (re-extraction) would backfill these.
+     *
+     * @return array<int, array{kind: string, linkage_type: string, reference: string, reason: string}>
+     */
+    public function diagnoseLinkageDrift(DatasetVersion $dv): array
+    {
+        // Blob linkage only ($applySupplementary = false) — i.e. what extraction reads.
+        $gwdm = $this->datasetService()->getReconstructedMetadataEnvelope(
+            $dv->dataset_id,
+            $dv->version,
+            false,
+            $dv,
+            false,
+        )['metadata'] ?? [];
+
+        $linkage = $gwdm['linkage'] ?? [];
+        $drift = [];
+
+        foreach (['publicationAboutDataset' => 'ABOUT', 'publicationUsingDataset' => 'USING'] as $key => $linkType) {
+            $dois = $linkage[$key] ?? null;
+            if (! is_array($dois)) {
+                continue;
+            }
+
+            $represented = $this->representedPublicationDois($dv->id, $linkType);
+
+            foreach ($dois as $doi) {
+                if (! is_string($doi) || trim($doi) === '') {
+                    continue;
+                }
+                $bare = $this->normalisePublicationDoi($doi);
+                if ($bare !== null && in_array($bare, $represented, true)) {
+                    continue; // in sync
+                }
+                $drift[] = [
+                    'kind' => 'publication',
+                    'linkage_type' => $linkType,
+                    'reference' => $doi,
+                    'reason' => $this->publicationDriftReason($dv->id, $bare, $linkType),
+                ];
+            }
+        }
+
+        $datasetLinkage = $linkage['datasetLinkage'] ?? null;
+        if (is_array($datasetLinkage)) {
+            foreach ($datasetLinkage as $type => $refs) {
+                if (! is_array($refs)) {
+                    continue;
+                }
+                foreach ($refs as $ref) {
+                    if (! is_array($ref)) {
+                        continue;
+                    }
+                    $reason = $this->datasetDriftReason($dv->id, $ref, (string) $type);
+                    if ($reason === null) {
+                        continue; // in sync
+                    }
+                    $drift[] = [
+                        'kind' => 'dataset',
+                        'linkage_type' => (string) $type,
+                        'reference' => (string) ($ref['url'] ?? $ref['pid'] ?? $ref['title'] ?? '(unknown)'),
+                        'reason' => $reason,
+                    ];
+                }
+            }
+        }
+
+        return $drift;
+    }
+
+    /** Bare DOIs already represented by a live publication junction row for this version + link type. */
+    protected function representedPublicationDois(int $versionId, string $linkType): array
+    {
+        $rows = DB::select(
+            'SELECT COALESCE(publications.paper_doi, publication_has_dataset_version.raw_doi) AS doi
+            FROM publication_has_dataset_version
+            LEFT JOIN publications
+                ON publications.id = publication_has_dataset_version.publication_id
+               AND publications.deleted_at IS NULL
+            WHERE publication_has_dataset_version.dataset_version_id = ?
+              AND publication_has_dataset_version.description = ?
+              AND publication_has_dataset_version.link_type = ?
+              AND publication_has_dataset_version.deleted_at IS NULL',
+            [$versionId, self::LINKAGE_DESCRIPTION, $linkType]
+        );
+
+        return array_values(array_filter(array_map(
+            fn ($r) => $this->normalisePublicationDoi($r->doi),
+            $rows
+        )));
+    }
+
+    /** Why a blob DOI is missing from SQL (only called when it is not represented). */
+    protected function publicationDriftReason(int $versionId, ?string $bareDoi, string $linkType): string
+    {
+        $trashed = PublicationHasDatasetVersion::onlyTrashed()
+            ->where('dataset_version_id', $versionId)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->where('link_type', $linkType)
+            ->get();
+
+        foreach ($trashed as $row) {
+            $doi = $row->raw_doi
+                ?? optional(Publication::withTrashed()->find($row->publication_id))->paper_doi;
+            if ($doi !== null && $this->normalisePublicationDoi($doi) === $bareDoi) {
+                return 'linkage soft-deleted';
+            }
+        }
+
+        if ($bareDoi !== null && $this->findTargetPublication($bareDoi)) {
+            return 'publication exists but not linked';
+        }
+
+        return 'no publication row (reconcile stores raw DOI)';
+    }
+
+    /** Why a blob dataset reference is missing from SQL, or null when it is represented. */
+    protected function datasetDriftReason(int $versionId, array $ref, string $type): ?string
+    {
+        $targetVersionId = $this->findTargetDataset($ref);
+
+        if ($targetVersionId) {
+            $linked = DatasetVersionHasDatasetVersion::query()
+                ->where('dataset_version_source_id', $versionId)
+                ->where('dataset_version_target_id', $targetVersionId)
+                ->where('linkage_type', $type)
+                ->where('direct_linkage', 1)
+                ->where('description', self::LINKAGE_DESCRIPTION)
+                ->exists();
+            if ($linked) {
+                return null;
+            }
+
+            $targetVersion = DatasetVersion::find($targetVersionId);
+            $targetDataset = $targetVersion ? Dataset::find($targetVersion->dataset_id) : null;
+            if (! $targetDataset || $targetDataset->status !== Dataset::STATUS_ACTIVE) {
+                return 'target dataset not active (excluded from reconstruction)';
+            }
+
+            return 'dataset exists but not linked';
+        }
+
+        // Unresolvable free-text reference: represented by a live raw_* row?
+        $matched = false;
+        $query = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_source_id', $versionId)
+            ->whereNull('dataset_version_target_id')
+            ->where('linkage_type', $type)
+            ->where('direct_linkage', 1)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->where(function ($q) use ($ref, &$matched) {
+                foreach (['raw_url' => 'url', 'raw_pid' => 'pid', 'raw_title' => 'title'] as $col => $k) {
+                    if (! empty($ref[$k])) {
+                        $q->orWhere($col, $ref[$k]);
+                        $matched = true;
+                    }
+                }
+                if (! $matched) {
+                    $q->whereRaw('1 = 0');
+                }
+            });
+
+        if ($matched && $query->exists()) {
+            return null;
+        }
+
+        return 'unresolvable reference (reconcile stores raw url/pid/title)';
     }
 
     /**

--- a/app/Services/Gwdm/Gwdm2xHandler.php
+++ b/app/Services/Gwdm/Gwdm2xHandler.php
@@ -180,6 +180,18 @@ class Gwdm2xHandler extends GwdmMetadataHandler
                 $targetVersionId = $this->findTargetDataset($d);
 
                 if (! $targetVersionId) {
+                    // Store unresolved reference so afterRead() can reconstruct it from SQL.
+                    DatasetVersionHasDatasetVersion::create([
+                        'dataset_version_source_id' => $sourceVersionId,
+                        'dataset_version_target_id' => null,
+                        'linkage_type' => $key,
+                        'direct_linkage' => 1,
+                        'description' => self::LINKAGE_DESCRIPTION,
+                        'raw_url' => $d['url'] ?? null,
+                        'raw_pid' => $d['pid'] ?? null,
+                        'raw_title' => $d['title'] ?? null,
+                    ]);
+
                     continue;
                 }
 
@@ -214,6 +226,15 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             $publicationId = $this->findTargetPublication($doi);
 
             if (! $publicationId) {
+                // Store unresolved DOI so afterRead() can reconstruct it from SQL.
+                PublicationHasDatasetVersion::create([
+                    'publication_id' => null,
+                    'dataset_version_id' => $sourceVersionId,
+                    'link_type' => $linkType,
+                    'description' => self::LINKAGE_DESCRIPTION,
+                    'raw_doi' => $doi,
+                ]);
+
                 continue;
             }
 
@@ -304,9 +325,20 @@ class Gwdm2xHandler extends GwdmMetadataHandler
     public function afterRead(DatasetVersion $dv): array
     {
         $resolvedDatasets = $this->resolveDatasetLinkages($dv->id, useLatestTitle: true);
+
+        // Unresolved rows (target_id = NULL) carry the raw free-text reference captured
+        // at extraction time. resolveDatasetLinkages() intentionally excludes them (it
+        // requires an ACTIVE target dataset), so read them separately to preserve them.
+        $unresolvedDatasets = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_source_id', $dv->id)
+            ->where('direct_linkage', 1)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->whereNull('dataset_version_target_id')
+            ->get();
+
         $publications = $this->resolvePublicationLinkages($dv->id);
 
-        if (empty($resolvedDatasets) && empty($publications)) {
+        if (empty($resolvedDatasets) && $unresolvedDatasets->isEmpty() && empty($publications)) {
             return [];
         }
 
@@ -316,6 +348,13 @@ class Gwdm2xHandler extends GwdmMetadataHandler
                 'url' => config('gateway.gateway_url').'/en/dataset/'.$row->dataset_id,
                 'pid' => $row->pid,
                 'title' => $row->title,
+            ];
+        }
+        foreach ($unresolvedDatasets as $row) {
+            $datasetLinkage[$row->linkage_type][] = [
+                'url' => $row->raw_url,
+                'pid' => $row->raw_pid,
+                'title' => $row->raw_title,
             ];
         }
 
@@ -410,9 +449,13 @@ class Gwdm2xHandler extends GwdmMetadataHandler
     }
 
     /**
-     * Resolved publication linkages for the given source version, sourced from SQL.
+     * Publication linkages for the given source version, sourced from SQL.
      * Companion to resolveDatasetLinkages(); consumed by afterRead() to rebuild the
      * publicationAboutDataset / publicationUsingDataset arrays.
+     *
+     * Uses a LEFT JOIN and coalesces the resolved publication's paper_doi with the
+     * raw_doi captured at extraction time, so unresolved (free-text) DOIs survive the
+     * read the same way unresolved dataset linkages do.
      *
      * @return array<int, object{link_type: string, doi: string}>
      */
@@ -421,9 +464,9 @@ class Gwdm2xHandler extends GwdmMetadataHandler
         return DB::select(
             'SELECT
                 publication_has_dataset_version.link_type,
-                publications.paper_doi AS doi
+                COALESCE(publications.paper_doi, publication_has_dataset_version.raw_doi) AS doi
             FROM publication_has_dataset_version
-            INNER JOIN publications
+            LEFT JOIN publications
                 ON publications.id = publication_has_dataset_version.publication_id
                AND publications.deleted_at IS NULL
             WHERE publication_has_dataset_version.dataset_version_id = ?
@@ -435,11 +478,12 @@ class Gwdm2xHandler extends GwdmMetadataHandler
 
     /**
      * Flat dataset-linkage list for the given version (frontend `linkages` attribute).
-     * Thin formatter over resolveDatasetLinkages() — see it for the selection rules.
+     * Formats resolveDatasetLinkages() and appends unresolved (free-text) rows so a
+     * linkage to a dataset not on the gateway still surfaces its raw title/url.
      */
     public function getLinkages(int $datasetVersionId): array
     {
-        return array_map(
+        $resolved = array_map(
             fn ($row) => [
                 'title' => $row->title,
                 'url' => config('gateway.gateway_url').'/en/dataset/'.$row->dataset_id,
@@ -448,6 +492,22 @@ class Gwdm2xHandler extends GwdmMetadataHandler
             ],
             $this->resolveDatasetLinkages($datasetVersionId, useLatestTitle: true)
         );
+
+        $unresolved = DatasetVersionHasDatasetVersion::query()
+            ->where('dataset_version_source_id', $datasetVersionId)
+            ->where('direct_linkage', 1)
+            ->where('description', self::LINKAGE_DESCRIPTION)
+            ->whereNull('dataset_version_target_id')
+            ->get()
+            ->map(fn ($row) => [
+                'title' => $row->raw_title,
+                'url' => $row->raw_url,
+                'dataset_id' => null,
+                'linkage_type' => $row->linkage_type,
+            ])
+            ->all();
+
+        return array_merge($resolved, $unresolved);
     }
 
     /**

--- a/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
+++ b/database/migrations/2026_06_18_000001_add_unresolved_linkage_columns.php
@@ -1,0 +1,98 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Make both linkage junction tables the complete source of truth for linkage data.
+ *
+ * Previously, LinkageExtraction skipped any reference it could not resolve to a known
+ * dataset or publication. This meant unresolvable free-text titles and DOIs only lived
+ * in the JSON metadata blob, requiring a dual-source merge on every read.
+ *
+ * After this migration:
+ *   - dataset_version_has_dataset_version stores unresolved dataset references as rows
+ *     with dataset_version_target_id = NULL and the raw url/pid/title preserved.
+ *   - publication_has_dataset_version stores unresolved publication references as rows
+ *     with publication_id = NULL and the raw DOI preserved.
+ *   - Gwdm2xHandler::afterRead() can reconstruct the full GWDM linkage section from SQL.
+ *
+ * NOTE: Existing rows that were extracted before this migration contain only resolved
+ * references. Re-dispatching LinkageExtraction for those dataset versions will backfill
+ * any unresolved references that were previously discarded.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = DB::connection()->getDriverName() === 'sqlite';
+
+        Schema::table('dataset_version_has_dataset_version', function (Blueprint $table) use ($isSqlite) {
+            // SQLite rebuilds the whole table on ALTER — named FK drop is not supported.
+            if (! $isSqlite) {
+                $table->dropForeign('ld_dataset_version_target_id_fk');
+            }
+
+            $table->unsignedBigInteger('dataset_version_target_id')->nullable()->change();
+
+            // Raw reference fields for unresolved linkages (target_id = NULL rows).
+            $table->string('raw_url')->nullable()->after('dataset_version_target_id');
+            $table->string('raw_pid')->nullable()->after('raw_url');
+            $table->text('raw_title')->nullable()->after('raw_pid');
+
+            // Re-add FK as nullable (NULL = unresolved, non-NULL = resolved).
+            if (! $isSqlite) {
+                $table->foreign('dataset_version_target_id', 'ld_dataset_version_target_id_fk')
+                    ->references('id')->on('dataset_versions')
+                    ->onDelete('cascade');
+            }
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->dropForeign(['publication_id']);
+
+            $table->unsignedBigInteger('publication_id')->nullable()->change();
+
+            $table->string('raw_doi')->nullable()->after('publication_id');
+
+            $table->foreign('publication_id')
+                ->references('id')->on('publications')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        $isSqlite = DB::connection()->getDriverName() === 'sqlite';
+
+        Schema::table('dataset_version_has_dataset_version', function (Blueprint $table) use ($isSqlite) {
+            if (! $isSqlite) {
+                $table->dropForeign('ld_dataset_version_target_id_fk');
+            }
+            $table->dropColumn(['raw_url', 'raw_pid', 'raw_title']);
+            DB::table('dataset_version_has_dataset_version')
+                ->whereNull('dataset_version_target_id')
+                ->delete();
+            $table->unsignedBigInteger('dataset_version_target_id')->nullable(false)->change();
+            if (! $isSqlite) {
+                $table->foreign('dataset_version_target_id', 'ld_dataset_version_target_id_fk')
+                    ->references('id')->on('dataset_versions')
+                    ->onDelete('cascade');
+            }
+        });
+
+        Schema::table('publication_has_dataset_version', function (Blueprint $table) {
+            $table->dropForeign(['publication_id']);
+            $table->dropColumn('raw_doi');
+            \DB::table('publication_has_dataset_version')
+                ->whereNull('publication_id')
+                ->delete();
+            $table->unsignedBigInteger('publication_id')->nullable(false)->change();
+            $table->foreign('publication_id')
+                ->references('id')->on('publications')
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -17,7 +17,8 @@ use Tests\Traits\Authorization;
 use Tests\Traits\MockExternalApis;
 
 /**
- * Covers resolved dataset linkage title read-back via DatasetService/Gwdm2xHandler.
+ * Covers dataset/publication linkage extraction, free-text fallback, and
+ * resolved-title read-back via DatasetService/Gwdm2xHandler.
  *
  * Drives DatasetService/handlers directly; the x-gwdm-version header steers
  * the target GWDM version via GwdmVersionContext.
@@ -93,6 +94,81 @@ class DatasetVersionLinkageTest extends TestCase
         $this->assertTrue($created['translated']);
 
         return [$created['dataset_id'], $created['version_id']];
+    }
+
+    public function test_unresolved_linkage_roundtrips_title_and_url_via_get_linkages(): void
+    {
+        $this->disableObservers();
+
+        [, $versionId] = $this->createDataset($this->getMetadataV2p0());
+
+        // An unresolved (free-text) linkage: no target dataset, raw reference only.
+        DatasetVersionHasDatasetVersion::create([
+            'dataset_version_source_id' => $versionId,
+            'dataset_version_target_id' => null,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => 1,
+            'description' => 'Extracted from GWDM',
+            'raw_url' => 'https://example.org/dataset/unknown-ref',
+            'raw_pid' => 'free-text-pid',
+            'raw_title' => 'Free Text Linked Dataset',
+        ]);
+
+        $linkages = $this->handler()->getLinkages($versionId);
+
+        $this->assertCount(1, $linkages);
+        $this->assertSame('Free Text Linked Dataset', $linkages[0]['title']);
+        $this->assertSame('https://example.org/dataset/unknown-ref', $linkages[0]['url']);
+        $this->assertNull($linkages[0]['dataset_id']);
+        $this->assertSame('isDerivedFrom', $linkages[0]['linkage_type']);
+    }
+
+    public function test_extract_linkages_reads_blob_not_stale_sql_overlay(): void
+    {
+        $this->disableObservers();
+
+        // Stored blob linkage points to the "blob" reference.
+        $metadata = $this->getMetadataV2p0();
+        $metadata['metadata']['linkage']['datasetLinkage'] = [
+            'isDerivedFrom' => [
+                ['url' => 'https://example.org/dataset/99999999', 'title' => 'Blob Linked'],
+            ],
+        ];
+        $metadata['metadata']['linkage']['publicationAboutDataset'] = null;
+        $metadata['metadata']['linkage']['publicationUsingDataset'] = null;
+
+        [, $versionId] = $this->createDataset($metadata, Dataset::STATUS_DRAFT);
+
+        // Simulate pre-existing (stale) junction-table linkage that afterRead() would
+        // overlay on the read path. If extractLinkages() consumed that overlay it would
+        // rewrite STALE and drop the freshly-authored blob linkage.
+        DatasetVersionHasDatasetVersion::create([
+            'dataset_version_source_id' => $versionId,
+            'dataset_version_target_id' => null,
+            'linkage_type' => 'isDerivedFrom',
+            'direct_linkage' => 1,
+            'description' => 'Extracted from GWDM',
+            'raw_url' => 'https://example.org/dataset/STALE',
+            'raw_title' => 'STALE Linked',
+        ]);
+
+        $dv = DatasetVersion::find($versionId);
+        app(GwdmHandlerFactory::class)->resolve('2.0')->extractLinkages($dv);
+
+        $rows = DatasetVersionHasDatasetVersion::where('dataset_version_source_id', $versionId)
+            ->where('direct_linkage', 1)
+            ->where('description', 'Extracted from GWDM')
+            ->get();
+
+        // The blob reference wins; the stale SQL overlay must not survive.
+        $this->assertTrue(
+            $rows->contains(fn ($r) => str_contains((string) $r->raw_url, '99999999')),
+            'extractLinkages must write the blob-sourced linkage',
+        );
+        $this->assertFalse(
+            $rows->contains(fn ($r) => str_contains((string) $r->raw_url, 'STALE')),
+            'extractLinkages must not resurrect stale SQL-overlay linkage',
+        );
     }
 
     public function test_resolved_linkage_title_tracks_target_latest_version(): void

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -434,4 +434,50 @@ class DatasetVersionLinkageTest extends TestCase
         );
         $this->assertSame(['10.1371/journal.pone.0338652'], $linkage['publicationUsingDataset']);
     }
+
+    /**
+     * app:reconcile-linkages re-runs extraction so a DOI present in the blob but with no
+     * matching publications row is backfilled into SQL as an unresolved junction row
+     * (publication_id NULL, raw_doi set) — proving the command recovers linkages that
+     * pre-migration extraction would have dropped. Regression guard for GAT-9018.
+     */
+    public function test_reconcile_command_backfills_unresolved_publication_doi(): void
+    {
+        $this->disableObservers();
+
+        [$datasetId, $versionId] = $this->createDataset($this->getMetadataV2p0(), Dataset::STATUS_DRAFT);
+
+        // Write a snapshot blob whose linkage carries a DOI that resolves to no
+        // publications row (set directly to isolate the command from the translate mock).
+        $unknownDoi = '10.9999/unresolved-doi';
+        $this->overwriteVersionMetadata($versionId, [
+            'linkage' => [
+                'datasetLinkage' => null,
+                'publicationAboutDataset' => [$unknownDoi],
+                'publicationUsingDataset' => null,
+            ],
+        ]);
+
+        // Nothing extracted yet (observers disabled): no junction rows exist.
+        $this->assertSame(0, PublicationHasDatasetVersion::where('dataset_version_id', $versionId)->count());
+
+        $this->artisan('app:reconcile-linkages', [
+            '--dataset' => $datasetId,
+            '--sync' => true,
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        // The unresolved DOI is now preserved as a raw_doi junction row (no publication_id).
+        $row = PublicationHasDatasetVersion::where('dataset_version_id', $versionId)
+            ->where('link_type', 'ABOUT')
+            ->first();
+
+        $this->assertNotNull($row, 'reconcile should create a junction row for the unresolved DOI');
+        $this->assertNull($row->publication_id);
+        $this->assertSame($unknownDoi, $row->raw_doi);
+
+        // And it round-trips through afterRead() (COALESCE(paper_doi, raw_doi)).
+        $linkage = $this->handler()->afterRead(DatasetVersion::find($versionId))['linkage'];
+        $this->assertContains($unknownDoi, $linkage['publicationAboutDataset']);
+    }
 }

--- a/tests/Feature/DatasetVersionLinkageTest.php
+++ b/tests/Feature/DatasetVersionLinkageTest.php
@@ -480,4 +480,35 @@ class DatasetVersionLinkageTest extends TestCase
         $linkage = $this->handler()->afterRead(DatasetVersion::find($versionId))['linkage'];
         $this->assertContains($unknownDoi, $linkage['publicationAboutDataset']);
     }
+
+    /**
+     * app:reconcile-linkages --dry-run reports what is in the blob but missing from SQL
+     * (with a reason) and changes nothing. Regression guard for GAT-9018.
+     */
+    public function test_reconcile_dry_run_reports_drift_without_writing(): void
+    {
+        $this->disableObservers();
+
+        [$datasetId, $versionId] = $this->createDataset($this->getMetadataV2p0(), Dataset::STATUS_DRAFT);
+
+        $unknownDoi = '10.9999/unresolved-doi';
+        $this->overwriteVersionMetadata($versionId, [
+            'linkage' => [
+                'datasetLinkage' => null,
+                'publicationAboutDataset' => [$unknownDoi],
+                'publicationUsingDataset' => null,
+            ],
+        ]);
+
+        $this->artisan('app:reconcile-linkages', [
+            '--dataset' => $datasetId,
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain($unknownDoi)
+            ->expectsOutputToContain('no publication row')
+            ->assertExitCode(0);
+
+        // Dry-run must not write anything.
+        $this->assertSame(0, PublicationHasDatasetVersion::where('dataset_version_id', $versionId)->count());
+    }
 }


### PR DESCRIPTION
> **Note:** The automated tests in this PR were written by Claude (AI assistant) and reviewed by the author.

## Screenshots (if relevant)

N/A

## Describe your changes

Now that the linkage junction tables are the source of truth for GWDM 2.x linkages, `afterRead()` rebuilds the linkage block from SQL alone. Previously, any reference extraction could not resolve at write time was **dropped** — so it survived only in the JSON blob and was lost on read:

- a **publication DOI** with no matching `publications` row, or
- a **free-text dataset reference** (raw url/pid/title not matching any gateway dataset).

This branch makes the junction tables the *complete* source of truth so those references are preserved, and adds a manual command to backfill/inspect existing data.

**1. Preserve unresolved references (`Gwdm2xHandler` + migration `2026_06_18_000001`)**
- Unresolved dataset refs are stored with `dataset_version_target_id = NULL` + `raw_url/raw_pid/raw_title`; unresolved DOIs with `publication_id = NULL` + `raw_doi` (both FKs made nullable).
- `afterRead()` / `getLinkages()` reconstruct them (publications via `COALESCE(publications.paper_doi, raw_doi)`).
- Empty raw strings are coerced to `NULL` (`blankToNull`) on write and read: the GWDM schema allows null `url/pid/title` but rejects `''` (minLength/uri), so this prevents read-time validation failures. (Null itself is valid per the schema.)
- The unresolved-rows query is a shared raw-SQL helper (`resolveUnresolvedDatasetLinkages`) reused by `afterRead()` and `getLinkages()`.

**2. `app:reconcile-linkages` command (manual ops tool — not auto-wired)**
- Re-runs extraction (idempotent, blob → SQL) to backfill references that pre-date the migration.
- `--dry-run` prints a **drift report**: a table of what is in the blob but missing from SQL, with a reason, plus a per-reason summary — and writes nothing. Reasons: *no publication row*, *publication exists but not linked*, *linkage soft-deleted*, *unresolvable reference*, *dataset exists but not linked*, *target dataset not active*.
- Options: `--dataset`, `--all-versions`, `--sync` (inline via handler), `--dry-run`, `--force`, `--chunk`.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9245

## Environment / Configuration changes (if applicable)

None. New artisan command is run manually; nothing dispatches it automatically.

## Requires migrations being run?

**Yes** — `2026_06_18_000001_add_unresolved_linkage_columns` (nullable target FKs + `raw_url/raw_pid/raw_title/raw_doi`). Existing rows predate the change; run `php artisan app:reconcile-linkages --dry-run` to see drift, then without `--dry-run` to backfill.

## If not using the pre-push hook. Confirm tests pass:

- `pest tests/Feature/DatasetVersionLinkageTest.php` — 12 passed.
- Pint clean; PHPStan level 3 clean on changed files.

Tests added (authored by Claude, reviewed by the author):
- `test_unresolved_linkage_roundtrips_title_and_url_via_get_linkages`
- `test_extract_linkages_reads_blob_not_stale_sql_overlay`
- `test_reconcile_command_backfills_unresolved_publication_doi`
- `test_reconcile_dry_run_reports_drift_without_writing`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate) — N/A (feature tests hit the DB; TRASER mocked via `MockExternalApis`)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable) — N/A
- [ ] I have added Swagger annotations for new endpoints (if applicable) — N/A (no new endpoints)
- [ ] I have added audit logs for new operation logic (if applicable) — N/A (reconstruction is read-path; command re-uses `LinkageExtraction`)
- [ ] I have added new environment variables to the .env.example file (if applicable) — N/A
- [ ] I have added new environment variables to terraform repository (if applicable) — N/A
