### PR TITLE
feat(GAT-8899): improves call speeds to return teams

### DIFF
--- a/app/Http/Controllers/Api/V1/TeamController.php
+++ b/app/Http/Controllers/Api/V1/TeamController.php
@@ -119,10 +119,13 @@ class TeamController extends Controller
             }
 
             $perPage = request('per_page', Config::get('constants.per_page'));
-            $teams = $query
+            $teamsPaginator = $query
                 ->with(['users', 'aliases'])
-                ->paginate($perPage, ['*'], 'page')
-                ->toArray();
+                ->paginate($perPage, ['*'], 'page');
+
+            User::preloadCohortDataForUsers($teamsPaginator->getCollection()->flatMap(fn ($team) => $team->users));
+
+            $teams = $teamsPaginator->toArray();
 
             $teams['data'] = $this->getTeams($teams['data']);
 
@@ -259,7 +262,11 @@ class TeamController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
-            $userTeam = Team::where('id', $teamId)->with(['users', 'notifications', 'aliases'])->get()->toArray();
+            $userTeamCollection = Team::where('id', $teamId)->with(['users', 'notifications', 'aliases'])->get();
+
+            User::preloadCohortDataForUsers($userTeamCollection->flatMap(fn ($team) => $team->users));
+
+            $userTeam = $userTeamCollection->toArray();
 
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Controllers/Api/V1/TeamUserController.php
+++ b/app/Http/Controllers/Api/V1/TeamUserController.php
@@ -937,7 +937,11 @@ class TeamUserController extends Controller
     {
         try {
             $admins = [];
-            $userTeam = Team::where('id', $teamId)->with(['users', 'notifications'])->get()->toArray();
+            $userTeamCollection = Team::where('id', $teamId)->with(['users', 'notifications'])->get();
+
+            User::preloadCohortDataForUsers($userTeamCollection->flatMap(fn ($team) => $team->users));
+
+            $userTeam = $userTeamCollection->toArray();
             $team = $this->getTeams($userTeam);
 
             $users = $team['users'];

--- a/app/Http/Traits/TeamTransformation.php
+++ b/app/Http/Traits/TeamTransformation.php
@@ -10,6 +10,7 @@ use App\Models\Notification;
 use App\Models\TeamHasAlias;
 use App\Models\TeamHasNotification;
 use App\Models\TeamUserHasNotification;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait TeamTransformation
 {
@@ -22,6 +23,40 @@ trait TeamTransformation
     public function getTeams(array $teams): array
     {
         $response = [];
+
+        $teamIds = array_column($teams, 'id');
+
+        $teamHasUserIds = [];
+        foreach ($teams as $team) {
+            foreach ($team['users'] as $user) {
+                if ($user['is_admin']) {
+                    continue;
+                }
+                $teamHasUserIds[] = (int)$user['pivot']['id'];
+            }
+        }
+
+        $rolesByTeamHasUserId = TeamHasUser::whereIn('id', $teamHasUserIds)
+            ->with('roles', 'roles.permissions')
+            ->get()
+            ->keyBy('id')
+            ->toArray();
+
+        $notificationsByTeamId = TeamHasNotification::whereIn('team_id', $teamIds)
+            ->get()
+            ->groupBy('team_id');
+
+        $notificationIds = $notificationsByTeamId->flatten()->pluck('notification_id')->unique()->values()->all();
+
+        $notificationsById = Notification::whereIn('id', $notificationIds)->get()->keyBy('id');
+
+        $aliasIdsByTeamId = TeamHasAlias::whereIn('team_id', $teamIds)
+            ->get()
+            ->groupBy('team_id');
+
+        $allAliasIds = $aliasIdsByTeamId->flatten()->pluck('alias_id')->unique()->values()->all();
+
+        $aliasesById = Alias::whereIn('id', $allAliasIds)->get()->keyBy('id');
 
         foreach ($teams as $team) {
             $tmpTeam = [
@@ -86,10 +121,8 @@ trait TeamTransformation
 
                 $teamHasUserId = (int)$user['pivot']['id'];
 
-                $roles = TeamHasUser::where('id', $teamHasUserId)->with('roles', 'roles.permissions')->get()->toArray();
-
                 $tmpPerm = [];
-                foreach ($roles[0]['roles'] as $role) {
+                foreach ($rolesByTeamHasUserId[$teamHasUserId]['roles'] ?? [] as $role) {
                     $tmpPerm[] = $role;
                 }
                 $tmp['roles'] = $tmpPerm;
@@ -101,21 +134,22 @@ trait TeamTransformation
 
             $tmpTeam['users'] = $tmpUser;
 
-            $notifications = TeamHasNotification::where('team_id', $tmpTeam['id'])->get()->toArray();
             $tmpNotification = [];
-            foreach ($notifications as $value) {
-                $notification = Notification::where('id', $value['notification_id'])->firstOrFail();
+            foreach ($notificationsByTeamId->get($tmpTeam['id'], collect()) as $value) {
+                $notification = $notificationsById->get($value['notification_id']);
+                if ($notification === null) {
+                    throw (new ModelNotFoundException())->setModel(Notification::class, [$value['notification_id']]);
+                }
                 $tmpNotification[] = $notification;
             }
             $tmpTeam['notifications'] = $tmpNotification;
 
-            $aliasIds = TeamHasAlias::where('team_id', $tmpTeam['id'])->pluck('alias_id');
-            $tmpTeam['aliases'] = Alias::whereIn('id', $aliasIds)->get()->toArray();
+            $teamAliasIds = $aliasIdsByTeamId->get($tmpTeam['id'], collect())->pluck('alias_id')->all();
+            $tmpTeam['aliases'] = $aliasesById->only($teamAliasIds)->sortBy('id')->values()->toArray();
 
             $response[] = $tmpTeam;
             unset($tmpTeam);
             unset($tmpUser);
-            unset($notifications);
             unset($tmpNotification);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -108,8 +108,78 @@ class User extends Authenticatable
 
     protected $appends = ['rquestroles', 'cohort_discovery_roles', 'cohort_discovery_nhs_sde'];
 
+    /**
+     * Instance-scoped cache populated by preloadCohortDataForUsers() to avoid
+     * per-user queries when serializing many users at once. Instance-level
+     * (not static) so it carries no state across requests under Octane.
+     */
+    private ?array $cohortRoleCache = null;
+
+    private ?bool $cohortNhsSdeCache = null;
+
+    /**
+     * Batch-load cohort request roles and NHS SDE approval for a collection of
+     * users, so serializing them (which auto-computes the $appends below)
+     * doesn't issue per-user queries. Call before ->toArray()/response.
+     */
+    public static function preloadCohortDataForUsers(\Illuminate\Support\Collection $users): void
+    {
+        $userIds = $users->pluck('id')->unique()->values()->all();
+
+        if (empty($userIds)) {
+            return;
+        }
+
+        $firstApprovedCohortRequestByUser = CohortRequest::whereIn('user_id', $userIds)
+            ->where('request_status', 'APPROVED')
+            ->get()
+            ->groupBy('user_id')
+            ->map(fn ($requests) => $requests->first());
+
+        $cohortRequestIds = $firstApprovedCohortRequestByUser->pluck('id')->all();
+
+        $permissionIdsByCohortRequest = CohortRequestHasPermission::whereIn('cohort_request_id', $cohortRequestIds)
+            ->get()
+            ->groupBy('cohort_request_id');
+
+        $allPermissionIds = $permissionIdsByCohortRequest->flatten()->pluck('permission_id')->unique()->values()->all();
+
+        $permissionNamesById = Permission::whereIn('id', $allPermissionIds)->pluck('name', 'id');
+
+        $nhsSdeApprovedUserIds = array_flip(
+            CohortRequest::whereIn('user_id', $userIds)
+                ->where('request_status', 'APPROVED')
+                ->where('nhse_sde_request_status', 'APPROVED')
+                ->whereNull('nhse_sde_request_expire_at')
+                ->pluck('user_id')
+                ->unique()
+                ->all()
+        );
+
+        foreach ($users as $user) {
+            $cohortRequest = $firstApprovedCohortRequestByUser->get($user->id);
+
+            if ($cohortRequest === null) {
+                $user->cohortRoleCache = [];
+            } else {
+                $user->cohortRoleCache = $permissionIdsByCohortRequest->get($cohortRequest->id, collect())
+                    ->pluck('permission_id')
+                    ->map(fn ($permissionId) => $permissionNamesById->get($permissionId))
+                    ->filter()
+                    ->values()
+                    ->all();
+            }
+
+            $user->cohortNhsSdeCache = isset($nhsSdeApprovedUserIds[$user->id]);
+        }
+    }
+
     public function getCohortDiscoveryRolesAttribute()
     {
+        if ($this->cohortRoleCache !== null) {
+            return $this->cohortRoleCache;
+        }
+
         $id = $this->id;
 
         $cohortRequest = CohortRequest::where([
@@ -132,6 +202,10 @@ class User extends Authenticatable
 
     public function getRquestRolesAttribute()
     {
+        if ($this->cohortRoleCache !== null) {
+            return $this->cohortRoleCache;
+        }
+
         $id = $this->id;
 
         $cohortRequest = CohortRequest::where([
@@ -154,6 +228,10 @@ class User extends Authenticatable
 
     public function getCohortDiscoveryNhsSdeAttribute()
     {
+        if ($this->cohortNhsSdeCache !== null) {
+            return $this->cohortNhsSdeCache;
+        }
+
         $id = $this->id;
 
         $nhsSdeApproved = CohortRequest::where([


### PR DESCRIPTION
## Screenshots (if relevant)

## Describe your changes

Upon investigation this code was really poor. I discovered the following:
- For every user of every team `roles.permissions` is called inside a foreach. That means, for a full page (25) of teams with 10 users, you're looking at 250 queries per.
- For every team, we'd fetch `TeamHasNotifications`, then for every record, pull `Notification`, which essentially exposed an N+1 inside an N+1. Fun!
- We then, for reasons unknown to me, throw away an eagerly loaded `TeamHasAlias` and pull it again manually?! Bonkers.

Optimisations made:
- Batched the per-team/per-user N+1 queries (roles, notifications and aliases) into `whereIn` lookups.
- Added an Octane safe (no stale, or drifting static states) instance cache, so that the `$appends` accessors don't fire DB queries per user when many users are serialised at once.
- Preload before serialising teams' users, in index, show and listOfAdmin functions.

Optimisations thus lead to use using existing eagerly loaded relations. In profiling, db calls went from ~1315 to ~15 per.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-8899

## Environment / Configuration changes (if applicable)
None

## Requires migrations being run?
No

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
