### PR TITLE
feat(GAT-9442): Allows toggling and editing of email templates with live …

### DIFF
--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -5,12 +5,11 @@ namespace App\Console\Commands;
 use Config;
 use Auditor;
 use Exception;
-use App\Jobs\SendEmailJob;
 use App\Models\CohortRequest;
 use App\Models\CohortRequestLog;
 use App\Models\CohortRequestHasLog;
 use App\Models\CohortRequestHasPermission;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Support\Carbon;
@@ -154,13 +153,13 @@ class CohortUserExpiry extends Command
             $user = User::where('id', $cohortRequestUserId)->first();
             $userEmail = ($user['preferred_email'] === 'primary') ?
                 $user['email'] : $user['secondary_email'];
-            $template = null;
+            $identifier = null;
             switch ($cohortRequestStatus) {
                 case 'WILL_EXPIRE':
-                    $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.will.expire')->first();
+                    $identifier = 'cohort.discovery.access.will.expire';
                     break;
                 case 'EXPIRED':
-                    $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.expired')->first();
+                    $identifier = 'cohort.discovery.access.expired';
                     break;
             }
 
@@ -181,7 +180,9 @@ class CohortUserExpiry extends Command
                 '[[COHORT_DISCOVERY_RENEW_URL]]' => Config::get('cohort.cohort_discovery_renew_url'),
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            if ($identifier) {
+                app(EmailManager::class)->send($identifier, $to, $replacements);
+            }
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',

--- a/app/Console/Commands/PreviewEmailTemplate.php
+++ b/app/Console/Commands/PreviewEmailTemplate.php
@@ -2,9 +2,10 @@
 
 namespace App\Console\Commands;
 
+use App\Services\EmailPreviewRenderer;
 use App\Services\EmailTemplateAssembler;
+use Exception;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Http;
 
 class PreviewEmailTemplate extends Command
 {
@@ -78,19 +79,15 @@ class PreviewEmailTemplate extends Command
             }
         }
 
-        // Replace any remaining [[PLACEHOLDER]] tokens with dummy preview data
-        $body = $this->applyDummyData($body);
-
         $this->info("Calling MJML render API for '{$identifier}'...");
 
-        $response = Http::post(config('services.mjml.render_url'), ['mjml' => $body]);
-
-        if (!$response->successful()) {
-            $this->error('MJML render failed: ' . $response->body());
+        try {
+            $html = (new EmailPreviewRenderer())->renderHtml($body);
+        } catch (Exception $e) {
+            $this->error('MJML render failed: ' . $e->getMessage());
             return self::FAILURE;
         }
 
-        $html    = $response->json()['html'];
         $subject = $template['subject'] ?? $identifier;
         $html    = str_replace('<title>', "<title>{$subject} — ", $html);
 
@@ -105,43 +102,5 @@ class PreviewEmailTemplate extends Command
         exec("{$opener} " . escapeshellarg($tmpFile));
 
         return self::SUCCESS;
-    }
-
-    private function applyDummyData(string $body): string
-    {
-        $successList = implode('', [
-            '<li>PID: dataset-001 - Synced OK (1 record)</li>',
-            '<li>PID: dataset-002 - Synced OK (3 records)</li>',
-            '<li>PID: dataset-003 - Synced OK (2 records)</li>',
-        ]);
-
-        $errorList = implode('', [
-            '<li>PID - dataset-004:<br><ul>' .
-                '<li>my-failing-dataset / 1.0 — Schema validation failed: \'description\' is required</li>' .
-                '<li>my-failing-dataset / 1.0 — Schema validation failed: \'keywords\' must be an array</li>' .
-            '</ul></li>',
-        ]);
-
-        $adminList = '<ul><li>Jane Doe (jane.doe@example.com)</li><li>John Smith (john.smith@example.com)</li></ul>';
-
-        $map = [
-            // Generic
-            '[[USER_FIRSTNAME]]'      => 'Jane',
-            '[[USER_LASTNAME]]'       => 'Doe',
-            '[[USER_EMAIL]]'          => 'jane.doe@example.com',
-            '[[TEAM_NAME]]'           => 'Health Data Research UK',
-            '[[TEAM_ID]]'             => '10',
-            '[[RUN_DATE]]'            => now()->toDateTimeString(),
-            // Integration job
-            '[[INTEGRATION_ID]]'      => '42',
-            '[[INTEGRATION_LIST_URL]]' => config('gateway.gateway_url') . '/en/account/team/10/integrations/integration/list',
-            '[[DATASET_COUNT]]'       => '3',
-            '[[INTEGRATION_SUCCESS]]' => "<ul>{$successList}</ul>",
-            '[[INTEGRATION_ERRORS]]'  => "<ul>{$errorList}</ul>",
-            '[[JOB_ERROR]]'           => 'Connection timed out after 30 seconds (HTTP 504 from upstream)',
-            '[[USER_LIST]]'           => $adminList,
-        ];
-
-        return str_replace(array_keys($map), array_values($map), $body);
     }
 }

--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -9,13 +9,12 @@ use Exception;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
-use App\Jobs\SendEmailJob;
 use App\Models\Application;
 use App\Models\TeamHasUser;
 use Illuminate\Support\Str;
 use App\Models\Notification;
+use App\Services\EmailManager;
 use Illuminate\Http\Request;
-use App\Models\EmailTemplate;
 use App\Models\TeamUserHasRole;
 use App\Http\Traits\CheckAccess;
 use Illuminate\Http\JsonResponse;
@@ -916,24 +915,18 @@ class ApplicationController extends Controller
             throw new Exception('Application not found!');
         }
 
-        $template = null;
-        switch ($type) {
-            case 'CREATE':
-                $template = EmailTemplate::where('identifier', 'private.app.create')->first();
-                break;
-            case 'UPDATE':
-                $template = EmailTemplate::where('identifier', 'private.app.update')->first();
-                break;
-            case 'DELETE':
-                $template = EmailTemplate::where('identifier', 'private.app.delete')->first();
-                break;
-            case 'UPDATE.CLIENTID':
-                $template = EmailTemplate::where('identifier', 'private.app.update.clientid')->first();
-                break;
-            default:
-                throw new Exception("Send email type not found!");
-                break;
+        $identifiers = [
+            'CREATE' => 'private.app.create',
+            'UPDATE' => 'private.app.update',
+            'DELETE' => 'private.app.delete',
+            'UPDATE.CLIENTID' => 'private.app.update.clientid',
+        ];
+
+        if (!array_key_exists($type, $identifiers)) {
+            throw new Exception("Send email type not found!");
         }
+
+        $identifier = $identifiers[$type];
 
         $receivers = $this->sendEmailTo($app);
 
@@ -965,7 +958,7 @@ class ApplicationController extends Controller
                 '[[CURRENT_YEAR]]' => date('Y'),
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            app(EmailManager::class)->send($identifier, $to, $replacements);
         }
 
     }

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -11,12 +11,11 @@ use App\Http\Requests\CohortRequest\GetCohortRequest;
 use App\Http\Requests\CohortRequest\RemoveAdminCohortRequest;
 use App\Http\Requests\CohortRequest\UpdateCohortRequest;
 use App\Http\Traits\HubspotContacts;
-use App\Jobs\SendEmailJob;
 use App\Models\CohortRequest;
 use App\Models\CohortRequestHasLog;
 use App\Models\CohortRequestHasPermission;
 use App\Models\CohortRequestLog;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\OauthClient;
 use App\Models\OauthUser;
 use App\Models\Permission;
@@ -1549,24 +1548,24 @@ class CohortRequestController extends Controller
             $user = User::where('id', $cohortRequestUserId)->first();
             $userEmail = ($user['preferred_email'] === 'primary') ? $user['email'] : $user['secondary_email'];
 
-            // template
-            $template = null;
+            // identifier
+            $identifier = null;
             if (!$admin || !$statusNhs) {
                 switch ($cohortRequestStatus) {
                     case 'PENDING': // submitted
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.submitted')->first();
+                        $identifier = 'cohort.discovery.access.submitted';
                         break;
                     case 'REJECTED':
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.rejected')->first();
+                        $identifier = 'cohort.discovery.access.rejected';
                         break;
                     case 'APPROVED':
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.approved')->first();
+                        $identifier = 'cohort.discovery.access.approved';
                         break;
                     case 'BANNED':
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.banned')->first();
+                        $identifier = 'cohort.discovery.access.banned';
                         break;
                     case 'SUSPENDED':
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.discovery.access.suspended')->first();
+                        $identifier = 'cohort.discovery.access.suspended';
                         break;
                 }
             }
@@ -1574,10 +1573,10 @@ class CohortRequestController extends Controller
             if ($admin) {
                 switch ($admin) {
                     case 'assign': // submitted
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.request.admin.approve')->first();
+                        $identifier = 'cohort.request.admin.approve';
                         break;
                     case 'remove':
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.request.admin.remove')->first();
+                        $identifier = 'cohort.request.admin.remove';
                         break;
                 }
             }
@@ -1585,7 +1584,7 @@ class CohortRequestController extends Controller
             if ($statusNhs) {
                 switch ($statusNhs) {
                     case 'APPROVED': // approved nhs
-                        $template = EmailTemplate::where('identifier', '=', 'cohort.request.nhs.approved')->first();
+                        $identifier = 'cohort.request.nhs.approved';
                         break;
                 }
             }
@@ -1609,8 +1608,8 @@ class CohortRequestController extends Controller
                 '[[COHORT_DISCOVERY_RENEW_URL]]' => Config::get('cohort.cohort_discovery_renew_url'),
             ];
 
-            if ($template) {
-                SendEmailJob::dispatch($to, $template, $replacements);
+            if ($identifier) {
+                app(EmailManager::class)->send($identifier, $to, $replacements);
             }
         } catch (Exception $e) {
             Auditor::log([

--- a/app/Http/Controllers/Api/V1/DataAccessApplicationReviewController.php
+++ b/app/Http/Controllers/Api/V1/DataAccessApplicationReviewController.php
@@ -25,12 +25,11 @@ use App\Http\Requests\DataAccessApplicationReview\UpdateGlobalUserDataAccessAppl
 use App\Http\Requests\DataAccessApplicationReview\UpdateUserDataAccessApplicationReview;
 use App\Http\Traits\RequestTransformation;
 use App\Http\Traits\DataAccessApplicationHelpers;
-use App\Jobs\SendEmailJob;
 use App\Models\DataAccessApplication;
 use App\Models\DataAccessApplicationComment;
 use App\Models\DataAccessApplicationReview;
 use App\Models\DataAccessApplicationReviewHasFile;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\Team;
 use App\Models\Upload;
 use App\Models\User;
@@ -1558,7 +1557,6 @@ class DataAccessApplicationReviewController extends Controller
 
     private function emailCustodianReview(int $reviewId, int $applicationId): void
     {
-        $template = EmailTemplate::where(['identifier' => 'dar.review.custodian'])->first();
         $application = DataAccessApplication::where('id', $applicationId)->first();
         $comments = DataAccessApplicationReview::where('id', $reviewId)
             ->with('comments')
@@ -1578,13 +1576,12 @@ class DataAccessApplicationReviewController extends Controller
                 '[[CURRENT_YEAR]]' => date("Y"),
             ];
 
-            SendEmailJob::dispatch($darManager, $template, $replacements);
+            app(EmailManager::class)->send('dar.review.custodian', $darManager, $replacements);
         }
     }
 
     private function emailResearcherReview(int $reviewId, int $applicationId): void
     {
-        $template = EmailTemplate::where(['identifier' => 'dar.review.researcher'])->first();
         $application = DataAccessApplication::where('id', $applicationId)->first();
         $comments = DataAccessApplicationReview::where('id', $reviewId)
             ->with('comments')
@@ -1612,7 +1609,7 @@ class DataAccessApplicationReviewController extends Controller
             '[[CURRENT_YEAR]]' => date("Y"),
         ];
 
-        SendEmailJob::dispatch($to, $template, $replacements);
+        app(EmailManager::class)->send('dar.review.researcher', $to, $replacements);
     }
 
     private function formatThread(array $comments): string

--- a/app/Http/Controllers/Api/V1/EmailController.php
+++ b/app/Http/Controllers/Api/V1/EmailController.php
@@ -4,18 +4,16 @@ namespace App\Http\Controllers\Api\V1;
 
 use Config;
 use App\Models\User;
-use App\Jobs\SendEmailJob;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\DispatchEmailRequest;
 
 class EmailController extends Controller
 {
-    public function dispatchEmail(DispatchEmailRequest $request)
+    public function dispatchEmail(DispatchEmailRequest $request, EmailManager $emailManager)
     {
         $body = $request->post();
 
-        $template = EmailTemplate::where('identifier', '=', $body['identifier'])->first();
         $user = User::where('id', '=', $body['to'])->first();
 
         $toArray = [
@@ -25,8 +23,9 @@ class EmailController extends Controller
             ],
         ];
 
-        if ($template) {
-            SendEmailJob::dispatch($toArray, $template, $body['replacements']);
+        $sent = $emailManager->send($body['identifier'], $toArray, $body['replacements']);
+
+        if ($sent) {
             return response()->json([
                 'message' => Config::get('statuscodes.STATUS_OK.message'),
             ], Config::get('statuscodes.STATUS_OK.code'));

--- a/app/Http/Controllers/Api/V1/EmailTemplateController.php
+++ b/app/Http/Controllers/Api/V1/EmailTemplateController.php
@@ -7,6 +7,7 @@ use Config;
 use Exception;
 use Illuminate\Http\Request;
 use App\Models\EmailTemplate;
+use App\Services\EmailPreviewRenderer;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 use App\Exceptions\NotFoundException;
@@ -16,6 +17,7 @@ use App\Http\Requests\EmailTemplate\EditEmailTemplate;
 use App\Http\Requests\EmailTemplate\CreateEmailTemplate;
 use App\Http\Requests\EmailTemplate\DeleteEmailTemplate;
 use App\Http\Requests\EmailTemplate\UpdateEmailTemplate;
+use App\Http\Requests\EmailTemplate\RenderEmailTemplatePreview;
 
 class EmailTemplateController extends Controller
 {
@@ -66,9 +68,10 @@ class EmailTemplateController extends Controller
                 'description' => 'Email template get all',
             ]);
 
-            return response()->json(
-                $emailTemplates
-            );
+            return response()->json([
+                'message' => 'success',
+                'data' => $emailTemplates,
+            ]);
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],
@@ -138,15 +141,12 @@ class EmailTemplateController extends Controller
         $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
 
         try {
-            $emailTemplates = EmailTemplate::where([
-                'id' =>  $id,
-                'enabled' => 1,
-            ])->get();
+            $emailTemplate = EmailTemplate::where('id', $id)->first();
 
-            if ($emailTemplates->count()) {
+            if ($emailTemplate) {
                 return response()->json([
                     'message' => 'success',
-                    'data' => $emailTemplates,
+                    'data' => $emailTemplate,
                 ], 200);
             }
 
@@ -554,6 +554,75 @@ class EmailTemplateController extends Controller
             }
 
             throw new NotFoundException();
+        } catch (Exception $e) {
+            Auditor::log([
+                'user_id' => (int)$jwtUser['id'],
+                'action_type' => 'EXCEPTION',
+                'action_name' => class_basename($this) . '@'.__FUNCTION__,
+                'description' => $e->getMessage(),
+            ]);
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *    path="/api/v1/emailtemplates/preview",
+     *    operationId="preview_emailtemplates",
+     *    tags={"Email Templates"},
+     *    summary="EmailTemplateController@preview",
+     *    description="Render an email template body (raw MJML) to HTML for live preview, with fictional placeholder data",
+     *    security={{"bearerAuth":{}}},
+     *    @OA\RequestBody(
+     *       required=true,
+     *       @OA\MediaType(
+     *          mediaType="application/json",
+     *          @OA\Schema(
+     *             @OA\Property(property="body", type="string", example="<mjml>...</mjml>")
+     *          )
+     *       )
+     *    ),
+     *    @OA\Response(
+     *       response="200",
+     *       description="Success response",
+     *       @OA\JsonContent(
+     *          @OA\Property(property="message", type="string", example="success"),
+     *          @OA\Property(
+     *             property="data",
+     *             type="object",
+     *             @OA\Property(property="html", type="string")
+     *          )
+     *       )
+     *    ),
+     *      @OA\Response(
+     *          response=401,
+     *          description="Unauthorized",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="unauthorized")
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error"),
+     *          )
+     *      )
+     * )
+     */
+    public function preview(RenderEmailTemplatePreview $request): JsonResponse
+    {
+        $input = $request->all();
+        $jwtUser = array_key_exists('jwt_user', $input) ? $input['jwt_user'] : [];
+
+        try {
+            $html = (new EmailPreviewRenderer())->renderHtml(html_entity_decode($input['body']));
+
+            return response()->json([
+                'message' => 'success',
+                'data' => ['html' => $html],
+            ], 200);
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Http/Controllers/Api/V1/FederationController.php
+++ b/app/Http/Controllers/Api/V1/FederationController.php
@@ -14,9 +14,8 @@ use App\Http\Requests\Federation\UpdateFederation;
 use App\Http\Traits\LoggingContext;
 use App\Http\Traits\RequestTransformation;
 use App\Jobs\ProcessFederation;
-use App\Jobs\SendEmailJob;
 use App\Jobs\TestFederation;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\Federation;
 use App\Models\FederationHasNotification;
 use App\Models\FederationJobRun;
@@ -1237,22 +1236,16 @@ class FederationController extends Controller
             throw new Exception('Gateway App not found!');
         }
 
-        $template = null;
-        switch ($type) {
-            case 'CREATE':
-                $template = EmailTemplate::where('identifier', '=', 'federation.app.create')->first();
-                break;
-            case 'UPDATE':
-                $template = EmailTemplate::where('identifier', '=', 'federation.app.update')->first();
-                break;
-            default:
-                throw new Exception("Send email type not found!");
-                break;
+        $identifiers = [
+            'CREATE' => 'federation.app.create',
+            'UPDATE' => 'federation.app.update',
+        ];
+
+        if (!array_key_exists($type, $identifiers)) {
+            throw new Exception("Send email type not found!");
         }
 
-        if (is_null($template)) {
-            throw new Exception('Email template not found!');
-        }
+        $identifier = $identifiers[$type];
 
         $receivers = $this->sendEmailTo($federationId);
 
@@ -1275,7 +1268,7 @@ class FederationController extends Controller
                 '[[CURRENT_YEAR]]' => date('Y'),
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            app(EmailManager::class)->send($identifier, $to, $replacements);
         }
 
     }

--- a/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/TeamDataAccessApplicationController.php
@@ -14,13 +14,12 @@ use App\Http\Requests\DataAccessApplication\GetDataAccessApplication;
 use App\Http\Requests\DataAccessApplication\GetDataAccessApplicationFile;
 use App\Http\Requests\DataAccessApplication\EditDataAccessApplication;
 use App\Http\Requests\DataAccessApplication\DeleteDataAccessApplicationFile;
-use App\Jobs\SendEmailJob;
 use App\Models\DataAccessApplication;
 use App\Models\DataAccessApplicationComment;
 use App\Models\DataAccessApplicationReview;
 use App\Models\DataAccessApplicationStatus;
 use App\Models\DataAccessApplicationAnswer;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\TeamHasDataAccessApplication;
 use App\Models\Upload;
 use App\Models\User;
@@ -1292,7 +1291,6 @@ class TeamDataAccessApplicationController extends Controller
 
     private function emailStatusNotification(int $id, DataAccessApplication $application, int $teamId): void
     {
-        $template = EmailTemplate::where(['identifier' => 'dar.status.researcher'])->first();
         $user = User::where('id', $application->applicant_id)->first();
 
         $to = [
@@ -1317,6 +1315,6 @@ class TeamDataAccessApplicationController extends Controller
             '[[CURRENT_YEAR]]' => date("Y"),
         ];
 
-        SendEmailJob::dispatch($to, $template, $replacements);
+        app(EmailManager::class)->send('dar.status.researcher', $to, $replacements);
     }
 }

--- a/app/Http/Controllers/Api/V1/TeamUserController.php
+++ b/app/Http/Controllers/Api/V1/TeamUserController.php
@@ -8,10 +8,9 @@ use Exception;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
-use App\Jobs\SendEmailJob;
 use App\Models\TeamHasUser;
 use App\Models\Notification;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\TeamUserHasRole;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
@@ -778,7 +777,6 @@ class TeamUserController extends Controller
     private function sendEmailNewUser(int $teamId, int $userId, array $roles)
     {
         try {
-            $template = EmailTemplate::where(['identifier' => 'add.new.user.team'])->first();
             $user = User::where('id', '=', $userId)->first();
             $team = Team::where('id', '=', $teamId)->first();
 
@@ -797,7 +795,7 @@ class TeamUserController extends Controller
                 '[[CURRENT_YEAR]]' => date("Y"),
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            app(EmailManager::class)->send('add.new.user.team', $to, $replacements);
         } catch (Exception $e) {
             Auditor::log([
                 'action_type' => 'EXCEPTION',
@@ -811,7 +809,6 @@ class TeamUserController extends Controller
 
     public function sendEmailUpdate(int $teamId, int $userId)
     {
-        $template = EmailTemplate::where(['identifier' => 'update.roles.team.user'])->first();
         $team = Team::where('id', '=', $teamId)->first();
         $user = User::where('id', '=', $userId)->first();
         $to = [
@@ -831,12 +828,11 @@ class TeamUserController extends Controller
             '[[REMOVED_ROLES]]' => $this->stringRoleFullName($this->deleteRoleNames),
         ];
 
-        SendEmailJob::dispatch($to, $template, $replacements);
+        app(EmailManager::class)->send('update.roles.team.user', $to, $replacements);
     }
 
     public function sendEmailUpdateToTeam(int $teamId)
     {
-        $template = EmailTemplate::where(['identifier' => 'update.roles.team.notifications'])->first();
         $team = Team::where('id', '=', $teamId)->first();
         if (!$team->notification_status) {
             return;
@@ -875,7 +871,7 @@ class TeamUserController extends Controller
                 '[[USER_CHANGES]]' => $this->stringUserRoleTeamNotifications(),
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            app(EmailManager::class)->send('update.roles.team.notifications', $to, $replacements);
         }
     }
 

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -25,8 +25,7 @@ use App\Http\Traits\UserTransformation;
 use App\Http\Traits\RequestTransformation;
 use App\Models\EmailVerification;
 use Carbon\Carbon;
-use App\Models\EmailTemplate;
-use App\Jobs\SendEmailJob;
+use App\Services\EmailManager;
 
 class UserController extends Controller
 {
@@ -480,21 +479,19 @@ class UserController extends Controller
                             'expires_at' => Carbon::now()->addHours(24),
                         ]);
 
-                        $template = EmailTemplate::where('identifier', '=', 'user.email_verification')->first();
-
                         $replacements = [
                             '[[UUID]]' => $newToken,
                             '[[USER_FIRST_NAME]]' => $input['firstname'] ?? $user->firstname,
                         ];
 
-                        if ($template && !empty($input['secondary_email'])) {
+                        if (!empty($input['secondary_email'])) {
                             $to = [
                             'to' => [
                               'email' => $input['secondary_email'],
                               'name' => $user['name'],
                             ],
                                   ];
-                            SendEmailJob::dispatch($to, $template, $replacements);
+                            app(EmailManager::class)->send('user.email_verification', $to, $replacements);
                         }
                     }
 
@@ -855,24 +852,19 @@ class UserController extends Controller
             'is_secondary' => true,
         ]);
 
-        // Get email template
-        $template = EmailTemplate::where('identifier', '=', 'user.email_verification')->first();
-
         $replacements = [
             '[[UUID]]' => $newToken,
             '[[USER_FIRST_NAME]]' => $user->firstname,
         ];
 
-        if ($template) {
-            $to = [
-                'to' => [
-                    'email' => $user->secondary_email,
-                    'name' => $user->name,
-                ],
-            ];
+        $to = [
+            'to' => [
+                'email' => $user->secondary_email,
+                'name' => $user->name,
+            ],
+        ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
-        }
+        app(EmailManager::class)->send('user.email_verification', $to, $replacements);
 
         return response()->json([
             'message' => 'Verification email resent.',

--- a/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
+++ b/app/Http/Controllers/Api/V1/UserDataAccessApplicationController.php
@@ -19,13 +19,12 @@ use App\Http\Requests\DataAccessApplication\GetUserDataAccessApplication;
 use App\Http\Requests\DataAccessApplication\GetUserDataAccessApplicationFile;
 use App\Http\Requests\DataAccessApplication\UpdateUserDataAccessApplication;
 use App\Http\Traits\DataAccessApplicationHelpers;
-use App\Jobs\SendEmailJob;
 use App\Models\DataAccessApplication;
 use App\Models\DataAccessApplicationAnswer;
 use App\Models\DataAccessApplicationHasDataset;
 use App\Models\DataAccessApplicationHasQuestion;
 use App\Models\DataAccessApplicationStatus;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\Team;
 use App\Models\TeamHasDataAccessApplication;
 use App\Models\Upload;
@@ -1386,7 +1385,6 @@ class UserDataAccessApplicationController extends Controller
 
     private function emailSubmissionNotification(int $id, int $userId, DataAccessApplication $application): void
     {
-        $template = EmailTemplate::where(['identifier' => 'dar.submission.researcher'])->first();
         $user = User::where('id', '=', $userId)->first();
 
         $teamIds = TeamHasDataAccessApplication::where('dar_application_id', $id)
@@ -1413,9 +1411,8 @@ class UserDataAccessApplicationController extends Controller
             '[[CURRENT_YEAR]]' => date("Y"),
         ];
 
-        SendEmailJob::dispatch($to, $template, $replacements);
+        app(EmailManager::class)->send('dar.submission.researcher', $to, $replacements);
 
-        $custodianTemplate = EmailTemplate::where(['identifier' => 'dar.submission.custodian'])->first();
         foreach ($teams as $team) {
             $darManagers = $this->getDarManagers($team->id);
             $teamNotifications = $this->getTeamNotifications($team->id);
@@ -1431,7 +1428,7 @@ class UserDataAccessApplicationController extends Controller
                     '[[CURRENT_YEAR]]' => date('Y'),
                     '[[TEAM_ID]]' => $team->id,
                 ];
-                SendEmailJob::dispatch($dm, $custodianTemplate, $replacements);
+                app(EmailManager::class)->send('dar.submission.custodian', $dm, $replacements);
             }
         }
     }

--- a/app/Http/Requests/EmailTemplate/RenderEmailTemplatePreview.php
+++ b/app/Http/Requests/EmailTemplate/RenderEmailTemplatePreview.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\EmailTemplate;
+
+use App\Http\Requests\BaseFormRequest;
+
+class RenderEmailTemplatePreview extends BaseFormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Traits/EnquiriesTrait.php
+++ b/app/Http/Traits/EnquiriesTrait.php
@@ -7,10 +7,9 @@ use Exception;
 use App\Models\Role;
 use App\Models\Team;
 use App\Models\User;
-use App\Jobs\SendEmailJob;
 use App\Models\TeamHasUser;
 use App\Models\Notification;
-use App\Models\EmailTemplate;
+use App\Services\EmailManager;
 use App\Models\EnquiryThread;
 use App\Models\DatasetVersion;
 use App\Models\EnquiryMessage;
@@ -185,8 +184,6 @@ trait EnquiriesTrait
         list($username, $domain) = explode('@', $imapUsername);
 
         try {
-            $template = EmailTemplate::where('identifier', $ident)->first();
-
             if (array_key_exists('datasets', $threadDetail['thread'])) {
                 $threadDetail['message']['message_body']['[[DATASETS]]'] = $threadDetail['thread']['datasets'];
             }
@@ -234,13 +231,10 @@ trait EnquiriesTrait
                 }
 
                 $from = $username . '+' . $threadDetail['thread']['unique_key'] . '@' . $domain;
-                SendEmailJob::dispatch($to, $template, $replacements, $from);
+                app(EmailManager::class)->send($ident, $to, $replacements, $from);
             }
 
-            unset(
-                $template,
-                $replacements,
-            );
+            unset($replacements);
         } catch (Exception $e) {
             Auditor::log([
                 'user_id' => (int)$jwtUser['id'],

--- a/app/Jobs/SendEmailCustomIntegration.php
+++ b/app/Jobs/SendEmailCustomIntegration.php
@@ -3,9 +3,9 @@
 namespace App\Jobs;
 
 use App\Models\Dataset;
-use App\Models\EmailTemplate;
 use App\Models\Federation;
 use App\Models\FederationJobRun;
+use App\Services\EmailManager;
 use App\Traits\GatewayMetadataIngestionTrait;
 use Carbon\Carbon;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -70,13 +70,6 @@ class SendEmailCustomIntegration implements ShouldQueue
             $permSuffix     = $checkUser ? 'teamadmin_developer' : 'no_teamadmin_developer';
             $templateId     = "integration.job.{$this->outcome}.{$permSuffix}";
 
-            $template = EmailTemplate::where('identifier', $templateId)->first();
-
-            if (!$template) {
-                $this->log('warning', "send email after integration: template '{$templateId}' not found");
-                continue;
-            }
-
             $to = [
                 'to' => [
                     'email' => $userEmail,
@@ -97,7 +90,7 @@ class SendEmailCustomIntegration implements ShouldQueue
                 '[[JOB_ERROR]]'            => $this->errorMessage ?? '',
             ];
 
-            SendEmailJob::dispatch($to, $template, $replacements);
+            app(EmailManager::class)->send($templateId, $to, $replacements);
         }
     }
 

--- a/app/Models/EmailTemplate.php
+++ b/app/Models/EmailTemplate.php
@@ -43,32 +43,4 @@ class EmailTemplate extends Model
      * @var boolean
      */
     public $timestamps = true;
-
-    /**
-     * Represents the descriptive text to describe this email object
-     *
-     * @var string
-     */
-    public $identifier = '';
-
-    /**
-     * Whether or not this model is enabled or disabled
-     *
-     * @var boolean
-     */
-    public $enabled = true;
-
-    /**
-     * Represents the body of the entire message of this email object
-     *
-     * @var string
-     */
-    public $body = '';
-
-    /**
-     * Represents the subject for this message of this email object
-     *
-     * @var string
-     */
-    public $subject = '';
 }

--- a/app/Services/AliasReplyScannerService.php
+++ b/app/Services/AliasReplyScannerService.php
@@ -4,8 +4,6 @@ namespace App\Services;
 
 use Exception;
 use App\Models\User;
-use App\Jobs\SendEmailJob;
-use App\Models\EmailTemplate;
 use App\Models\EnquiryThread;
 use App\Models\EnquiryMessage;
 use Webklex\PHPIMAP\ClientManager;
@@ -251,7 +249,6 @@ class AliasReplyScannerService
         list($username, $domain) = explode('@', $imapUsername);
 
         try {
-            $template = EmailTemplate::where('identifier', $ident)->first();
             // TODO: once templates reworking is done, we will need to increase or standardise the replacements in use
             $replacements = array_merge(
                 [
@@ -273,13 +270,11 @@ class AliasReplyScannerService
                 ];
 
                 $from = $username . '+' . $threadDetail['thread']['unique_key'] . '@' . $domain;
-                $something = SendEmailJob::dispatch($to, $template, $replacements, $from);
+                app(EmailManager::class)->send($ident, $to, $replacements, $from);
             }
             unset(
-                $template,
                 $replacements,
                 $from,
-                $something,
             );
         } catch (Exception $e) {
             $this->loggingContext['method_name'] = class_basename($this) . '@' . __FUNCTION__;

--- a/app/Services/EmailManager.php
+++ b/app/Services/EmailManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\SendEmailJob;
+use App\Models\EmailTemplate;
+use Illuminate\Support\Facades\Log;
+
+class EmailManager
+{
+    /**
+     * Single choke point for outbound templated email. Looks up the template
+     * by identifier, refuses to send if missing or disabled (email_templates.enabled),
+     * then dispatches SendEmailJob as before.
+     *
+     * @param array $to ['to' => ['email' => ..., 'name' => ...]]
+     * @param array $replacements ['[[PLACEHOLDER]]' => value, ...]
+     */
+    public function send(string $identifier, array $to, array $replacements = [], ?string $fromAddress = null): bool
+    {
+        $template = EmailTemplate::where('identifier', $identifier)->first();
+
+        if (is_null($template)) {
+            Log::warning('EmailManager: email template not found, email not sent', [
+                'identifier' => $identifier,
+            ]);
+            return false;
+        }
+
+        if (!$template->enabled) {
+            Log::warning('EmailManager: email template disabled, email not sent', [
+                'identifier' => $identifier,
+            ]);
+            return false;
+        }
+
+        SendEmailJob::dispatch($to, $template, $replacements, $fromAddress);
+        return true;
+    }
+}

--- a/app/Services/EmailPreviewRenderer.php
+++ b/app/Services/EmailPreviewRenderer.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\MailSendException;
+use Illuminate\Support\Facades\Http;
+
+class EmailPreviewRenderer
+{
+    /**
+     * Substitutes any remaining [[PLACEHOLDER]] tokens with fictional preview data,
+     * then renders the MJML source to HTML via the MJML render service.
+     */
+    public function renderHtml(string $body): string
+    {
+        $response = Http::post(config('services.mjml.render_url'), [
+            'mjml' => $this->applyDummyData($body),
+        ]);
+
+        if (!$response->successful()) {
+            throw new MailSendException('Unable to contact MJML render service');
+        }
+
+        return $response->json()['html'];
+    }
+
+    public function applyDummyData(string $body): string
+    {
+        $successList = implode('', [
+            '<li>PID: dataset-001 - Synced OK (1 record)</li>',
+            '<li>PID: dataset-002 - Synced OK (3 records)</li>',
+            '<li>PID: dataset-003 - Synced OK (2 records)</li>',
+        ]);
+
+        $errorList = implode('', [
+            '<li>PID - dataset-004:<br><ul>' .
+                '<li>my-failing-dataset / 1.0 — Schema validation failed: \'description\' is required</li>' .
+                '<li>my-failing-dataset / 1.0 — Schema validation failed: \'keywords\' must be an array</li>' .
+            '</ul></li>',
+        ]);
+
+        $adminList = '<ul><li>Jane Doe (jane.doe@example.com)</li><li>John Smith (john.smith@example.com)</li></ul>';
+
+        $map = [
+            // Generic
+            '[[USER_FIRSTNAME]]'      => 'Jane',
+            '[[USER_LASTNAME]]'       => 'Doe',
+            '[[USER_FIRST_NAME]]'     => 'Jane',
+            '[[USER_EMAIL]]'          => 'jane.doe@example.com',
+            '[[RECIPIENT_NAME]]'      => 'Jane Doe',
+            '[[SENDER_NAME]]'         => 'John Smith',
+            '[[TEAM_NAME]]'           => 'Health Data Research UK',
+            '[[TEAM_ID]]'             => '10',
+            '[[RUN_DATE]]'            => now()->toDateTimeString(),
+            '[[CURRENT_YEAR]]'        => now()->format('Y'),
+            '[[PROJECT_TITLE]]'       => 'Example Research Project',
+            '[[APPLICATION_ID]]'      => '123',
+            '[[STATUS]]'              => 'Approved',
+            '[[CUSTODIANS]]'          => 'Health Data Research UK',
+            '[[APP_NAME]]'            => 'Example Application',
+            '[[UUID]]'                => 'example-uuid-0000-0000',
+            // Integration job
+            '[[INTEGRATION_ID]]'      => '42',
+            '[[INTEGRATION_LIST_URL]]' => config('gateway.gateway_url') . '/en/account/team/10/integrations/integration/list',
+            '[[DATASET_COUNT]]'       => '3',
+            '[[INTEGRATION_SUCCESS]]' => "<ul>{$successList}</ul>",
+            '[[INTEGRATION_ERRORS]]'  => "<ul>{$errorList}</ul>",
+            '[[JOB_ERROR]]'           => 'Connection timed out after 30 seconds (HTTP 504 from upstream)',
+            '[[USER_LIST]]'           => $adminList,
+        ];
+
+        return str_replace(array_keys($map), array_values($map), $body);
+    }
+}

--- a/config/routes.php
+++ b/config/routes.php
@@ -2298,6 +2298,19 @@ return [
     ],
     [
         'name' => 'emailtemplates',
+        'method' => 'post',
+        'path' => '/emailtemplates/preview',
+        'methodController' => 'EmailTemplateController@preview',
+        'namespaceController' => 'App\Http\Controllers\Api\V1',
+        'middleware' => [
+            'jwt.verify',
+            'sanitize.input',
+            'check.access:roles,hdruk.superadmin',
+        ],
+        'constraint' => [],
+    ],
+    [
+        'name' => 'emailtemplates',
         'method' => 'put',
         'path' => '/emailtemplates/{id}',
         'methodController' => 'EmailTemplateController@update',

--- a/tests/Feature/EmailTemplatePreviewTest.php
+++ b/tests/Feature/EmailTemplatePreviewTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+use Tests\Traits\MockExternalApis;
+
+class EmailTemplatePreviewTest extends TestCase
+{
+    use MockExternalApis {
+        setUp as commonSetUp;
+    }
+
+    public const TEST_URL = '/api/v1/emailtemplates/preview';
+
+    protected $header = [];
+
+    public function setUp(): void
+    {
+        $this->commonSetUp();
+    }
+
+    public function test_preview_renders_body_with_dummy_data_substitution(): void
+    {
+        Http::fake([
+            config('services.mjml.render_url') => function ($request) {
+                return Http::response(['html' => '<html>' . $request['mjml'] . '</html>'], 200);
+            },
+        ]);
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['body' => '<mjml><mj-body>Hello [[USER_FIRSTNAME]]</mj-body></mjml>'],
+            $this->header
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'message',
+            'data' => ['html'],
+        ]);
+
+        $content = $response->decodeResponseJson();
+        $this->assertStringContainsString('Hello Jane', $content['data']['html']);
+        $this->assertStringNotContainsString('[[USER_FIRSTNAME]]', $content['data']['html']);
+
+        // The SanitizeMiddleware htmlentities-encodes all string input; the controller
+        // must html_entity_decode it back before sending to the MJML service, or every
+        // preview receives '&lt;mjml&gt;...' instead of real markup and fails to render.
+        $this->assertStringContainsString('<mjml><mj-body>', $content['data']['html']);
+        $this->assertStringNotContainsString('&lt;mjml&gt;', $content['data']['html']);
+    }
+
+    public function test_preview_requires_body(): void
+    {
+        $response = $this->json('POST', self::TEST_URL, [], $this->header);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_preview_fails_when_mjml_service_errors(): void
+    {
+        Http::fake([
+            config('services.mjml.render_url') => Http::response('bad gateway', 502),
+        ]);
+
+        $response = $this->json(
+            'POST',
+            self::TEST_URL,
+            ['body' => '<mjml><mj-body>test</mj-body></mjml>'],
+            $this->header
+        );
+
+        $response->assertStatus(500);
+    }
+}

--- a/tests/Feature/EmailTemplateTest.php
+++ b/tests/Feature/EmailTemplateTest.php
@@ -37,15 +37,18 @@ class EmailTemplateTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
-            0 => [
-                'id',
-                'created_at',
-                'updated_at',
-                'deleted_at',
-                'identifier',
-                'enabled',
-                'body',
-                'subject',
+            'message',
+            'data' => [
+                0 => [
+                    'id',
+                    'created_at',
+                    'updated_at',
+                    'deleted_at',
+                    'identifier',
+                    'enabled',
+                    'body',
+                    'subject',
+                ],
             ],
         ]);
     }
@@ -58,19 +61,16 @@ class EmailTemplateTest extends TestCase
     public function test_get_email_template_by_id_with_success(): void
     {
         $response = $this->json('GET', self::TEST_URL . '/1', [], $this->header);
-        $this->assertCount(1, $response['data']);
         $response->assertJsonStructure([
             'data' => [
-                0 => [
-                    'id',
-                    'created_at',
-                    'updated_at',
-                    'deleted_at',
-                    'identifier',
-                    'enabled',
-                    'body',
-                    'subject',
-                ]
+                'id',
+                'created_at',
+                'updated_at',
+                'deleted_at',
+                'identifier',
+                'enabled',
+                'body',
+                'subject',
             ]
         ]);
         $response->assertStatus(200);

--- a/tests/Unit/EmailManagerTest.php
+++ b/tests/Unit/EmailManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\SendEmailJob;
+use App\Models\EmailTemplate;
+use App\Services\EmailManager;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class EmailManagerTest extends TestCase
+{
+    private function to(): array
+    {
+        return [
+            'to' => [
+                'email' => 'user@example.com',
+                'name' => 'Jane Doe',
+            ],
+        ];
+    }
+
+    public function test_send_dispatches_job_when_template_is_enabled(): void
+    {
+        $template = EmailTemplate::where('identifier', '=', 'example_template')->first();
+        $this->assertNotNull($template, 'Expected seeded example_template to exist');
+        $this->assertTrue($template->enabled);
+
+        $sent = app(EmailManager::class)->send('example_template', $this->to(), []);
+
+        $this->assertTrue($sent);
+        Queue::assertPushed(SendEmailJob::class, 1);
+    }
+
+    public function test_send_returns_false_and_logs_when_template_is_disabled(): void
+    {
+        Log::spy();
+
+        EmailTemplate::create([
+            'identifier' => 'test.email_manager.disabled',
+            'enabled' => false,
+            'subject' => 'Disabled template',
+            'body' => '<p>Disabled</p>',
+        ]);
+
+        $sent = app(EmailManager::class)->send('test.email_manager.disabled', $this->to(), []);
+
+        $this->assertFalse($sent);
+        Queue::assertNothingPushed();
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, 'disabled'));
+    }
+
+    public function test_send_returns_false_and_logs_when_template_is_missing(): void
+    {
+        Log::spy();
+
+        $sent = app(EmailManager::class)->send('test.email_manager.does_not_exist', $this->to(), []);
+
+        $this->assertFalse($sent);
+        Queue::assertNothingPushed();
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, 'not found'));
+    }
+}

--- a/tests/Unit/SendEmailCustomIntegrationTest.php
+++ b/tests/Unit/SendEmailCustomIntegrationTest.php
@@ -8,6 +8,7 @@ use App\Models\Dataset;
 use App\Models\DatasetVersion;
 use App\Models\EmailTemplate;
 use App\Models\FederationJobRun;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
@@ -206,9 +207,12 @@ class SendEmailCustomIntegrationTest extends TestCase
 
     public function test_logs_warning_and_skips_when_template_not_found(): void
     {
-        // Use a made-up outcome that has no matching template in the database
+        // Use a made-up outcome that has no matching template in the database.
+        // Template lookup + missing-template logging now lives in EmailManager.
+        Log::spy();
+
         $job = $this->getMockBuilder(SendEmailCustomIntegration::class)
-            ->onlyMethods(['getDetails', 'getFederationHistory', 'checkUserPerms', 'getListOfUsers', 'log'])
+            ->onlyMethods(['getDetails', 'getFederationHistory', 'checkUserPerms', 'getListOfUsers'])
             ->setConstructorArgs([self::FEDERATION_ID, self::JOB_UUID, 'nonexistent', null])
             ->getMock();
 
@@ -216,13 +220,13 @@ class SendEmailCustomIntegrationTest extends TestCase
         $job->method('getFederationHistory')->willReturn($this->historyStub());
         $job->method('checkUserPerms')->willReturn(true);
         $job->method('getListOfUsers')->willReturn('');
-        $job->expects($this->once())
-            ->method('log')
-            ->with('warning', $this->stringContains('template'));
 
         $job->handle();
 
         Queue::assertNothingPushed();
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn ($message) => str_contains($message, 'template'));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
…renderer for real-time feedback

> AI disclaimer: Claude Sonnet 5 was used to write test suite for these changes. Was also used to validate logic and theory.

## Screenshots (if relevant)

<img width="1822" height="1255" alt="image" src="https://github.com/user-attachments/assets/3455eba5-13ea-4191-9398-41be79ef5460" />


## Describe your changes
Massively refactors email logic to funnel through an EmailManager service, to consolidate all business logic and reduce code footprint elsewhere.

BE additions and refactor to allow the toggling of individual emails. Also allows the creation/editing of new and existing templates with live renderer for feedback.

*Note* Creation is added for a future addition where we can link email sends to actions. Currently, new templates can be created, but will be unused until BE wires them up in logic. Kept for completeness - will set expectations and awareness.

## Issue ticket link
https://hdruk.atlassian.net/browse/GAT-9442

## Environment / Configuration changes (if applicable)
None.

## Requires migrations being run?
No.

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [x] I have added Swagger annotations for new endpoints (if applicable)
- [x] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
