### PR TITLE
fix(GAT-9343): Backfill missing metadata title/short_title fields on …

### DIFF
--- a/database/deployment-steps/2026_08_10_162029_backfill_dataset_version_title.php
+++ b/database/deployment-steps/2026_08_10_162029_backfill_dataset_version_title.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\DeploymentSteps\DeploymentStep;
+use App\Models\DatasetVersion;
+use App\Services\DatasetService;
+use App\Services\Gwdm\GwdmHandlerFactory;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Back-fill dataset_versions.title/short_title for rows left NULL by write
+ * paths that never set them (see MetadataOnboard::metadataOnboard() fix,
+ * GAT-9343).
+ */
+return new class () extends DeploymentStep {
+    public function handle(): void
+    {
+        $datasetService = app(DatasetService::class);
+        $handlerFactory = app(GwdmHandlerFactory::class);
+
+        $fixed = 0;
+        $failed = 0;
+
+        DatasetVersion::whereNull('title')
+            ->whereNull('short_title')
+            ->chunkById(200, function ($versions) use ($datasetService, $handlerFactory, &$fixed, &$failed) {
+                foreach ($versions as $version) {
+                    try {
+                        $envelope = $datasetService->getReconstructedMetadataEnvelope(
+                            $version->dataset_id,
+                            $version->version,
+                            validate: false,
+                            prefetched: $version,
+                            applySupplementary: false,
+                        );
+
+                        $gwdmVersion = $envelope['gwdmVersion'] ?? Config::get('metadata.GWDM.version');
+                        $handler = $handlerFactory->resolve($gwdmVersion);
+                        [$title, $shortTitle] = $handler->extractTitleFields($envelope['metadata']);
+
+                        if ($title === null) {
+                            $failed++;
+                            $this->warn("dataset_version {$version->id}: reconstructed metadata has no title, skipping.");
+                            continue;
+                        }
+
+                        $version->forceFill([
+                            'title' => $title,
+                            'short_title' => $shortTitle,
+                        ])->saveQuietly();
+
+                        $fixed++;
+                    } catch (\Throwable $e) {
+                        $failed++;
+                        $this->warn("dataset_version {$version->id}: could not be reconstructed — {$e->getMessage()}");
+                    }
+                }
+            });
+
+        $this->info("Back-filled title/short_title on {$fixed} dataset_version row(s); {$failed} could not be reconstructed and remain NULL.");
+    }
+};


### PR DESCRIPTION
## Describe your changes

Backfill missing metadata title/short_title fields on deployment

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9343?search_id=671d1c93-53ac-4eaa-bc23-32127b7f80d8&xpis=eyJicmlkZ2UiOiJxdWlja0ZpbmQiLCJpZCI6IjE3ODYzNjk1OTI4NDQiLCJzb3VyY2UiOiJqaXJhLXNvZnR3YXJlIn0%3D

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
