### PR TITLE
feat(GAT-9459): Cast CohortRequest request_status to an enum

### DIFF
--- a/app/Console/Commands/CohortPreprodUsersRestore.php
+++ b/app/Console/Commands/CohortPreprodUsersRestore.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\CohortRequestStatus;
 use App\Models\CohortRequest;
 use App\Models\CohortRequestHasLog;
 use App\Models\CohortRequestHasPermission;
@@ -60,7 +61,7 @@ class CohortPreprodUsersRestore extends Command
                 }
 
                 // If the user had a non-approved request on prod - override status with preprod value
-                if (($cohortRequest) && ($cohortRequest->request_status !== 'APPROVED')) {
+                if (($cohortRequest) && ($cohortRequest->request_status !== CohortRequestStatus::APPROVED)) {
                     $cohortRequest->request_status = $cohortUser['request_status'];
                     $cohortRequest->access_to_env = 'PREPROD';
                     $cohortRequest->save();

--- a/app/Console/Commands/CohortUserExpiry.php
+++ b/app/Console/Commands/CohortUserExpiry.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Config;
 use Auditor;
 use Exception;
+use App\Enums\CohortRequestStatus;
 use App\Models\CohortRequest;
 use App\Models\CohortRequestLog;
 use App\Models\CohortRequestHasLog;
@@ -67,14 +68,14 @@ class CohortUserExpiry extends Command
         switch ($expiryField) {
             case 'request_expire_at':
                 if ($trueExpiryDate <= $now) {
-                    if ($r->request_status === CohortRequest::REQUEST_APPROVED) {
+                    if ($r->request_status === CohortRequestStatus::APPROVED) {
                         $this->expireRequest($r, $expiryField);
                         $this->removePermissions($r);
                         $this->createLog($r, $u);
                         $this->sendEmail($r->id, CohortRequest::REQUEST_EXPIRED, $trueExpiryDate);
                     }
                 } elseif (in_array($diff, $warnings)) {
-                    if ($r->request_status === CohortRequest::REQUEST_APPROVED) {
+                    if ($r->request_status === CohortRequestStatus::APPROVED) {
                         $this->sendEmail($r->id, 'WILL_EXPIRE', $trueExpiryDate);
                     }
                 }

--- a/app/Enums/CohortRequestStatus.php
+++ b/app/Enums/CohortRequestStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum CohortRequestStatus: string
+{
+    case APPROVED = 'APPROVED';
+    case PENDING = 'PENDING';
+    case REJECTED = 'REJECTED';
+    case BANNED = 'BANNED';
+    case SUSPENDED = 'SUSPENDED';
+    case EXPIRED = 'EXPIRED';
+}

--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -462,7 +462,7 @@ class CohortRequestController extends Controller
             ])->first();
 
             // keep just one request by user id
-            if ($checkRequestByUserId && in_array(strtoupper($checkRequestByUserId['request_status']), $notAllowUpdateRequest)) {
+            if ($checkRequestByUserId && in_array(strtoupper($checkRequestByUserId->request_status?->value ?? ''), $notAllowUpdateRequest)) {
                 throw new Exception('A cohort request already exists or the status of the request does not allow updating.');
             } else {
                 $id = $checkRequestByUserId ? $checkRequestByUserId->id : 0;
@@ -623,7 +623,7 @@ class CohortRequestController extends Controller
             $nhseSdeRequestStatus = strtoupper(trim($input['nhse_sde_request_status']));
 
             $currCohortRequest = CohortRequest::where('id', $id)->first();
-            $currRequestStatus = strtoupper(trim($currCohortRequest['request_status']));
+            $currRequestStatus = strtoupper(trim($currCohortRequest->request_status?->value ?? ''));
             $currNhseSdeRequestStatus = strtoupper(trim($currCohortRequest['nhse_sde_request_status']));
 
             $cohortRequestLog = new CohortRequestLog([
@@ -1020,7 +1020,7 @@ class CohortRequestController extends Controller
                                 (string) $rowDetails['user']['link'],
                                 (string) $rowDetails['user']['orcid'],
                                 (string) $rowDetails['user']['updated_at'],
-                                (string) $rowDetails['request_status'],
+                                (string) ($rowDetails['request_status']?->value ?? ''),
                                 (string) $rowDetails['access_to_env'],
                                 (string) $rowDetails['created_at'],
                                 (string) $rowDetails['updated_at'],
@@ -1543,7 +1543,7 @@ class CohortRequestController extends Controller
     {
         try {
             $cohort = CohortRequest::where('id', $cohortId)->first();
-            $cohortRequestStatus = $cohort['request_status'];
+            $cohortRequestStatus = $cohort['request_status']?->value;
             $cohortRequestUserId = $cohort['user_id'];
             $user = User::where('id', $cohortRequestUserId)->first();
             $userEmail = ($user['preferred_email'] === 'primary') ? $user['email'] : $user['secondary_email'];

--- a/app/Http/Requests/CohortRequest/UpdateCohortRequest.php
+++ b/app/Http/Requests/CohortRequest/UpdateCohortRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\CohortRequest;
 
 use Illuminate\Validation\Rule;
+use App\Enums\CohortRequestStatus;
 use App\Http\Requests\BaseFormRequest;
 
 class UpdateCohortRequest extends BaseFormRequest
@@ -27,7 +28,13 @@ class UpdateCohortRequest extends BaseFormRequest
             'request_status' => [
                 'string',
                 'required',
-                Rule::in(['PENDING', 'APPROVED','REJECTED','BANNED','SUSPENDED']),
+                Rule::in([
+                    CohortRequestStatus::PENDING,
+                    CohortRequestStatus::APPROVED,
+                    CohortRequestStatus::REJECTED,
+                    CohortRequestStatus::BANNED,
+                    CohortRequestStatus::SUSPENDED,
+                ]),
             ],
             'nhse_sde_request_status' => [
                 'string',

--- a/app/Models/CohortRequest.php
+++ b/app/Models/CohortRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\CohortRequestStatus;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Prunable;
@@ -40,6 +41,7 @@ class CohortRequest extends Model
     ];
 
     protected $casts = [
+        'request_status' => CohortRequestStatus::class,
         'accept_declaration' => 'boolean',
         'request_expire_at' => 'datetime',
         'nhse_sde_requested_at' => 'datetime',


### PR DESCRIPTION
## Describe your changes

There's no constraint on this column, so nothing stops an invalid status string being written or compared against. Casting to a backed enum pushes that guarantee to the type system instead of relying on scattered runtime string checks.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9459

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
