### PR TITLE
feat(GAT-9459): expose has access on response

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -135,6 +135,7 @@ class CohortRequestController extends Controller
      *                   @OA\Property(property="user_id", type="integer", example="1"),
      *                   @OA\Property(property="request_status", type="string", example="PENDING"),
      *                   @OA\Property(property="request_expire_at", type="datetime", example="2023-04-03 12:00:00"),
+     *                   @OA\Property(property="has_access", type="boolean", example="1"),
      *                   @OA\Property(property="created_at", type="datetime", example="2023-04-03 12:00:00"),
      *                   @OA\Property(property="updated_at", type="datetime", example="2023-04-03 12:00:00"),
      *                   @OA\Property(property="deleted_at", type="datetime", example="2023-04-03 12:00:00"),

--- a/app/Models/CohortRequest.php
+++ b/app/Models/CohortRequest.php
@@ -14,6 +14,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
 
+/**
+ * @property-read bool $has_access
+ */
 class CohortRequest extends Model
 {
     use HasFactory;
@@ -50,6 +53,10 @@ class CohortRequest extends Model
         'nhse_sde_self_declared_approved_at' => 'datetime',
         'nhse_sde_request_expire_at' => 'datetime',
         'nhse_sde_updated_at' => 'datetime',
+    ];
+
+    protected $appends = [
+        'has_access',
     ];
 
     public const REQUEST_APPROVED = 'APPROVED';
@@ -97,7 +104,7 @@ class CohortRequest extends Model
         return Carbon::instance(min($candidates));
     }
 
-    public static function hasAccess(CohortRequest $request): bool
+    public static function grantsAccess(CohortRequest $request): bool
     {
         if (! in_array($request->request_status, self::ACCESS_GRANTING_STATUSES, true)) {
             return false;
@@ -119,6 +126,11 @@ class CohortRequest extends Model
         }
 
         return self::RENEWAL_ELIGIBLE;
+    }
+
+    public function getHasAccessAttribute(): bool
+    {
+        return self::grantsAccess($this);
     }
 
     /**

--- a/tests/Feature/CohortRequestTest.php
+++ b/tests/Feature/CohortRequestTest.php
@@ -62,6 +62,7 @@ class CohortRequestTest extends TestCase
                     'user',
                     'request_status',
                     'request_expire_at',
+                    'has_access',
                     'created_at',
                     'updated_at',
                     'deleted_at',
@@ -107,6 +108,20 @@ class CohortRequestTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+    }
+
+    public function test_get_cohort_request_by_id_includes_has_access(): void
+    {
+        $userId = User::factory()->create()->id;
+        $this->approveTestUserForCohort($userId);
+        $cohortRequestId = CohortRequest::where('user_id', $userId)->first()->id;
+
+        $response = $this->json('GET', self::TEST_URL.'/'.$cohortRequestId, [], $this->header);
+
+        $content = $response->decodeResponseJson();
+
+        $response->assertStatus(200);
+        $this->assertTrue($content['data']['has_access']);
     }
 
     /**

--- a/tests/Unit/Models/CohortRequestTest.php
+++ b/tests/Unit/Models/CohortRequestTest.php
@@ -65,7 +65,7 @@ class CohortRequestTest extends TestCase
             'request_expire_at' => Carbon::now()->addDays(30),
         ]);
 
-        $this->assertTrue(CohortRequest::hasAccess($cohortRequest));
+        $this->assertTrue(CohortRequest::grantsAccess($cohortRequest));
     }
 
     public function test_has_access_is_true_for_renewing_within_expiry(): void
@@ -75,7 +75,7 @@ class CohortRequestTest extends TestCase
             'request_expire_at' => Carbon::now()->addDays(30),
         ]);
 
-        $this->assertTrue(CohortRequest::hasAccess($cohortRequest));
+        $this->assertTrue(CohortRequest::grantsAccess($cohortRequest));
     }
 
     public function test_has_access_is_false_for_approved_past_its_true_expiry(): void
@@ -87,7 +87,7 @@ class CohortRequestTest extends TestCase
             'request_expire_at' => Carbon::now()->subDay(),
         ]);
 
-        $this->assertFalse(CohortRequest::hasAccess($cohortRequest));
+        $this->assertFalse(CohortRequest::grantsAccess($cohortRequest));
     }
 
     public function test_has_access_is_false_for_renewing_past_its_true_expiry(): void
@@ -97,7 +97,7 @@ class CohortRequestTest extends TestCase
             'request_expire_at' => Carbon::now()->subDay(),
         ]);
 
-        $this->assertFalse(CohortRequest::hasAccess($cohortRequest));
+        $this->assertFalse(CohortRequest::grantsAccess($cohortRequest));
     }
 
     public function test_has_access_is_false_for_other_statuses(): void
@@ -112,7 +112,7 @@ class CohortRequestTest extends TestCase
             $cohortRequest = $this->makeCohortRequest(['request_status' => $status]);
 
             $this->assertFalse(
-                CohortRequest::hasAccess($cohortRequest),
+                CohortRequest::grantsAccess($cohortRequest),
                 "Expected hasAccess to be false for status {$status->value}"
             );
         }


### PR DESCRIPTION
## Describe your changes

Exposes the new has_access on CohortRequest response. 

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9459

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [x] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
