### PR TITLE
feat(GAT-9459): Add RENEWING status with access/renewal eligibility checks

### DIFF
--- a/app/Enums/CohortRequestStatus.php
+++ b/app/Enums/CohortRequestStatus.php
@@ -5,6 +5,7 @@ namespace App\Enums;
 enum CohortRequestStatus: string
 {
     case APPROVED = 'APPROVED';
+    case RENEWING = 'RENEWING';
     case PENDING = 'PENDING';
     case REJECTED = 'REJECTED';
     case BANNED = 'BANNED';

--- a/app/Models/CohortRequest.php
+++ b/app/Models/CohortRequest.php
@@ -58,6 +58,18 @@ class CohortRequest extends Model
     public const REQUEST_PENDING = 'PENDING';
     public const REQUEST_EXPIRED = 'EXPIRED';
 
+    /**
+     * Statuses under which a user currently has CDS access.
+     */
+    public const ACCESS_GRANTING_STATUSES = [
+        CohortRequestStatus::APPROVED,
+        CohortRequestStatus::RENEWING,
+    ];
+
+    public const RENEWAL_ELIGIBLE = 'ELIGIBLE';
+    public const RENEWAL_ALREADY_RENEWING = 'ALREADY_RENEWING';
+    public const RENEWAL_NOT_APPLICABLE = 'NOT_APPLICABLE';
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
@@ -83,6 +95,30 @@ class CohortRequest extends Model
         }
 
         return Carbon::instance(min($candidates));
+    }
+
+    public static function hasAccess(CohortRequest $request): bool
+    {
+        if (! in_array($request->request_status, self::ACCESS_GRANTING_STATUSES, true)) {
+            return false;
+        }
+
+        $trueExpiry = $request->calculateTrueExpiry('request_expire_at');
+
+        return $trueExpiry === null || Carbon::now()->lessThan($trueExpiry);
+    }
+
+    public function renewalEligibility(): string
+    {
+        if ($this->request_status === CohortRequestStatus::RENEWING) {
+            return self::RENEWAL_ALREADY_RENEWING;
+        }
+
+        if ($this->request_status !== CohortRequestStatus::APPROVED) {
+            return self::RENEWAL_NOT_APPLICABLE;
+        }
+
+        return self::RENEWAL_ELIGIBLE;
     }
 
     /**

--- a/tests/Unit/Models/CohortRequestTest.php
+++ b/tests/Unit/Models/CohortRequestTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use App\Enums\CohortRequestStatus;
+use App\Models\CohortRequest;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+class CohortRequestTest extends TestCase
+{
+    private function makeCohortRequest(array $attributes = []): CohortRequest
+    {
+        $user = User::factory()->create();
+
+        return CohortRequest::create(array_merge([
+            'user_id' => $user->id,
+            'request_status' => CohortRequestStatus::APPROVED,
+            'request_expire_at' => null,
+        ], $attributes));
+    }
+
+    public function test_renewal_eligibility_is_eligible_for_approved(): void
+    {
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::APPROVED,
+        ]);
+
+        $this->assertSame(CohortRequest::RENEWAL_ELIGIBLE, $cohortRequest->renewalEligibility());
+    }
+
+    public function test_renewal_eligibility_is_already_renewing_when_status_renewing(): void
+    {
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::RENEWING,
+        ]);
+
+        $this->assertSame(CohortRequest::RENEWAL_ALREADY_RENEWING, $cohortRequest->renewalEligibility());
+    }
+
+    public function test_renewal_eligibility_is_not_applicable_for_other_statuses(): void
+    {
+        foreach ([
+            CohortRequestStatus::PENDING,
+            CohortRequestStatus::REJECTED,
+            CohortRequestStatus::BANNED,
+            CohortRequestStatus::SUSPENDED,
+            CohortRequestStatus::EXPIRED,
+        ] as $status) {
+            $cohortRequest = $this->makeCohortRequest(['request_status' => $status]);
+
+            $this->assertSame(
+                CohortRequest::RENEWAL_NOT_APPLICABLE,
+                $cohortRequest->renewalEligibility(),
+                "Expected NOT_APPLICABLE for status {$status->value}"
+            );
+        }
+    }
+
+    public function test_has_access_is_true_for_approved_within_expiry(): void
+    {
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::APPROVED,
+            'request_expire_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this->assertTrue(CohortRequest::hasAccess($cohortRequest));
+    }
+
+    public function test_has_access_is_true_for_renewing_within_expiry(): void
+    {
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::RENEWING,
+            'request_expire_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $this->assertTrue(CohortRequest::hasAccess($cohortRequest));
+    }
+
+    public function test_has_access_is_false_for_approved_past_its_true_expiry(): void
+    {
+        // Simulates the gap before the nightly CohortUserExpiry job has run:
+        // request_status still says APPROVED, but the true expiry has passed.
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::APPROVED,
+            'request_expire_at' => Carbon::now()->subDay(),
+        ]);
+
+        $this->assertFalse(CohortRequest::hasAccess($cohortRequest));
+    }
+
+    public function test_has_access_is_false_for_renewing_past_its_true_expiry(): void
+    {
+        $cohortRequest = $this->makeCohortRequest([
+            'request_status' => CohortRequestStatus::RENEWING,
+            'request_expire_at' => Carbon::now()->subDay(),
+        ]);
+
+        $this->assertFalse(CohortRequest::hasAccess($cohortRequest));
+    }
+
+    public function test_has_access_is_false_for_other_statuses(): void
+    {
+        foreach ([
+            CohortRequestStatus::PENDING,
+            CohortRequestStatus::REJECTED,
+            CohortRequestStatus::BANNED,
+            CohortRequestStatus::SUSPENDED,
+            CohortRequestStatus::EXPIRED,
+        ] as $status) {
+            $cohortRequest = $this->makeCohortRequest(['request_status' => $status]);
+
+            $this->assertFalse(
+                CohortRequest::hasAccess($cohortRequest),
+                "Expected hasAccess to be false for status {$status->value}"
+            );
+        }
+    }
+}


### PR DESCRIPTION

## Describe your changes

Users can currently only reapply for CDS access after it's already expired. This adds RENEWING as a real status so a renewal can be in progress without ever touching a user's existing access or expiry.

Also adds a new hasAccess check which acts as a computed property, derived from status and expiry.

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9459

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
