### PR TITLE
feat(GAT-9459): adjust cds gate to use new logic

### DIFF
--- a/app/Http/Controllers/Api/V1/CohortRequestController.php
+++ b/app/Http/Controllers/Api/V1/CohortRequestController.php
@@ -1449,10 +1449,9 @@ class CohortRequestController extends Controller
 
             $checkingCohortRequest = CohortRequest::where([
                 'user_id' => $userId,
-                'request_status' => 'APPROVED',
             ])->first();
 
-            if (! $checkingCohortRequest) {
+            if (! $checkingCohortRequest || ! CohortRequest::grantsAccess($checkingCohortRequest)) {
                 return response()->json([
                     'message' => 'Unauthorized for access :: The request is not approved',
                 ], Config::get('statuscodes.STATUS_OK.code'));

--- a/tests/Feature/CohortRequestTest.php
+++ b/tests/Feature/CohortRequestTest.php
@@ -720,11 +720,11 @@ class CohortRequestTest extends TestCase
         }
     }
 
-    private function approveTestUserForCohort(int $userId): void
+    private function approveTestUserForCohort(int $userId, string $status = 'APPROVED'): void
     {
         $cohortRequest = CohortRequest::updateOrCreate(
             ['user_id' => $userId],
-            ['request_status' => 'APPROVED', 'accept_declaration' => true]
+            ['request_status' => $status, 'accept_declaration' => true]
         );
 
         $permission = Permission::where([
@@ -798,5 +798,94 @@ class CohortRequestTest extends TestCase
 
         $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
         // $response->assertSessionMissing('cr_uid');
+    }
+
+    public function test_check_access_cohort_discovery_allows_renewing_status(): void
+    {
+        Feature::flushCache();
+        Feature::activate('CohortDiscoveryService', true);
+
+        $jwtUser = $this->getUserFromJwt($this->getAuthorisationJwt());
+        $userId = (int) $jwtUser['id'];
+
+        $this->createCohortServiceAccount();
+        $this->approveTestUserForCohort($userId, 'RENEWING');
+
+        $response = $this->json(
+            'GET',
+            self::TEST_URL.'/access/cohort-discovery',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $response->assertJsonStructure(['data' => ['redirect_url']]);
+    }
+
+    public function test_check_access_cohort_discovery_denies_when_status_is_pending(): void
+    {
+        Feature::flushCache();
+        Feature::activate('CohortDiscoveryService', true);
+
+        $jwtUser = $this->getUserFromJwt($this->getAuthorisationJwt());
+        $userId = (int) $jwtUser['id'];
+
+        $this->createCohortServiceAccount();
+        $this->approveTestUserForCohort($userId, 'PENDING');
+
+        $response = $this->json(
+            'GET',
+            self::TEST_URL.'/access/cohort-discovery',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $this->assertStringContainsString(
+            'not approved',
+            $response->json('message')
+        );
+    }
+
+    public function test_check_access_rquest_returns_redirect_url_for_approved_status(): void
+    {
+        Feature::flushCache();
+        Feature::activate('RQuest', true);
+
+        $jwtUser = $this->getUserFromJwt($this->getAuthorisationJwt());
+        $userId = (int) $jwtUser['id'];
+
+        $this->approveTestUserForCohort($userId);
+
+        $response = $this->json(
+            'GET',
+            self::TEST_URL.'/access/rquest',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $response->assertJsonStructure(['data' => ['redirect_url']]);
+    }
+
+    public function test_check_access_rquest_allows_renewing_status(): void
+    {
+        Feature::flushCache();
+        Feature::activate('RQuest', true);
+
+        $jwtUser = $this->getUserFromJwt($this->getAuthorisationJwt());
+        $userId = (int) $jwtUser['id'];
+
+        $this->approveTestUserForCohort($userId, 'RENEWING');
+
+        $response = $this->json(
+            'GET',
+            self::TEST_URL.'/access/rquest',
+            [],
+            $this->header
+        );
+
+        $response->assertStatus(Config::get('statuscodes.STATUS_OK.code'));
+        $response->assertJsonStructure(['data' => ['redirect_url']]);
     }
 }


### PR DESCRIPTION
## Describe your changes

CDS access is now governed by a mix of status and expiry dates. 

## Issue ticket link

https://hdruk.atlassian.net/browse/GAT-9459

## Environment / Configuration changes (if applicable)

## Requires migrations being run?

## If not using the pre-push hook. Confirm tests pass:

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have added appropriate unit tests
- [ ] I have created mocks for unit tests (where appropriate)
- [ ] I have added appropriate Behat tests to confirm AC (if applicable)
- [ ] I have added Swagger annotations for new endpoints (if applicable)
- [ ] I have added audit logs for new operation logic (if applicable)
- [ ] I have added new environment variables to the .env.example file (if applicable)
- [ ] I have added new environment variables to terraform repository (if applicable)
